### PR TITLE
fix(web): contain helper scroll within dashboard layout

### DIFF
--- a/web/src/components/layout/dashboard-shell.tsx
+++ b/web/src/components/layout/dashboard-shell.tsx
@@ -13,16 +13,18 @@ export function DashboardShell({
   const [mobileOpen, setMobileOpen] = useState(false);
 
   return (
-    <div className="flex min-h-screen bg-page">
+    <div className="flex h-svh overflow-hidden bg-page">
       <AppSidebar
         collapsed={collapsed}
         onCollapsedChange={setCollapsed}
         mobileOpen={mobileOpen}
         onMobileOpenChange={setMobileOpen}
       />
-      <div className="flex min-w-0 flex-1 flex-col">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         <AppHeader onOpenMobileSidebar={() => setMobileOpen(true)} />
-        <main className="min-w-0 flex-1">{children}</main>
+        <main className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -122,8 +122,8 @@ export function AppSidebar({
     isMobile: boolean,
   ) {
     return (
-      <div className="flex h-full flex-col justify-between bg-sidebar text-sidebar-foreground">
-        <div className="flex flex-col gap-1">
+      <div className="flex h-full min-h-0 flex-col bg-sidebar text-sidebar-foreground">
+        <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto pb-4">
           <div className="mt-5 flex h-10 items-center gap-2.5 px-3">
             <BrandLogo
               size="sm"
@@ -169,7 +169,7 @@ export function AppSidebar({
           </nav>
         </div>
 
-        <div className="flex flex-col gap-2 px-3 pb-5">
+        <div className="shrink-0 flex flex-col gap-2 px-3 pb-5">
           <Link
             href={helpHref}
             onClick={() => {
@@ -283,7 +283,7 @@ export function AppSidebar({
 
       <aside
         className={cn(
-          "hidden min-h-screen flex-col justify-between bg-sidebar text-sidebar-foreground transition-[width] duration-200 md:flex",
+          "hidden h-svh overflow-hidden flex-col bg-sidebar text-sidebar-foreground transition-[width] duration-200 md:flex",
           collapsed ? "w-16" : "w-60",
         )}
       >

--- a/web/tests/dashboard-layout-scroll-containment.test.mjs
+++ b/web/tests/dashboard-layout-scroll-containment.test.mjs
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+
+function read(path) {
+  return readFileSync(join(root, path), "utf8");
+}
+
+test("dashboard shell constrains the app to the viewport and scrolls inside main", () => {
+  const dashboardShell = read("web/src/components/layout/dashboard-shell.tsx");
+
+  assert.match(
+    dashboardShell,
+    /className="flex h-svh overflow-hidden bg-page"/,
+    "Dashboard shell must be locked to the viewport instead of extending the document height",
+  );
+
+  assert.match(
+    dashboardShell,
+    /className="flex min-h-0 min-w-0 flex-1 flex-col"/,
+    "Dashboard content column must allow children to shrink inside the viewport",
+  );
+
+  assert.match(
+    dashboardShell,
+    /<main className="min-h-0 min-w-0 flex-1 overflow-y-auto">/,
+    "Main dashboard content must scroll internally when a session grows taller than the viewport",
+  );
+});
+
+test("sidebar keeps footer visible and scrolls its upper content independently", () => {
+  const sidebar = read("web/src/components/layout/sidebar.tsx");
+
+  assert.match(
+    sidebar,
+    /className="flex h-full min-h-0 flex-col bg-sidebar text-sidebar-foreground"/,
+    "Sidebar root content must establish a shrinkable flex column",
+  );
+
+  assert.match(
+    sidebar,
+    /className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto[^"]*"/,
+    "Sidebar top section must own the scroll when navigation/help content overflows",
+  );
+
+  assert.match(
+    sidebar,
+    /"hidden h-svh overflow-hidden flex-col bg-sidebar text-sidebar-foreground transition-\[width\] duration-200 md:flex"/,
+    "Desktop sidebar wrapper must be constrained to the viewport and hide document overflow",
+  );
+});


### PR DESCRIPTION
Closes #8

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- constrain the dashboard shell to the viewport instead of letting helper content grow the document
- move overflow scrolling into the main content panel and the sidebar upper section
- add a regression test that locks the expected scroll containment behavior

## Changes
| File | Change |
|------|--------|
| `web/src/components/layout/dashboard-shell.tsx` | Switched the dashboard shell to viewport height and added internal scrolling to `<main>` |
| `web/src/components/layout/sidebar.tsx` | Kept the sidebar footer fixed and moved overflow to the upper navigation region |
| `web/tests/dashboard-layout-scroll-containment.test.mjs` | Added regression coverage for dashboard and sidebar scroll containment |

## Test Plan
- [x] `node --test web/tests/*.mjs`
- [x] Manually validated the layout logic in code for dashboard viewport containment
- [x] No build run (per repo instructions)

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran the relevant automated tests for this change
- [x] Used a conventional commit message
- [x] No `Co-Authored-By` trailers added
