### PR TITLE
fix(web): stabilize injector field row keys

### DIFF
--- a/web/src/components/injectors/injector-form-model.test.ts
+++ b/web/src/components/injectors/injector-form-model.test.ts
@@ -13,6 +13,7 @@ const {
 } = await import(new URL("./injector-form-model.ts", import.meta.url).href);
 
 type InjectorDefinition = import("@/types/injectors").InjectorDefinition;
+type InjectorFormFieldEntry = import("./injector-form-model").InjectorFormFieldEntry;
 
 const FULL_NAME = "full name";
 const ADA_LOVELACE = "Ada Lovelace";
@@ -41,10 +42,31 @@ test("injectorDefinitionToFormValues hydrates edit mode state preserving order a
     ],
   };
 
-  assert.deepEqual(injectorDefinitionToFormValues(injector), {
-    name: "student",
-    description: "Student profile",
-    fields: [
+  const values = injectorDefinitionToFormValues(injector);
+
+  assert.equal(values.name, "student");
+  assert.equal(values.description, "Student profile");
+  assert.equal(values.fields.length, 2);
+  assert.equal(values.fields[0].form_id.length > 0, true);
+  assert.equal(values.fields[1].form_id.length > 0, true);
+  assert.notEqual(values.fields[0].form_id, values.fields[1].form_id);
+  assert.deepEqual(
+    values.fields.map(
+      ({
+        field_name,
+        field_type,
+        description,
+        default_value,
+        allow_overwrite,
+      }: InjectorFormFieldEntry) => ({
+        field_name,
+        field_type,
+        description,
+        default_value,
+        allow_overwrite,
+      }),
+    ),
+    [
       {
         field_name: "full name",
         field_type: "text",
@@ -60,7 +82,7 @@ test("injectorDefinitionToFormValues hydrates edit mode state preserving order a
         allow_overwrite: false,
       },
     ],
-  });
+  );
 });
 
 test("buildInjectorRequest serializes edited fields with index-based positions", () => {
@@ -69,6 +91,7 @@ test("buildInjectorRequest serializes edited fields with index-based positions",
     description: "  ",
     fields: [
       {
+        form_id: "field-1",
         field_name: FULL_NAME,
         field_type: "text",
         description: "Primary label",
@@ -76,6 +99,7 @@ test("buildInjectorRequest serializes edited fields with index-based positions",
         allow_overwrite: true,
       },
       {
+        form_id: "field-2",
         field_name: "is active",
         field_type: "bool",
         description: "",
@@ -126,6 +150,7 @@ test("serialization helpers preserve bool defaults and spaced field names use re
   assert.equal(parseInjectorFieldValue("number", "42"), 42);
   assert.equal(parseInjectorFieldValue("text", ""), undefined);
   assert.equal(emptyInjectorFormField().field_name, "");
+  assert.equal(emptyInjectorFormField().form_id.length > 0, true);
   assert.equal(
     resolveUpdatedInjectorSelection({ name: STUDENT_PROFILE }),
     STUDENT_PROFILE,

--- a/web/src/components/injectors/injector-form-model.ts
+++ b/web/src/components/injectors/injector-form-model.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/types/injectors";
 
 export interface InjectorFormFieldEntry {
+  form_id: string;
   field_name: string;
   field_type: InjectorFieldType;
   description: string;
@@ -22,6 +23,7 @@ export interface InjectorFormValues {
 
 export function emptyInjectorFormField(): InjectorFormFieldEntry {
   return {
+    form_id: crypto.randomUUID(),
     field_name: "",
     field_type: "text",
     description: "",
@@ -44,6 +46,7 @@ export function injectorDefinitionToFormValues(
   const fields = [...injector.fields]
     .sort((left, right) => left.position - right.position)
     .map((field) => ({
+      form_id: crypto.randomUUID(),
       field_name: field.field_name,
       field_type: field.field_type,
       description: field.description ?? "",

--- a/web/src/components/injectors/injector-form.tsx
+++ b/web/src/components/injectors/injector-form.tsx
@@ -178,7 +178,7 @@ export function InjectorForm({
 
           {fields.map((field, index) => (
             <InjectorFieldCard
-              key={`${field.field_name || "field"}-${index}`}
+              key={field.form_id}
               testId={`injector-field-row-${index}`}
               headerTestId={`injector-field-header-${index}`}
               title={field.field_name.trim() || `Field ${index + 1}`}


### PR DESCRIPTION
## Summary

- add a stable client-only `form_id` to injector field form entries
- use that identifier as the React key for injector field rows instead of mutable field names
- extend model tests to cover the new stable field identity

## Context

- Related issue: Closes #57
- Related story (if any): none
- Risk / tradeoffs: adds a UI-only field identifier to form state, but keeps request serialization unchanged so the API contract is unaffected

## Validation

Mark everything you actually ran.

- [ ] `make ci-backend-pr` (if backend, infra, migrations, or tests changed)
- [x] `make ci-frontend` (if `web/` changed)
- [ ] `make ci-pr` (if both backend and frontend changed)
- [ ] `make ci-main` (required for pushes to `main` and systemic/cross-layer changes; fast gate, no Docker)

Optional deeper checks when you intentionally want Docker-backed coverage:

- [ ] `make test-integration`
- [ ] `make test-e2e`

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test-only
- [ ] Security-sensitive

## Contributor checklist

- [x] I kept the change focused and reviewable.
- [x] I added or updated tests where behavior changed.
- [ ] I updated docs when behavior, setup, API, or workflows changed.
- [x] I did not add build-only validation as a substitute for the required local gates.
- [x] I did not add AI attribution or `Co-Authored-By` trailers.

## Compatibility / ops impact

- [x] No migration
- [ ] Migration included
- [x] No config changes
- [ ] Config changes included
- [x] No security impact
- [ ] Security impact described above
