### PR TITLE
feat(web): add global tenant management and align audit log filters

### DIFF
--- a/test/system/screen-manifest.json
+++ b/test/system/screen-manifest.json
@@ -364,6 +364,44 @@
       "critical": true
     },
     {
+      "route": "/global/tenants",
+      "scope": [
+        "global"
+      ],
+      "role": [
+        "superadmin",
+        "tenant-admin",
+        "workspace-admin",
+        "workspace-editor",
+        "workspace-viewer",
+        "no-member"
+      ],
+      "locale": [
+        "en",
+        "es"
+      ],
+      "viewport": [
+        "desktop",
+        "mobile"
+      ],
+      "preconditions": [
+        "baseline data seeded"
+      ],
+      "actions": [
+        "open route",
+        "wait network idle",
+        "verify sidebar and header visible"
+      ],
+      "assertions": [
+        "HTTP render without crash",
+        "no runtime fatal errors",
+        "page not 404",
+        "scope navigation remains available"
+      ],
+      "pencilFrameId": "frame:global__tenants",
+      "critical": false
+    },
+    {
       "route": "/global/settings",
       "scope": [
         "global"

--- a/test/system/visual-baseline-map.json
+++ b/test/system/visual-baseline-map.json
@@ -47,6 +47,11 @@
       "critical": true
     },
     {
+      "route": "/global/tenants",
+      "pencilFrameId": "frame:global__tenants",
+      "critical": false
+    },
+    {
       "route": "/global/settings",
       "pencilFrameId": "frame:global__settings",
       "critical": false

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -89,6 +89,7 @@
   },
   "nav": {
     "dashboard": "Dashboard",
+    "tenants": "Tenants",
     "emails": "Emails",
     "templates": "Templates",
     "injectors": "Injectors",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -89,6 +89,7 @@
   },
   "nav": {
     "dashboard": "Dashboard",
+    "tenants": "Tenants",
     "emails": "Emails",
     "templates": "Plantillas",
     "injectors": "Injectors",

--- a/web/src/app/(dashboard)/global/tenants/page.tsx
+++ b/web/src/app/(dashboard)/global/tenants/page.tsx
@@ -1,0 +1,14 @@
+import { PageShell } from "@/components/shared/page-shell";
+import { TenantsContent } from "@/components/tenants/tenants-content";
+
+export default function GlobalTenantsPage() {
+  return (
+    <PageShell
+      title="Tenants"
+      description="Create, update, and retire tenant scopes across the platform"
+      breadcrumbs={[{ label: "Global" }, { label: "Tenants" }]}
+    >
+      <TenantsContent />
+    </PageShell>
+  );
+}

--- a/web/src/components/audit-log/audit-log-filters.tsx
+++ b/web/src/components/audit-log/audit-log-filters.tsx
@@ -32,10 +32,27 @@ interface AuditLogFiltersBarProps {
 
 function getDateRange(value: string): { since?: string; until?: string } {
   if (value === "all") return {};
-  const days = parseInt(value);
+  const days = parseInt(value, 10);
   const since = new Date();
   since.setDate(since.getDate() - days);
   return { since: since.toISOString() };
+}
+
+function FilterField({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={className ?? "flex flex-col gap-1.5"}>
+      <label className="text-[13px] font-medium">{label}</label>
+      {children}
+    </div>
+  );
 }
 
 export function AuditLogFiltersBar({
@@ -43,24 +60,25 @@ export function AuditLogFiltersBar({
   onFiltersChange,
 }: AuditLogFiltersBarProps) {
   return (
-    <div className="flex items-center gap-3 w-full">
-      <div className="relative w-60">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-        <Input
-          placeholder="Search..."
-          className="h-9 pl-9 text-[13px]"
-          onChange={(e) => {
-            const val = e.target.value.trim();
-            onFiltersChange({
-              ...filters,
-              entity_type: val || undefined,
-            });
-          }}
-        />
-      </div>
+    <div className="grid w-full gap-3 md:grid-cols-[minmax(0,1.6fr)_220px_220px] md:items-end">
+      <FilterField label="Search" className="flex flex-col gap-1.5 md:min-w-0">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search..."
+            className="h-9 pl-9 text-[13px]"
+            onChange={(e) => {
+              const val = e.target.value.trim();
+              onFiltersChange({
+                ...filters,
+                entity_type: val || undefined,
+              });
+            }}
+          />
+        </div>
+      </FilterField>
 
-      <div className="flex flex-col gap-1.5 w-[220px]">
-        <label className="text-[13px] font-medium">Action</label>
+      <FilterField label="Action" className="flex flex-col gap-1.5 md:w-[220px]">
         <Select
           defaultValue="all"
           onValueChange={(val) =>
@@ -81,10 +99,9 @@ export function AuditLogFiltersBar({
             ))}
           </SelectContent>
         </Select>
-      </div>
+      </FilterField>
 
-      <div className="flex flex-col gap-1.5 w-[220px]">
-        <label className="text-[13px] font-medium">Date</label>
+      <FilterField label="Date" className="flex flex-col gap-1.5 md:w-[220px]">
         <Select
           defaultValue="7d"
           onValueChange={(val) => {
@@ -107,7 +124,7 @@ export function AuditLogFiltersBar({
             ))}
           </SelectContent>
         </Select>
-      </div>
+      </FilterField>
     </div>
   );
 }

--- a/web/src/components/layout/header.tsx
+++ b/web/src/components/layout/header.tsx
@@ -21,6 +21,7 @@ export function AppHeader({
     "/webhooks": t("webhooks"),
     "/members": t("members"),
     "/api-keys": t("apiKeys"),
+    "/tenants": t("tenants"),
     "/api-docs": t("apiDocs"),
     "/audit-log": t("auditLog"),
     "/settings": t("settings"),

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Plug,
   Webhook,
   Users,
+  Building2,
   Key,
   ScrollText,
   Settings,
@@ -77,6 +78,7 @@ export function AppSidebar({
 
   const navItems = [
     { label: t("dashboard"), icon: LayoutDashboard, href: "" },
+    { label: t("tenants"), icon: Building2, href: "/tenants" },
     { label: t("emails"), icon: Mail, href: "/emails" },
     { label: t("templates"), icon: FileText, href: "/templates" },
     { label: t("injectors"), icon: Database, href: "/injectors" },
@@ -106,9 +108,12 @@ export function AppSidebar({
   const initials = getUserInitials(session?.user?.name, session?.user?.email);
   const helpHref = getContextualHelpHref(pathname);
 
-  const visibleNavItems = navItems.filter(
-    (item) => !(item.href === "/settings" && level !== "global"),
-  );
+  const visibleNavItems = navItems.filter((item) => {
+    if (item.href === "/settings" || item.href === "/tenants") {
+      return level === "global";
+    }
+    return true;
+  });
 
   function hrefForItem(href: string) {
     if (href === "/settings") {

--- a/web/src/components/tenants/tenants-content.tsx
+++ b/web/src/components/tenants/tenants-content.tsx
@@ -1,0 +1,489 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type ColumnDef } from "@tanstack/react-table";
+import { HTTPError } from "ky";
+import { useForm, useWatch, type UseFormSetError } from "react-hook-form";
+import { z } from "zod";
+import { Building2, Pencil, Plus, Search, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { DataTable } from "@/components/shared/data-table";
+import { EmptyState } from "@/components/shared/empty-state";
+import { FormDialog } from "@/components/shared/form-dialog";
+import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  type CreateTenantInput,
+  useCreateTenant,
+  useDeleteTenant,
+  useTenants,
+  useUpdateTenant,
+} from "@/hooks/use-tenants-mgmt";
+import { parseApiError } from "@/lib/api";
+import { formatDate } from "@/lib/utils";
+import {
+  generateSlug,
+  nameSchema,
+  slugSchema,
+} from "@/lib/validations/slug";
+import type { Tenant } from "@/types/api";
+
+const createTenantSchema = z.object({
+  name: nameSchema,
+  code: slugSchema,
+});
+
+const editTenantSchema = z.object({
+  name: nameSchema,
+});
+
+type CreateTenantFormValues = z.infer<typeof createTenantSchema>;
+type EditTenantFormValues = z.infer<typeof editTenantSchema>;
+
+function formatCompactDate(value: string): string {
+  return formatDate(value).replace(",", "");
+}
+
+async function applyCreateTenantErrors(
+  error: unknown,
+  setError: UseFormSetError<CreateTenantFormValues>,
+) {
+  if (error instanceof HTTPError && error.response.status >= 500) {
+    toast.error("Failed to create tenant");
+    return;
+  }
+
+  const apiError = await parseApiError(error);
+  if (apiError.error.details?.length) {
+    for (const detail of apiError.error.details) {
+      if (detail.field === "name" || detail.field === "code") {
+        setError(detail.field, { message: detail.message });
+      }
+    }
+    return;
+  }
+
+  toast.error(apiError.error.message || "Failed to create tenant");
+}
+
+async function applyEditTenantErrors(
+  error: unknown,
+  setError: UseFormSetError<EditTenantFormValues>,
+) {
+  const apiError = await parseApiError(error);
+  if (apiError.error.details?.length) {
+    for (const detail of apiError.error.details) {
+      if (detail.field === "name") {
+        setError("name", { message: detail.message });
+      }
+    }
+    return;
+  }
+
+  toast.error(apiError.error.message || "Failed to update tenant");
+}
+
+export function TenantsContent() {
+  const router = useRouter();
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<Tenant | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Tenant | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(searchInput.trim()), 250);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const {
+    data,
+    isLoading,
+    error,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useTenants(search);
+  const createTenant = useCreateTenant();
+  const updateTenant = useUpdateTenant();
+  const deleteTenant = useDeleteTenant();
+
+  useEffect(() => {
+    if (error) toast.error("Failed to load tenants");
+  }, [error]);
+
+  const tenants = useMemo(
+    () => data?.pages.flatMap((page) => page.items) ?? [],
+    [data],
+  );
+
+  const columns: ColumnDef<Tenant>[] = [
+    {
+      accessorKey: "code",
+      header: "Code",
+      cell: ({ row }) => (
+        <span className="font-mono text-[13px] font-medium">
+          {row.original.code}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "name",
+      header: "Name",
+      cell: ({ row }) => (
+        <span className="text-[13px]">{row.original.name}</span>
+      ),
+    },
+    {
+      accessorKey: "created_at",
+      header: "Created",
+      size: 180,
+      cell: ({ row }) => (
+        <span className="font-mono text-xs text-muted-foreground">
+          {formatCompactDate(row.original.created_at)}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "updated_at",
+      header: "Updated",
+      size: 180,
+      cell: ({ row }) => (
+        <span className="font-mono text-xs text-muted-foreground">
+          {formatCompactDate(row.original.updated_at)}
+        </span>
+      ),
+    },
+    {
+      id: "actions",
+      header: "",
+      size: 64,
+      enableSorting: false,
+      cell: ({ row }) => (
+        <div className="flex items-center justify-end gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setEditTarget(row.original);
+                }}
+              >
+                <Pencil className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Edit tenant</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-destructive"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setDeleteTarget(row.original);
+                }}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Delete tenant</TooltipContent>
+          </Tooltip>
+        </div>
+      ),
+    },
+  ];
+
+  const handleCreateTenant = async (values: CreateTenantInput) => {
+    const created = await createTenant.mutateAsync(values);
+    toast.success(`Tenant \"${created.name}\" created`);
+  };
+
+  const handleUpdateTenant = async (tenantCode: string, name: string) => {
+    const updated = await updateTenant.mutateAsync({
+      tenantCode,
+      data: { name },
+    });
+    toast.success(`Tenant \"${updated.name}\" updated`);
+  };
+
+  const handleDeleteTenant = async () => {
+    if (!deleteTarget) return;
+    await deleteTenant.mutateAsync(deleteTarget.code);
+    toast.success(`Tenant \"${deleteTarget.name}\" deleted`);
+    setDeleteTarget(null);
+  };
+
+  return (
+    <>
+      <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="relative w-full md:max-w-sm">
+          <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search tenants..."
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+            className="h-9 pl-9"
+          />
+        </div>
+
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          Create Tenant
+        </Button>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={tenants}
+        loading={isLoading}
+        hasMore={hasNextPage}
+        onLoadMore={() => fetchNextPage()}
+        loadingMore={isFetchingNextPage}
+        onRowClick={(tenant) => router.push(`/t/${tenant.code}`)}
+        emptyState={
+          <EmptyState
+            icon={Building2}
+            title="No tenants found"
+            description={
+              search
+                ? "No tenant matches the current search."
+                : "Create your first tenant to manage tenant dashboards, members, and workspaces."
+            }
+            action={
+              <Button onClick={() => setCreateOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Create Tenant
+              </Button>
+            }
+          />
+        }
+      />
+
+      <CreateTenantDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreateTenant={handleCreateTenant}
+      />
+
+      {editTarget && (
+        <EditTenantDialog
+          tenant={editTarget}
+          open={!!editTarget}
+          onOpenChange={(open) => {
+            if (!open) setEditTarget(null);
+          }}
+          onUpdateTenant={handleUpdateTenant}
+        />
+      )}
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        title="Delete tenant"
+        description={
+          deleteTarget
+            ? `Soft-delete tenant \"${deleteTarget.name}\" (${deleteTarget.code})? Its workspace data remains in the backend, but the tenant will disappear from active lists.`
+            : ""
+        }
+        confirmLabel="Delete tenant"
+        onConfirm={handleDeleteTenant}
+        loading={deleteTenant.isPending}
+      />
+    </>
+  );
+}
+
+function CreateTenantDialog({
+  open,
+  onOpenChange,
+  onCreateTenant,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreateTenant: (values: CreateTenantInput) => Promise<void>;
+}) {
+  const codeManuallyEdited = useRef(false);
+  const form = useForm<CreateTenantFormValues>({
+    resolver: zodResolver(createTenantSchema),
+    defaultValues: { name: "", code: "" },
+  });
+
+  const watchedName = useWatch({ control: form.control, name: "name" });
+
+  useEffect(() => {
+    if (!open) {
+      form.reset({ name: "", code: "" });
+      codeManuallyEdited.current = false;
+      return;
+    }
+
+    if (!codeManuallyEdited.current && watchedName) {
+      form.setValue("code", generateSlug(watchedName), {
+        shouldValidate: form.formState.isSubmitted,
+      });
+    }
+  }, [form, open, watchedName]);
+
+  const handleSubmit = async () => {
+    let keepOpen = false;
+
+    await form.handleSubmit(
+      async (values) => {
+        try {
+          await onCreateTenant(values);
+          form.reset({ name: "", code: "" });
+          codeManuallyEdited.current = false;
+        } catch (error) {
+          keepOpen = true;
+          await applyCreateTenantErrors(error, form.setError);
+        }
+      },
+      () => {
+        keepOpen = true;
+      },
+    )();
+
+    return keepOpen;
+  };
+
+  const codeField = form.register("code");
+
+  return (
+    <FormDialog
+      trigger={<span className="hidden" />}
+      title="Create Tenant"
+      description="Create a new tenant and its default _system workspace."
+      submitLabel="Create Tenant"
+      loadingLabel="Creating..."
+      submitIcon={<Plus className="h-4 w-4" />}
+      open={open}
+      onOpenChange={onOpenChange}
+      onSubmit={handleSubmit}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="tenant-name" className="text-[13px] font-medium">
+            Name
+          </Label>
+          <Input id="tenant-name" {...form.register("name")} />
+          {form.formState.errors.name && (
+            <p className="text-xs text-destructive">
+              {form.formState.errors.name.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="tenant-code" className="text-[13px] font-medium">
+            Code
+          </Label>
+          <Input
+            id="tenant-code"
+            {...codeField}
+            onChange={(event) => {
+              codeManuallyEdited.current = true;
+              codeField.onChange(event);
+            }}
+          />
+          {form.formState.errors.code && (
+            <p className="text-xs text-destructive">
+              {form.formState.errors.code.message}
+            </p>
+          )}
+        </div>
+      </div>
+    </FormDialog>
+  );
+}
+
+function EditTenantDialog({
+  tenant,
+  open,
+  onOpenChange,
+  onUpdateTenant,
+}: {
+  tenant: Tenant;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUpdateTenant: (tenantCode: string, name: string) => Promise<void>;
+}) {
+  const form = useForm<EditTenantFormValues>({
+    resolver: zodResolver(editTenantSchema),
+    defaultValues: { name: tenant.name },
+  });
+
+  useEffect(() => {
+    form.reset({ name: tenant.name });
+  }, [form, tenant]);
+
+  const handleSubmit = async () => {
+    let keepOpen = false;
+
+    await form.handleSubmit(
+      async (values) => {
+        try {
+          await onUpdateTenant(tenant.code, values.name);
+        } catch (error) {
+          keepOpen = true;
+          await applyEditTenantErrors(error, form.setError);
+        }
+      },
+      () => {
+        keepOpen = true;
+      },
+    )();
+
+    return keepOpen;
+  };
+
+  return (
+    <FormDialog
+      trigger={<span className="hidden" />}
+      title="Edit Tenant"
+      description="Update the tenant display name. The tenant code remains immutable."
+      submitLabel="Save Changes"
+      loadingLabel="Saving..."
+      submitIcon={<Pencil className="h-4 w-4" />}
+      open={open}
+      onOpenChange={onOpenChange}
+      onSubmit={handleSubmit}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="edit-tenant-name" className="text-[13px] font-medium">
+            Name
+          </Label>
+          <Input id="edit-tenant-name" {...form.register("name")} />
+          {form.formState.errors.name && (
+            <p className="text-xs text-destructive">
+              {form.formState.errors.name.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="edit-tenant-code" className="text-[13px] font-medium">
+            Code
+          </Label>
+          <Input id="edit-tenant-code" value={tenant.code} readOnly className="bg-muted/50 font-mono text-[13px] text-muted-foreground" />
+        </div>
+      </div>
+    </FormDialog>
+  );
+}

--- a/web/src/hooks/use-tenants-mgmt.ts
+++ b/web/src/hooks/use-tenants-mgmt.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useApi, useApiReady } from "@/hooks/use-api";
+import { usePaginatedQuery } from "@/hooks/use-paginated-query";
+import type { PaginatedResponse, Tenant } from "@/types/api";
+
+export interface CreateTenantInput {
+  code: string;
+  name: string;
+}
+
+export interface UpdateTenantInput {
+  name: string;
+}
+
+function invalidateTenantQueries(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: ["tenants"] });
+}
+
+export function useTenants(search: string) {
+  const api = useApi();
+  const ready = useApiReady();
+
+  return usePaginatedQuery<Tenant>({
+    queryKey: ["tenants", "management", search],
+    fetcher: (cursor) => {
+      const params: Record<string, string | number> = { limit: 25 };
+      if (cursor) params.cursor = cursor;
+      if (search) params.search = search;
+      return api
+        .get("manage/tenants", { searchParams: params })
+        .json<PaginatedResponse<Tenant>>();
+    },
+    enabled: ready,
+  });
+}
+
+export function useCreateTenant() {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateTenantInput) =>
+      api.post("manage/tenants", { json: data }).json<Tenant>(),
+    onSuccess: () => {
+      invalidateTenantQueries(queryClient);
+    },
+  });
+}
+
+export function useUpdateTenant() {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      tenantCode,
+      data,
+    }: {
+      tenantCode: string;
+      data: UpdateTenantInput;
+    }) => api.put(`manage/tenants/${tenantCode}`, { json: data }).json<Tenant>(),
+    onSuccess: () => {
+      invalidateTenantQueries(queryClient);
+    },
+  });
+}
+
+export function useDeleteTenant() {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (tenantCode: string) => {
+      await api.delete(`manage/tenants/${tenantCode}`);
+    },
+    onSuccess: () => {
+      invalidateTenantQueries(queryClient);
+    },
+  });
+}

--- a/web/tests/global-tenants-and-audit-log-ui.test.mjs
+++ b/web/tests/global-tenants-and-audit-log-ui.test.mjs
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+
+function read(path) {
+  return readFileSync(join(root, path), "utf8");
+}
+
+test("audit log filters share a responsive labeled grid layout", () => {
+  const filters = read("web/src/components/audit-log/audit-log-filters.tsx");
+
+  assert.match(
+    filters,
+    /grid w-full gap-3/,
+    "Audit log filters should use a stable grid layout instead of ad-hoc flex alignment",
+  );
+
+  assert.match(
+    filters,
+    /<FilterField label="Search"/,
+    "Search input should participate in the same labeled field structure as the other filters",
+  );
+});
+
+test("global tenants management screen is wired into navigation and routing", () => {
+  assert.equal(
+    existsSync(join(root, "web/src/app/(dashboard)/global/tenants/page.tsx")),
+    true,
+    "Global tenants route should exist",
+  );
+
+  assert.equal(
+    existsSync(join(root, "web/src/components/tenants/tenants-content.tsx")),
+    true,
+    "Tenants content feature component should exist",
+  );
+
+  const sidebar = read("web/src/components/layout/sidebar.tsx");
+  const header = read("web/src/components/layout/header.tsx");
+  const en = read("web/messages/en.json");
+  const es = read("web/messages/es.json");
+
+  assert.match(sidebar, /t\("tenants"\)/, "Sidebar should expose a Tenants navigation item");
+  assert.match(header, /"\/tenants": t\("tenants"\)/, "Header title mapping should resolve the Tenants page");
+  assert.match(en, /"tenants": "Tenants"/, "English translations should include nav.tenants");
+  assert.match(es, /"tenants": "Tenants"|"tenants": "Inquilinos"/, "Spanish translations should include nav.tenants");
+});
+
+test("tenant management hooks and coverage metadata exist", () => {
+  assert.equal(
+    existsSync(join(root, "web/src/hooks/use-tenants-mgmt.ts")),
+    true,
+    "Tenant management hooks should exist",
+  );
+
+  const screenManifest = read("test/system/screen-manifest.json");
+  const visualBaselineMap = read("test/system/visual-baseline-map.json");
+
+  assert.match(screenManifest, /"route": "\/global\/tenants"/, "Screen manifest should cover /global/tenants");
+  assert.match(visualBaselineMap, /"route": "\/global\/tenants"/, "Visual baseline map should cover /global/tenants");
+});


### PR DESCRIPTION
Closes #10

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- add a new global tenants management screen with search, create, rename, soft-delete, and row navigation
- wire the new tenants screen into global navigation, titles, translations, and system route coverage metadata
- normalize the Audit Log toolbar into a responsive labeled grid so search/action/date controls align consistently

## Changes Table
| File | Change |
|------|--------|
| `web/src/components/tenants/tenants-content.tsx` | Adds the feature-first tenants CRUD UI and dialogs |
| `web/src/hooks/use-tenants-mgmt.ts` | Adds tenant list/create/update/delete React Query hooks |
| `web/src/app/(dashboard)/global/tenants/page.tsx` | Registers the new `/global/tenants` route |
| `web/src/components/layout/sidebar.tsx` | Adds the global Tenants navigation entry |
| `web/src/components/layout/header.tsx` | Adds header title resolution for the Tenants page |
| `web/src/components/audit-log/audit-log-filters.tsx` | Refactors the Audit Log filters into a shared responsive field layout |
| `web/messages/en.json` | Adds `nav.tenants` |
| `web/messages/es.json` | Adds `nav.tenants` |
| `test/system/screen-manifest.json` | Covers `/global/tenants` in the route manifest |
| `test/system/visual-baseline-map.json` | Adds visual metadata for `/global/tenants` |
| `web/tests/global-tenants-and-audit-log-ui.test.mjs` | Adds regression coverage for the new UI wiring |

## Test Plan
- [x] `node --test web/tests/global-tenants-and-audit-log-ui.test.mjs`
- [x] `cd web && npm run lint`
- [x] `make system-validate-manifest`
- [ ] Browser smoke test against a running backend

## Notes
- I intentionally left unrelated local modifications in Postman/help docs out of this PR.
- I did not run a build, per repo instructions.
