### PR TITLE
fix(web): proxy video thumbnails through route handler

### DIFF
--- a/web/next.config.test.ts
+++ b/web/next.config.test.ts
@@ -6,34 +6,11 @@ const rewritesModule = await import(
 );
 const { buildRewrites } = rewritesModule;
 
-test("next config proxies public video thumbnails to the backend origin", () => {
+test("next config only proxies API routes through rewrites", () => {
   assert.deepEqual(buildRewrites("https://api.example.com"), [
     {
       source: "/api/v1/:path*",
       destination: "https://api.example.com/api/v1/:path*",
     },
-    {
-      source: "/public/video-thumbnail",
-      destination: "https://api.example.com/public/video-thumbnail",
-    },
   ]);
-});
-
-test("next config can proxy video thumbnails to a dedicated backend origin", () => {
-  assert.deepEqual(
-    buildRewrites(
-      "https://public.example.com",
-      "https://backend.example.com",
-    ),
-    [
-      {
-        source: "/api/v1/:path*",
-        destination: "https://public.example.com/api/v1/:path*",
-      },
-      {
-        source: "/public/video-thumbnail",
-        destination: "https://backend.example.com/public/video-thumbnail",
-      },
-    ],
-  );
 });

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -11,14 +11,13 @@ const workspaceRoot =
     ? process.cwd()
     : path.join(process.cwd(), "web");
 const apiOrigin = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
-const videoThumbnailOrigin = process.env.SENDA_SERVER_URL || apiOrigin;
 
 const nextConfig: NextConfig = {
   turbopack: {
     root: workspaceRoot,
   },
   async rewrites() {
-    return buildRewrites(apiOrigin, videoThumbnailOrigin);
+    return buildRewrites(apiOrigin);
   },
 };
 

--- a/web/src/app/public/video-thumbnail/proxy.test.ts
+++ b/web/src/app/public/video-thumbnail/proxy.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const proxyModule = await import(new URL("./proxy.ts", import.meta.url).href);
+const { buildUpstreamVideoThumbnailUrl, proxyVideoThumbnail } = proxyModule;
+
+test("buildUpstreamVideoThumbnailUrl targets the backend thumbnail endpoint", () => {
+  const upstream = buildUpstreamVideoThumbnailUrl(
+    new URL(
+      "https://senda.tether.education/public/video-thumbnail?url=https://img.youtube.com/vi/-pAu40lToXQ/maxresdefault.jpg",
+    ),
+    "https://backend.example.com",
+  );
+
+  assert.equal(
+    upstream.toString(),
+    "https://backend.example.com/public/video-thumbnail?url=https%3A%2F%2Fimg.youtube.com%2Fvi%2F-pAu40lToXQ%2Fmaxresdefault.jpg",
+  );
+});
+
+test("proxyVideoThumbnail streams the backend image response", async () => {
+  let requestedUrl = "";
+  const body = Uint8Array.from([1, 2, 3, 4]);
+
+  const response = await proxyVideoThumbnail(
+    new Request(
+      "https://senda.tether.education/public/video-thumbnail?url=https://img.youtube.com/vi/-pAu40lToXQ/maxresdefault.jpg",
+    ),
+    "https://backend.example.com",
+    async (input: string | URL | Request) => {
+      requestedUrl = String(input);
+      return new Response(body, {
+        status: 200,
+        headers: {
+          "content-type": "image/png",
+          "cache-control": "public, max-age=60",
+        },
+      });
+    },
+  );
+
+  assert.equal(
+    requestedUrl,
+    "https://backend.example.com/public/video-thumbnail?url=https%3A%2F%2Fimg.youtube.com%2Fvi%2F-pAu40lToXQ%2Fmaxresdefault.jpg",
+  );
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "image/png");
+  assert.equal(response.headers.get("cache-control"), "public, max-age=60");
+  assert.deepEqual(new Uint8Array(await response.arrayBuffer()), body);
+});

--- a/web/src/app/public/video-thumbnail/proxy.ts
+++ b/web/src/app/public/video-thumbnail/proxy.ts
@@ -1,0 +1,70 @@
+const defaultBackendOrigin =
+  process.env.SENDA_SERVER_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8080";
+
+type FetchLike = typeof fetch;
+
+export function buildUpstreamVideoThumbnailUrl(
+  requestUrl: URL,
+  backendOrigin = defaultBackendOrigin,
+): URL {
+  const upstream = new URL("/public/video-thumbnail", backendOrigin);
+  const rawThumbnailUrl = requestUrl.searchParams.get("url");
+
+  if (rawThumbnailUrl) {
+    upstream.searchParams.set("url", rawThumbnailUrl);
+  }
+
+  return upstream;
+}
+
+function copyProxyHeaders(upstream: Response): Headers {
+  const headers = new Headers();
+  for (const name of [
+    "content-type",
+    "cache-control",
+    "etag",
+    "last-modified",
+    "content-length",
+  ]) {
+    const value = upstream.headers.get(name);
+    if (value) {
+      headers.set(name, value);
+    }
+  }
+  return headers;
+}
+
+export async function proxyVideoThumbnail(
+  request: Request,
+  backendOrigin = defaultBackendOrigin,
+  fetchImpl: FetchLike = fetch,
+): Promise<Response> {
+  const upstreamUrl = buildUpstreamVideoThumbnailUrl(
+    new URL(request.url),
+    backendOrigin,
+  );
+
+  try {
+    const upstream = await fetchImpl(upstreamUrl, {
+      method: "GET",
+      headers: {
+        accept: request.headers.get("accept") || "*/*",
+      },
+      cache: "no-store",
+    });
+
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: copyProxyHeaders(upstream),
+    });
+  } catch {
+    return new Response("video thumbnail proxy failed", {
+      status: 502,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+      },
+    });
+  }
+}

