### PR TITLE
fix(web): stop preloading unused mono fonts on login

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -15,6 +15,7 @@ const ibmPlexMono = IBM_Plex_Mono({
   variable: "--font-ibm-plex-mono",
   subsets: ["latin"],
   weight: ["400", "500", "600"],
+  preload: false,
 });
 
 export const metadata: Metadata = {

--- a/web/tests/font-preload-scope.test.mjs
+++ b/web/tests/font-preload-scope.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+
+function read(path) {
+  return readFileSync(join(root, path), "utf8");
+}
+
+test("root layout does not preload IBM Plex Mono globally", () => {
+  const layout = read("web/src/app/layout.tsx");
+  const match = layout.match(/const ibmPlexMono = IBM_Plex_Mono\(([^]*?)\);/);
+
+  assert.ok(match, "IBM Plex Mono font config must exist in root layout");
+  assert.match(
+    match[1],
+    /preload:\s*false/,
+    "IBM Plex Mono must opt out of global preload in the root layout",
+  );
+});


### PR DESCRIPTION
## Summary

- disable global preload for `IBM_Plex_Mono` in the root App Router layout
- add a regression test that prevents reintroducing eager mono preload on public routes like `/login`

## Context

- Related issue: Closes #55
- Related story (if any): none
- Risk / tradeoffs: keeps the mono font variable globally available for dashboard overlays and portal-mounted UI, while avoiding unnecessary eager font fetches on login

## Validation

Mark everything you actually ran.

- [ ] `make ci-backend-pr` (if backend, infra, migrations, or tests changed)
- [x] `make ci-frontend` (if `web/` changed)
- [ ] `make ci-pr` (if both backend and frontend changed)
- [ ] `make ci-main` (required for pushes to `main` and systemic/cross-layer changes; fast gate, no Docker)

Optional deeper checks when you intentionally want Docker-backed coverage:

- [ ] `make test-integration`
- [ ] `make test-e2e`

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test-only
- [ ] Security-sensitive

## Contributor checklist

- [x] I kept the change focused and reviewable.
- [x] I added or updated tests where behavior changed.
- [ ] I updated docs when behavior, setup, API, or workflows changed.
- [x] I did not add build-only validation as a substitute for the required local gates.
- [x] I did not add AI attribution or `Co-Authored-By` trailers.

## Compatibility / ops impact

- [x] No migration
- [ ] Migration included
- [x] No config changes
- [ ] Config changes included
- [x] No security impact
- [ ] Security impact described above