--- a/web/src/app/public/video-thumbnail/route.ts
+++ b/web/src/app/public/video-thumbnail/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from "next/server";
+import { proxyVideoThumbnail } from "./proxy";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  return proxyVideoThumbnail(request);
+}

--- a/web/src/config/rewrites.ts
+++ b/web/src/config/rewrites.ts
@@ -1,15 +1,8 @@
-export function buildRewrites(
-  apiOrigin: string,
-  videoThumbnailOrigin = apiOrigin,
-) {
+export function buildRewrites(apiOrigin: string) {
   return [
     {
       source: "/api/v1/:path*",
       destination: `${apiOrigin}/api/v1/:path*`,
-    },
-    {
-      source: "/public/video-thumbnail",
-      destination: `${videoThumbnailOrigin}/public/video-thumbnail`,
     },
   ];
 }


### PR DESCRIPTION
Closes #53

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- replace the Next rewrite for `/public/video-thumbnail` with an explicit route handler proxy
- keep API rewrites unchanged and move thumbnail proxying to a dedicated request path
- validate locally with targeted tests, HTTP verification, and visual builder confirmation

## Changes
| File | Change |
|------|--------|
| `web/src/app/public/video-thumbnail/proxy.ts` | adds a backend proxy helper that forwards the thumbnail response and preserves key headers |
| `web/src/app/public/video-thumbnail/route.ts` | exposes the Next route handler for `/public/video-thumbnail` |
| `web/src/app/public/video-thumbnail/proxy.test.ts` | covers upstream URL building and binary response proxying |
| `web/src/config/rewrites.ts` | removes the thumbnail rewrite and leaves only API proxy rewrites |
| `web/next.config.ts` | uses the simplified rewrite contract |
| `web/next.config.test.ts` | locks the new rewrite behavior with regression coverage |

## Test Plan
- [x] `node --experimental-strip-types --test web/next.config.test.ts web/src/app/public/video-thumbnail/proxy.test.ts web/src/components/templates/video-block.test.ts`
- [x] `pnpm --dir web typecheck`
- [x] `make ci-frontend`
- [x] local browser verification in the real builder flow with `agent-browser`
- [x] local HTTP verification: `GET http://localhost:3000/public/video-thumbnail?...` returns `200` with `content-type: image/png`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran the relevant validation for the affected code
- [x] Docs update not required for this bugfix
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers
