### PR TITLE
feat(templates): add exact version cloning

### DIFF
--- a/cmd/senda/docs/docs.go
+++ b/cmd/senda/docs/docs.go
@@ -3566,6 +3566,89 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/manage/global/templates/{template_id}/versions/{version_id}/clone": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/global/templates/{template_id}/versions/{version_id}/clone",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/manage/global/templates/{template_id}/versions/{version_id}/locales": {
             "get": {
                 "security": [
@@ -11556,6 +11639,103 @@ const docTemplate = `{
                         "description": "No Content",
                         "schema": {
                             "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse"
                         }
                     },
                     "400": {

--- a/cmd/senda/docs/openapi.yaml
+++ b/cmd/senda/docs/openapi.yaml
@@ -4297,6 +4297,76 @@ paths:
             summary: PUT /api/v1/manage/global/templates/{template_id}/versions/{version_id}
             tags:
                 - templates
+    /api/v1/manage/global/templates/{template_id}/versions/{version_id}/clone:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/global/templates/{template_id}/versions/{version_id}/clone
+            tags:
+                - templates
     /api/v1/manage/global/templates/{template_id}/versions/{version_id}/locales:
         get:
             description: Auto-generated route stub for OpenAPI + MCP discovery.
@@ -11028,6 +11098,88 @@ paths:
             security:
                 - ManagementBearer: []
             summary: PUT /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+            tags:
+                - templates
+    /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone
             tags:
                 - templates
     /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales:

--- a/cmd/senda/docs/swagger.yaml
+++ b/cmd/senda/docs/swagger.yaml
@@ -3612,6 +3612,60 @@ paths:
       summary: PUT /api/v1/manage/global/templates/{template_id}/versions/{version_id}
       tags:
       - templates
+  /api/v1/manage/global/templates/{template_id}/versions/{version_id}/clone:
+    post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/global/templates/{template_id}/versions/{version_id}/clone
+      tags:
+      - templates
   /api/v1/manage/global/templates/{template_id}/versions/{version_id}/locales:
     get:
       description: Auto-generated route stub for OpenAPI + MCP discovery.
@@ -8874,6 +8928,70 @@ paths:
       security:
       - ManagementBearer: []
       summary: PUT /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+      tags:
+      - templates
+  /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone:
+    post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone
       tags:
       - templates
   /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales:

--- a/cmd/senda/openapi_generated.go
+++ b/cmd/senda/openapi_generated.go
@@ -877,6 +877,25 @@ func doc_get_api_v1_manage_global_templates_template_id_versions_version_id() {}
 // @Router       /api/v1/manage/global/templates/{template_id}/versions/{version_id} [put]
 func doc_put_api_v1_manage_global_templates_template_id_versions_version_id() {}
 
+// doc_post_api_v1_manage_global_templates_template_id_versions_version_id_clone auto-generated route documentation.
+// @Summary      POST /api/v1/manage/global/templates/{template_id}/versions/{version_id}/clone
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Success      201  {object}  response.TemplateVersionResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/global/templates/{template_id}/versions/{version_id}/clone [post]
+func doc_post_api_v1_manage_global_templates_template_id_versions_version_id_clone() {}
+
 // doc_get_api_v1_manage_global_templates_template_id_versions_version_id_locales auto-generated route documentation.
 // @Summary      GET /api/v1/manage/global/templates/{template_id}/versions/{version_id}/locales
 // @Description  Auto-generated route stub for OpenAPI + MCP discovery.
@@ -2673,6 +2692,27 @@ func doc_get_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_templat
 // @Failure      500  {object}  DocErrorResponse
 // @Router       /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id} [put]
 func doc_put_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id() {}
+
+// doc_post_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_clone auto-generated route documentation.
+// @Summary      POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Success      201  {object}  response.TemplateVersionResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone [post]
+func doc_post_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_clone() {}
 
 // doc_get_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales auto-generated route documentation.
 // @Summary      GET /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales

--- a/internal/adapter/postgres/template_repo.go
+++ b/internal/adapter/postgres/template_repo.go
@@ -522,6 +522,148 @@ func (r *TemplateRepo) CreateVersion(ctx context.Context, ver *domain.TemplateVe
 	return nil
 }
 
+func (r *TemplateRepo) CloneVersion(
+	ctx context.Context,
+	templateID, sourceVersionID uuid.UUID,
+	createdBy *uuid.UUID,
+) (*domain.TemplateVersion, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	var lockedTemplateID uuid.UUID
+	if err := tx.QueryRow(ctx,
+		`SELECT id FROM templates WHERE id = @template_id FOR UPDATE`,
+		pgx.NamedArgs{"template_id": templateID},
+	).Scan(&lockedTemplateID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperr.NotFound("template %s not found", templateID)
+		}
+		return nil, fmt.Errorf("locking template for version clone: %w", err)
+	}
+
+	sourceVersionRow := tx.QueryRow(ctx,
+		`SELECT id, template_id, version_number, status, subject, preview_text,
+		        from_name, reply_to, body_mjml, default_locale,
+		        editor_data, created_by, published_at, archived_at, created_at, updated_at
+		 FROM template_versions
+		 WHERE id = @source_version_id AND template_id = @template_id`,
+		pgx.NamedArgs{
+			"source_version_id": sourceVersionID,
+			"template_id":       templateID,
+		},
+	)
+	sourceVersion, err := scanTemplateVersion(sourceVersionRow)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceLocaleRows, err := tx.Query(ctx,
+		`SELECT id, template_version_id, locale, subject, preview_text, from_name,
+		        body_mjml, editor_data, created_at, updated_at
+		 FROM template_version_locales
+		 WHERE template_version_id = @source_version_id
+		 ORDER BY created_at ASC`,
+		pgx.NamedArgs{"source_version_id": sourceVersionID},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing source locales for clone: %w", err)
+	}
+
+	sourceLocales, err := pgx.CollectRows(sourceLocaleRows, scanTemplateVersionLocaleRow)
+	if err != nil {
+		return nil, fmt.Errorf("collecting source locales for clone: %w", err)
+	}
+
+	var versionNumber int
+	if err := tx.QueryRow(ctx,
+		`SELECT COALESCE(MAX(version_number), 0) + 1
+		 FROM template_versions
+		 WHERE template_id = @template_id`,
+		pgx.NamedArgs{"template_id": templateID},
+	).Scan(&versionNumber); err != nil {
+		return nil, fmt.Errorf("calculating cloned version number: %w", err)
+	}
+
+	cloned := &domain.TemplateVersion{
+		ID:            uuid.Must(uuid.NewV7()),
+		TemplateID:    templateID,
+		VersionNumber: versionNumber,
+		Status:        domain.VersionStatusDraft,
+		Subject:       sourceVersion.Subject,
+		PreviewText:   sourceVersion.PreviewText,
+		FromName:      sourceVersion.FromName,
+		ReplyTo:       sourceVersion.ReplyTo,
+		BodyMJML:      sourceVersion.BodyMJML,
+		DefaultLocale: sourceVersion.DefaultLocale,
+		EditorData:    sourceVersion.EditorData,
+		CreatedBy:     createdBy,
+	}
+
+	if err := tx.QueryRow(ctx,
+		`INSERT INTO template_versions (id, template_id, version_number, status, subject, preview_text,
+		                                from_name, reply_to, body_mjml, default_locale,
+		                                editor_data, created_by)
+		 VALUES (@id, @template_id, @version_number, @status, @subject, @preview_text,
+		         @from_name, @reply_to, @body_mjml, @default_locale,
+		         @editor_data, @created_by)
+		 RETURNING created_at, updated_at`,
+		pgx.NamedArgs{
+			"id":             cloned.ID,
+			"template_id":    cloned.TemplateID,
+			"version_number": cloned.VersionNumber,
+			"status":         cloned.Status,
+			"subject":        cloned.Subject,
+			"preview_text":   cloned.PreviewText,
+			"from_name":      cloned.FromName,
+			"reply_to":       cloned.ReplyTo,
+			"body_mjml":      cloned.BodyMJML,
+			"default_locale": cloned.DefaultLocale,
+			"editor_data":    cloned.EditorData,
+			"created_by":     cloned.CreatedBy,
+		},
+	).Scan(&cloned.CreatedAt, &cloned.UpdatedAt); err != nil {
+		if appErr := classifyPgError(err); appErr != nil {
+			return nil, appErr
+		}
+		return nil, fmt.Errorf("inserting cloned template version: %w", err)
+	}
+
+	for _, sourceLocale := range sourceLocales {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO template_version_locales (id, template_version_id, locale, subject, preview_text,
+			                                       from_name, body_mjml, editor_data)
+			 VALUES (@id, @template_version_id, @locale, @subject, @preview_text,
+			         @from_name, @body_mjml, @editor_data)`,
+			pgx.NamedArgs{
+				"id":                  uuid.Must(uuid.NewV7()),
+				"template_version_id": cloned.ID,
+				"locale":              sourceLocale.Locale,
+				"subject":             sourceLocale.Subject,
+				"preview_text":        sourceLocale.PreviewText,
+				"from_name":           sourceLocale.FromName,
+				"body_mjml":           sourceLocale.BodyMJML,
+				"editor_data":         sourceLocale.EditorData,
+			},
+		); err != nil {
+			if appErr := classifyPgError(err); appErr != nil {
+				return nil, appErr
+			}
+			return nil, fmt.Errorf("inserting cloned template locale %s: %w", sourceLocale.Locale, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("committing cloned template version: %w", err)
+	}
+
+	return cloned, nil
+}
+
 func (r *TemplateRepo) GetVersionByID(ctx context.Context, versionID uuid.UUID) (*domain.TemplateVersion, error) {
 	row := r.pool.QueryRow(ctx,
 		`SELECT id, template_id, version_number, status, subject, preview_text,

--- a/internal/adapter/postgres/template_repo.go
+++ b/internal/adapter/postgres/template_repo.go
@@ -535,18 +535,69 @@ func (r *TemplateRepo) CloneVersion(
 		_ = tx.Rollback(ctx)
 	}()
 
+	if err := lockTemplateForVersionMutation(ctx, tx, templateID, "clone"); err != nil {
+		return nil, err
+	}
+
+	sourceVersion, err := loadTemplateVersionForClone(ctx, tx, templateID, sourceVersionID)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceLocales, err := listTemplateVersionLocalesForClone(ctx, tx, sourceVersionID)
+	if err != nil {
+		return nil, err
+	}
+
+	cloned := &domain.TemplateVersion{
+		ID:            uuid.Must(uuid.NewV7()),
+		TemplateID:    templateID,
+		Status:        domain.VersionStatusDraft,
+		Subject:       sourceVersion.Subject,
+		PreviewText:   sourceVersion.PreviewText,
+		FromName:      sourceVersion.FromName,
+		ReplyTo:       sourceVersion.ReplyTo,
+		BodyMJML:      sourceVersion.BodyMJML,
+		DefaultLocale: sourceVersion.DefaultLocale,
+		EditorData:    sourceVersion.EditorData,
+		CreatedBy:     createdBy,
+	}
+
+	if err := insertClonedVersion(ctx, tx, cloned); err != nil {
+		return nil, err
+	}
+
+	if err := insertClonedLocales(ctx, tx, cloned.ID, sourceLocales); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("committing cloned template version: %w", err)
+	}
+
+	return cloned, nil
+}
+
+func lockTemplateForVersionMutation(ctx context.Context, tx pgx.Tx, templateID uuid.UUID, operation string) error {
 	var lockedTemplateID uuid.UUID
 	if err := tx.QueryRow(ctx,
 		`SELECT id FROM templates WHERE id = @template_id FOR UPDATE`,
 		pgx.NamedArgs{"template_id": templateID},
 	).Scan(&lockedTemplateID); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, apperr.NotFound("template %s not found", templateID)
+			return apperr.NotFound("template %s not found", templateID)
 		}
-		return nil, fmt.Errorf("locking template for version clone: %w", err)
+		return fmt.Errorf("locking template for version %s: %w", operation, err)
 	}
+	return nil
+}
 
-	sourceVersionRow := tx.QueryRow(ctx,
+func loadTemplateVersionForClone(
+	ctx context.Context,
+	tx pgx.Tx,
+	templateID, sourceVersionID uuid.UUID,
+) (*domain.TemplateVersion, error) {
+	row := tx.QueryRow(ctx,
 		`SELECT id, template_id, version_number, status, subject, preview_text,
 		        from_name, reply_to, body_mjml, default_locale,
 		        editor_data, created_by, published_at, archived_at, created_at, updated_at
@@ -557,12 +608,15 @@ func (r *TemplateRepo) CloneVersion(
 			"template_id":       templateID,
 		},
 	)
-	sourceVersion, err := scanTemplateVersion(sourceVersionRow)
-	if err != nil {
-		return nil, err
-	}
+	return scanTemplateVersion(row)
+}
 
-	sourceLocaleRows, err := tx.Query(ctx,
+func listTemplateVersionLocalesForClone(
+	ctx context.Context,
+	tx pgx.Tx,
+	sourceVersionID uuid.UUID,
+) ([]*domain.TemplateVersionLocale, error) {
+	rows, err := tx.Query(ctx,
 		`SELECT id, template_version_id, locale, subject, preview_text, from_name,
 		        body_mjml, editor_data, created_at, updated_at
 		 FROM template_version_locales
@@ -574,35 +628,19 @@ func (r *TemplateRepo) CloneVersion(
 		return nil, fmt.Errorf("listing source locales for clone: %w", err)
 	}
 
-	sourceLocales, err := pgx.CollectRows(sourceLocaleRows, scanTemplateVersionLocaleRow)
+	locales, err := pgx.CollectRows(rows, scanTemplateVersionLocaleRow)
 	if err != nil {
 		return nil, fmt.Errorf("collecting source locales for clone: %w", err)
 	}
+	return locales, nil
+}
 
-	var versionNumber int
-	if err := tx.QueryRow(ctx,
-		`SELECT COALESCE(MAX(version_number), 0) + 1
-		 FROM template_versions
-		 WHERE template_id = @template_id`,
-		pgx.NamedArgs{"template_id": templateID},
-	).Scan(&versionNumber); err != nil {
-		return nil, fmt.Errorf("calculating cloned version number: %w", err)
+func insertClonedVersion(ctx context.Context, tx pgx.Tx, cloned *domain.TemplateVersion) error {
+	versionNumber, err := nextTemplateVersionNumber(ctx, tx, cloned.TemplateID)
+	if err != nil {
+		return err
 	}
-
-	cloned := &domain.TemplateVersion{
-		ID:            uuid.Must(uuid.NewV7()),
-		TemplateID:    templateID,
-		VersionNumber: versionNumber,
-		Status:        domain.VersionStatusDraft,
-		Subject:       sourceVersion.Subject,
-		PreviewText:   sourceVersion.PreviewText,
-		FromName:      sourceVersion.FromName,
-		ReplyTo:       sourceVersion.ReplyTo,
-		BodyMJML:      sourceVersion.BodyMJML,
-		DefaultLocale: sourceVersion.DefaultLocale,
-		EditorData:    sourceVersion.EditorData,
-		CreatedBy:     createdBy,
-	}
+	cloned.VersionNumber = versionNumber
 
 	if err := tx.QueryRow(ctx,
 		`INSERT INTO template_versions (id, template_id, version_number, status, subject, preview_text,
@@ -628,11 +666,32 @@ func (r *TemplateRepo) CloneVersion(
 		},
 	).Scan(&cloned.CreatedAt, &cloned.UpdatedAt); err != nil {
 		if appErr := classifyPgError(err); appErr != nil {
-			return nil, appErr
+			return appErr
 		}
-		return nil, fmt.Errorf("inserting cloned template version: %w", err)
+		return fmt.Errorf("inserting cloned template version: %w", err)
 	}
+	return nil
+}
 
+func nextTemplateVersionNumber(ctx context.Context, tx pgx.Tx, templateID uuid.UUID) (int, error) {
+	var versionNumber int
+	if err := tx.QueryRow(ctx,
+		`SELECT COALESCE(MAX(version_number), 0) + 1
+		 FROM template_versions
+		 WHERE template_id = @template_id`,
+		pgx.NamedArgs{"template_id": templateID},
+	).Scan(&versionNumber); err != nil {
+		return 0, fmt.Errorf("calculating cloned version number: %w", err)
+	}
+	return versionNumber, nil
+}
+
+func insertClonedLocales(
+	ctx context.Context,
+	tx pgx.Tx,
+	clonedVersionID uuid.UUID,
+	sourceLocales []*domain.TemplateVersionLocale,
+) error {
 	for _, sourceLocale := range sourceLocales {
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO template_version_locales (id, template_version_id, locale, subject, preview_text,
@@ -641,7 +700,7 @@ func (r *TemplateRepo) CloneVersion(
 			         @from_name, @body_mjml, @editor_data)`,
 			pgx.NamedArgs{
 				"id":                  uuid.Must(uuid.NewV7()),
-				"template_version_id": cloned.ID,
+				"template_version_id": clonedVersionID,
 				"locale":              sourceLocale.Locale,
 				"subject":             sourceLocale.Subject,
 				"preview_text":        sourceLocale.PreviewText,
@@ -651,17 +710,12 @@ func (r *TemplateRepo) CloneVersion(
 			},
 		); err != nil {
 			if appErr := classifyPgError(err); appErr != nil {
-				return nil, appErr
+				return appErr
 			}
-			return nil, fmt.Errorf("inserting cloned template locale %s: %w", sourceLocale.Locale, err)
+			return fmt.Errorf("inserting cloned template locale %s: %w", sourceLocale.Locale, err)
 		}
 	}
-
-	if err := tx.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("committing cloned template version: %w", err)
-	}
-
-	return cloned, nil
+	return nil
 }
 
 func (r *TemplateRepo) GetVersionByID(ctx context.Context, versionID uuid.UUID) (*domain.TemplateVersion, error) {

--- a/internal/adapter/postgres/template_repo_test.go
+++ b/internal/adapter/postgres/template_repo_test.go
@@ -831,6 +831,100 @@ func TestTemplateRepo_ListVersions(t *testing.T) {
 	}
 }
 
+func TestTemplateRepo_CloneVersion_CopiesVersionAndLocales(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	repo := pgadapter.NewTemplateRepo(pool)
+
+	_, tpl := createTestTemplateWithType(ctx, t, repo)
+
+	replyTo := "reply@example.com"
+	source := &domain.TemplateVersion{
+		ID:            uuid.New(),
+		TemplateID:    tpl.ID,
+		Status:        domain.VersionStatusDraft,
+		Subject:       "Original subject",
+		PreviewText:   "Original preview",
+		FromName:      "Original sender",
+		ReplyTo:       &replyTo,
+		BodyMJML:      "<mjml><mj-body><mj-text>Hello</mj-text></mj-body></mjml>",
+		DefaultLocale: "en",
+		EditorData:    map[string]any{"blocks": []any{"hero"}, "meta": map[string]any{"theme": "dark"}},
+	}
+	if err := repo.CreateVersion(ctx, source); err != nil {
+		t.Fatalf("CreateVersion(source) error: %v", err)
+	}
+
+	esSubject := "Hola"
+	esBody := "<mjml><mj-body><mj-text>Hola</mj-text></mj-body></mjml>"
+	if err := repo.SetLocale(ctx, &domain.TemplateVersionLocale{
+		ID:                uuid.New(),
+		TemplateVersionID: source.ID,
+		Locale:            "es",
+		Subject:           &esSubject,
+		BodyMJML:          &esBody,
+		EditorData:        map[string]any{"blocks": []any{"hero-es"}},
+	}); err != nil {
+		t.Fatalf("SetLocale(es) error: %v", err)
+	}
+
+	frSubject := "Bonjour"
+	if err := repo.SetLocale(ctx, &domain.TemplateVersionLocale{
+		ID:                uuid.New(),
+		TemplateVersionID: source.ID,
+		Locale:            "fr",
+		Subject:           &frSubject,
+		EditorData:        map[string]any{"blocks": []any{"hero-fr"}},
+	}); err != nil {
+		t.Fatalf("SetLocale(fr) error: %v", err)
+	}
+
+	cloned, err := repo.CloneVersion(ctx, tpl.ID, source.ID, nil)
+	if err != nil {
+		t.Fatalf("CloneVersion() error: %v", err)
+	}
+	if cloned.ID == source.ID {
+		t.Fatal("expected cloned version to have a new ID")
+	}
+	if cloned.VersionNumber != source.VersionNumber+1 {
+		t.Fatalf("expected cloned version number %d, got %d", source.VersionNumber+1, cloned.VersionNumber)
+	}
+	if cloned.Status != domain.VersionStatusDraft {
+		t.Fatalf("expected cloned status draft, got %s", cloned.Status)
+	}
+	if cloned.Subject != source.Subject || cloned.PreviewText != source.PreviewText || cloned.FromName != source.FromName {
+		t.Fatalf("expected cloned content to match source")
+	}
+	if cloned.ReplyTo == nil || *cloned.ReplyTo != replyTo {
+		t.Fatalf("expected cloned reply_to %q, got %v", replyTo, cloned.ReplyTo)
+	}
+	if cloned.BodyMJML != source.BodyMJML || cloned.DefaultLocale != source.DefaultLocale {
+		t.Fatalf("expected cloned body/default locale to match source")
+	}
+
+	locales, err := repo.ListLocales(ctx, cloned.ID)
+	if err != nil {
+		t.Fatalf("ListLocales(cloned) error: %v", err)
+	}
+	if len(locales) != 2 {
+		t.Fatalf("expected 2 cloned locales, got %d", len(locales))
+	}
+
+	gotLocales := map[string]*domain.TemplateVersionLocale{}
+	for _, locale := range locales {
+		gotLocales[locale.Locale] = locale
+		if locale.TemplateVersionID != cloned.ID {
+			t.Fatalf("expected cloned locale to point to cloned version %s, got %s", cloned.ID, locale.TemplateVersionID)
+		}
+	}
+	if gotLocales["es"] == nil || gotLocales["es"].Subject == nil || *gotLocales["es"].Subject != esSubject {
+		t.Fatalf("expected es locale to be cloned exactly")
+	}
+	if gotLocales["fr"] == nil || gotLocales["fr"].Subject == nil || *gotLocales["fr"].Subject != frSubject {
+		t.Fatalf("expected fr locale to be cloned exactly")
+	}
+}
+
 // --- Locale tests ---
 
 func TestTemplateRepo_SetLocale(t *testing.T) {

--- a/internal/http/handler/template.go
+++ b/internal/http/handler/template.go
@@ -616,6 +616,39 @@ func (h *TemplateHandler) PublishVersion(c *echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+// CloneVersion handles POST .../templates/:template_id/versions/:version_id/clone.
+func (h *TemplateHandler) CloneVersion(c *echo.Context) error {
+	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+	return h.cloneVersion(c, &ws.ID)
+}
+
+// CloneVersionGlobal handles POST /global/templates/:template_id/versions/:version_id/clone.
+func (h *TemplateHandler) CloneVersionGlobal(c *echo.Context) error {
+	return h.cloneVersion(c, nil)
+}
+
+func (h *TemplateHandler) cloneVersion(c *echo.Context, wsID *uuid.UUID) error {
+	templateID, err := uuid.Parse(c.Param("template_id"))
+	if err != nil {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
+	}
+
+	versionID, err := uuid.Parse(c.Param("version_id"))
+	if err != nil {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid version ID")
+	}
+
+	cloned, err := h.svc.CloneVersion(c.Request().Context(), templateID, versionID, wsID, nil)
+	if err != nil {
+		return mapTemplateError(c, err)
+	}
+
+	return c.JSON(http.StatusCreated, response.NewTemplateVersionResponse(cloned))
+}
+
 // SetLocale handles POST .../templates/:template_id/versions/:version_id/locales.
 func (h *TemplateHandler) SetLocale(c *echo.Context) error { //nolint:dupl // structurally similar to UpdateLocale
 	versionID, err := uuid.Parse(c.Param("version_id"))

--- a/internal/http/handler/template_test.go
+++ b/internal/http/handler/template_test.go
@@ -109,6 +109,7 @@ func setupTemplateTestWithOptions(
 	e.POST("/api/v1/manage/global/templates", h.CreateTemplateGlobal)
 	e.GET(base+"/templates/:template_id/versions", h.ListVersions)
 	e.POST(base+"/templates/:template_id/versions", h.CreateVersion)
+	e.POST(base+"/templates/:template_id/versions/:version_id/clone", h.CloneVersion)
 	e.POST(base+"/templates/:template_id/versions/:version_id/publish", h.PublishVersion)
 	e.POST(base+"/templates/:template_id/versions/:version_id/locales/:locale", h.SetLocale)
 	e.GET(base+"/templates/:template_id/versions/:version_id/locales/:locale", h.GetLocale)
@@ -426,6 +427,91 @@ func TestTemplateHandler_PublishVersion_NotFound(t *testing.T) {
 	templateID := uuid.Must(uuid.NewV7())
 	versionID := uuid.Must(uuid.NewV7())
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions/"+versionID.String()+"/publish", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTemplateHandler_CloneVersion_Success(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+
+	templateID := uuid.Must(uuid.NewV7())
+	sourceVersionID := uuid.Must(uuid.NewV7())
+	clonedVersionID := uuid.Must(uuid.NewV7())
+
+	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return &domain.Template{ID: templateID, WorkspaceID: &ws.ID}, nil
+		},
+		getVersionByIDFn: func(_ context.Context, id uuid.UUID) (*domain.TemplateVersion, error) {
+			if id != sourceVersionID {
+				t.Fatalf("expected source version ID %s, got %s", sourceVersionID, id)
+			}
+			return &domain.TemplateVersion{ID: sourceVersionID, TemplateID: templateID, Status: domain.VersionStatusArchived}, nil
+		},
+		cloneVersionFn: func(_ context.Context, gotTemplateID, gotSourceVersionID uuid.UUID, _ *uuid.UUID) (*domain.TemplateVersion, error) {
+			if gotTemplateID != templateID {
+				t.Fatalf("expected clone template ID %s, got %s", templateID, gotTemplateID)
+			}
+			if gotSourceVersionID != sourceVersionID {
+				t.Fatalf("expected clone source version ID %s, got %s", sourceVersionID, gotSourceVersionID)
+			}
+			return &domain.TemplateVersion{
+				ID:            clonedVersionID,
+				TemplateID:    templateID,
+				VersionNumber: 4,
+				Status:        domain.VersionStatusDraft,
+				Subject:       "Cloned version",
+				CreatedAt:     time.Now().UTC(),
+				UpdatedAt:     time.Now().UTC(),
+			}, nil
+		},
+	}
+
+	e, _ := setupTemplateTest(store, &mockTemplateCompiler{}, ts, wsStore)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions/"+sourceVersionID.String()+"/clone", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp response.TemplateVersionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.ID != clonedVersionID.String() {
+		t.Fatalf("expected cloned version ID %s, got %s", clonedVersionID, resp.ID)
+	}
+	if resp.Status != string(domain.VersionStatusDraft) {
+		t.Fatalf("expected draft response, got %s", resp.Status)
+	}
+}
+
+func TestTemplateHandler_CloneVersion_WorkspaceMismatch(t *testing.T) {
+	_, _, ts, wsStore := testTenantAndWorkspace()
+
+	templateID := uuid.Must(uuid.NewV7())
+	sourceVersionID := uuid.Must(uuid.NewV7())
+	otherWorkspaceID := uuid.Must(uuid.NewV7())
+
+	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, _ uuid.UUID) (*domain.Template, error) {
+			return &domain.Template{ID: templateID, WorkspaceID: &otherWorkspaceID}, nil
+		},
+	}
+
+	e, _ := setupTemplateTest(store, &mockTemplateCompiler{}, ts, wsStore)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions/"+sourceVersionID.String()+"/clone", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 

--- a/internal/http/handler/template_type_test.go
+++ b/internal/http/handler/template_type_test.go
@@ -29,12 +29,15 @@ type mockTemplateStore struct {
 	getByTypeAndScopeFn     func(ctx context.Context, typeID uuid.UUID, wsID *uuid.UUID) (*domain.Template, error)
 	resolveTemplateFn       func(ctx context.Context, typeID uuid.UUID, chain []uuid.NullUUID) (*domain.Template, error)
 	createVersionFn         func(ctx context.Context, ver *domain.TemplateVersion) error
+	cloneVersionFn          func(ctx context.Context, templateID, sourceVersionID uuid.UUID, createdBy *uuid.UUID) (*domain.TemplateVersion, error)
+	getVersionByIDFn        func(ctx context.Context, versionID uuid.UUID) (*domain.TemplateVersion, error)
 	getPublishedVersionFn   func(ctx context.Context, templateID uuid.UUID) (*domain.TemplateVersion, error)
 	publishFn               func(ctx context.Context, versionID uuid.UUID) error
 	setDisabledFn           func(ctx context.Context, templateID uuid.UUID, wsID *uuid.UUID, disabled bool) error
 	listVersionsFn          func(ctx context.Context, templateID uuid.UUID) ([]*domain.TemplateVersion, error)
 	setLocaleFn             func(ctx context.Context, locale *domain.TemplateVersionLocale) error
 	getLocaleFn             func(ctx context.Context, versionID uuid.UUID, locale string) (*domain.TemplateVersionLocale, error)
+	listLocalesFn           func(ctx context.Context, versionID uuid.UUID) ([]*domain.TemplateVersionLocale, error)
 	deleteLocaleFn          func(ctx context.Context, versionID uuid.UUID, locale string) error
 	listTypesFn             func(ctx context.Context, wsID *uuid.UUID, opts port.ListOptions) ([]*domain.TemplateType, string, error)
 	updateTypeFn            func(ctx context.Context, tt *domain.TemplateType) error
@@ -93,7 +96,16 @@ func (m *mockTemplateStore) CreateVersion(ctx context.Context, ver *domain.Templ
 	}
 	return nil
 }
-func (m *mockTemplateStore) GetVersionByID(_ context.Context, _ uuid.UUID) (*domain.TemplateVersion, error) {
+func (m *mockTemplateStore) CloneVersion(ctx context.Context, templateID, sourceVersionID uuid.UUID, createdBy *uuid.UUID) (*domain.TemplateVersion, error) {
+	if m.cloneVersionFn != nil {
+		return m.cloneVersionFn(ctx, templateID, sourceVersionID, createdBy)
+	}
+	return nil, nil
+}
+func (m *mockTemplateStore) GetVersionByID(ctx context.Context, versionID uuid.UUID) (*domain.TemplateVersion, error) {
+	if m.getVersionByIDFn != nil {
+		return m.getVersionByIDFn(ctx, versionID)
+	}
 	return nil, nil
 }
 func (m *mockTemplateStore) GetPublishedVersion(ctx context.Context, templateID uuid.UUID) (*domain.TemplateVersion, error) {
@@ -134,7 +146,10 @@ func (m *mockTemplateStore) GetLocale(ctx context.Context, versionID uuid.UUID, 
 	}
 	return nil, nil
 }
-func (m *mockTemplateStore) ListLocales(_ context.Context, _ uuid.UUID) ([]*domain.TemplateVersionLocale, error) {
+func (m *mockTemplateStore) ListLocales(ctx context.Context, versionID uuid.UUID) ([]*domain.TemplateVersionLocale, error) {
+	if m.listLocalesFn != nil {
+		return m.listLocalesFn(ctx, versionID)
+	}
 	return nil, nil
 }
 func (m *mockTemplateStore) DeleteLocale(ctx context.Context, versionID uuid.UUID, locale string) error {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -460,7 +460,7 @@ func (s *Server) registerRoutes() { //nolint:gocognit,gocyclo,funlen // route re
 					ws.GET("/adapters/:id/provisioning-status", s.adapterSetupHandler.ProvisioningStatus, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
 				}
 			}
-				if s.identityHandler != nil { //nolint:dupl // repeated route group pattern
+			if s.identityHandler != nil { //nolint:dupl // repeated route group pattern
 				ws.GET("/adapters/:id/identities", s.identityHandler.List, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
 				ws.POST("/adapters/:id/identities", s.identityHandler.Create, middleware.RequireRole(domain.RoleWorkspaceAdmin, s.tenantStore, s.wsStore))
 				ws.POST("/adapters/:id/identities/sync", s.identityHandler.Sync, middleware.RequireRole(domain.RoleWorkspaceAdmin, s.tenantStore, s.wsStore))
@@ -486,6 +486,7 @@ func (s *Server) registerRoutes() { //nolint:gocognit,gocyclo,funlen // route re
 				ws.GET("/templates/:template_id/versions/:version_id", s.templateHandler.GetVersion, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
 				ws.POST("/templates/:template_id/versions", s.templateHandler.CreateVersion, middleware.RequireRole(domain.RoleWorkspaceEditor, s.tenantStore, s.wsStore))
 				ws.PUT("/templates/:template_id/versions/:version_id", s.templateHandler.UpdateVersion, middleware.RequireRole(domain.RoleWorkspaceEditor, s.tenantStore, s.wsStore))
+				ws.POST("/templates/:template_id/versions/:version_id/clone", s.templateHandler.CloneVersion, middleware.RequireRole(domain.RoleWorkspaceEditor, s.tenantStore, s.wsStore))
 				ws.POST("/templates/:template_id/versions/:version_id/publish", s.templateHandler.PublishVersion, middleware.RequireRole(domain.RoleWorkspaceAdmin, s.tenantStore, s.wsStore))
 				ws.GET("/templates/:template_id/versions/:version_id/locales", s.templateHandler.ListLocales, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
 				ws.POST("/templates/:template_id/versions/:version_id/locales/:locale", s.templateHandler.SetLocale, middleware.RequireRole(domain.RoleWorkspaceEditor, s.tenantStore, s.wsStore))
@@ -577,7 +578,7 @@ func (s *Server) registerRoutes() { //nolint:gocognit,gocyclo,funlen // route re
 					global.GET("/adapters/:id/provisioning-status", s.adapterSetupHandler.ProvisioningStatusGlobal)
 				}
 			}
-				if s.identityHandler != nil { //nolint:dupl // repeated route group pattern
+			if s.identityHandler != nil { //nolint:dupl // repeated route group pattern
 				global.GET("/adapters/:id/identities", s.identityHandler.ListGlobal)
 				global.POST("/adapters/:id/identities", s.identityHandler.CreateGlobal)
 				global.POST("/adapters/:id/identities/sync", s.identityHandler.SyncGlobal)
@@ -602,6 +603,7 @@ func (s *Server) registerRoutes() { //nolint:gocognit,gocyclo,funlen // route re
 				global.GET("/templates/:template_id/versions/:version_id", s.templateHandler.GetVersion)
 				global.POST("/templates/:template_id/versions", s.templateHandler.CreateVersion)
 				global.PUT("/templates/:template_id/versions/:version_id", s.templateHandler.UpdateVersion)
+				global.POST("/templates/:template_id/versions/:version_id/clone", s.templateHandler.CloneVersionGlobal)
 				global.POST("/templates/:template_id/versions/:version_id/publish", s.templateHandler.PublishVersion)
 				// Locale CRUD.
 				global.GET("/templates/:template_id/versions/:version_id/locales", s.templateHandler.ListLocales)

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -238,6 +238,7 @@ func routeHasBody(route Route) bool {
 	switch {
 	case strings.HasSuffix(normalized, "/disable"),
 		strings.HasSuffix(normalized, "/enable"),
+		strings.HasSuffix(normalized, "/clone"),
 		strings.HasSuffix(normalized, "/publish"),
 		strings.HasSuffix(normalized, "/test"),
 		strings.HasSuffix(normalized, "/test-send"),
@@ -615,6 +616,7 @@ func routeSuccessStatus(route Route) int {
 			strings.HasSuffix(normalized, "/template-types"),
 			strings.HasSuffix(normalized, "/templates"),
 			strings.HasSuffix(normalized, "/versions"),
+			strings.HasSuffix(normalized, "/clone"),
 			strings.Contains(normalized, "/locales/{locale}"),
 			strings.HasSuffix(normalized, "/api-keys"),
 			strings.HasSuffix(normalized, "/webhooks"),

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -556,6 +556,8 @@ func routeSuccessType(route Route) string {
 		return "response.TemplateVersionListResponse"
 	case strings.HasSuffix(normalized, "/versions") && route.Method == "POST":
 		return "response.TemplateVersionResponse"
+	case strings.HasSuffix(normalized, "/versions/{version_id}/clone") && route.Method == "POST":
+		return "response.TemplateVersionResponse"
 	case strings.Contains(normalized, "/versions/{version_id}") && route.Method == "GET" && !strings.Contains(normalized, "/locales/"):
 		return "response.TemplateVersionResponse"
 	case strings.Contains(normalized, "/versions/{version_id}") && route.Method == "PUT" && !strings.Contains(normalized, "/locales/"):

--- a/internal/port/store.go
+++ b/internal/port/store.go
@@ -68,6 +68,7 @@ type TemplateTypeStore interface {
 // TemplateVersionStore manages template version persistence.
 type TemplateVersionStore interface {
 	CreateVersion(ctx context.Context, ver *domain.TemplateVersion) error
+	CloneVersion(ctx context.Context, templateID, sourceVersionID uuid.UUID, createdBy *uuid.UUID) (*domain.TemplateVersion, error)
 	GetVersionByID(ctx context.Context, versionID uuid.UUID) (*domain.TemplateVersion, error)
 	GetPublishedVersion(ctx context.Context, templateID uuid.UUID) (*domain.TemplateVersion, error)
 	UpdateVersion(ctx context.Context, ver *domain.TemplateVersion) error

--- a/internal/resolution/template_resolver_test.go
+++ b/internal/resolution/template_resolver_test.go
@@ -40,6 +40,9 @@ func (m *mockTemplateStore) SetDisabled(_ context.Context, _ uuid.UUID, _ *uuid.
 func (m *mockTemplateStore) CreateVersion(_ context.Context, _ *domain.TemplateVersion) error {
 	return nil
 }
+func (m *mockTemplateStore) CloneVersion(_ context.Context, _, _ uuid.UUID, _ *uuid.UUID) (*domain.TemplateVersion, error) {
+	return nil, nil
+}
 func (m *mockTemplateStore) GetVersionByID(_ context.Context, _ uuid.UUID) (*domain.TemplateVersion, error) {
 	return nil, nil
 }
@@ -57,7 +60,7 @@ func (m *mockTemplateStore) GetLatestVersion(_ context.Context, _ uuid.UUID) (*d
 	return nil, domain.ErrNotFound
 }
 func (m *mockTemplateStore) SoftDeleteTemplate(_ context.Context, _ uuid.UUID) error { return nil }
-func (m *mockTemplateStore) DeleteDraftVersion(_ context.Context, _ uuid.UUID) error  { return nil }
+func (m *mockTemplateStore) DeleteDraftVersion(_ context.Context, _ uuid.UUID) error { return nil }
 func (m *mockTemplateStore) SetLocale(_ context.Context, _ *domain.TemplateVersionLocale) error {
 	return nil
 }
@@ -77,7 +80,7 @@ func (m *mockTemplateStore) ListTypes(_ context.Context, _ *uuid.UUID, _ port.Li
 	return nil, "", nil
 }
 func (m *mockTemplateStore) UpdateType(_ context.Context, _ *domain.TemplateType) error { return nil }
-func (m *mockTemplateStore) SoftDeleteType(_ context.Context, _ uuid.UUID) error              { return nil }
+func (m *mockTemplateStore) SoftDeleteType(_ context.Context, _ uuid.UUID) error        { return nil }
 func (m *mockTemplateStore) GetTemplateByID(_ context.Context, _ uuid.UUID) (*domain.Template, error) {
 	return nil, domain.ErrNotFound
 }

--- a/internal/service/send_test.go
+++ b/internal/service/send_test.go
@@ -197,6 +197,7 @@ type mockTemplateStoreSend struct {
 	getByTypeAndScopeFn     func(ctx context.Context, typeID uuid.UUID, wsID *uuid.UUID) (*domain.Template, error)
 	resolveTemplateFn       func(ctx context.Context, typeID uuid.UUID, chain []uuid.NullUUID) (*domain.Template, error)
 	createVersionFn         func(ctx context.Context, ver *domain.TemplateVersion) error
+	cloneVersionFn          func(ctx context.Context, templateID, sourceVersionID uuid.UUID, createdBy *uuid.UUID) (*domain.TemplateVersion, error)
 	getPublishedVersionFn   func(ctx context.Context, templateID uuid.UUID) (*domain.TemplateVersion, error)
 	publishFn               func(ctx context.Context, versionID uuid.UUID) error
 	setDisabledFn           func(ctx context.Context, templateID uuid.UUID, wsID *uuid.UUID, disabled bool) error
@@ -255,6 +256,12 @@ func (m *mockTemplateStoreSend) CreateVersion(ctx context.Context, ver *domain.T
 		return m.createVersionFn(ctx, ver)
 	}
 	return nil
+}
+func (m *mockTemplateStoreSend) CloneVersion(ctx context.Context, templateID, sourceVersionID uuid.UUID, createdBy *uuid.UUID) (*domain.TemplateVersion, error) {
+	if m.cloneVersionFn != nil {
+		return m.cloneVersionFn(ctx, templateID, sourceVersionID, createdBy)
+	}
+	return nil, nil
 }
 func (m *mockTemplateStoreSend) GetVersionByID(_ context.Context, _ uuid.UUID) (*domain.TemplateVersion, error) {
 	return nil, nil

--- a/internal/service/template.go
+++ b/internal/service/template.go
@@ -100,6 +100,39 @@ func (s *TemplateService) PublishVersion(ctx context.Context, versionID uuid.UUI
 	return s.store.Publish(ctx, versionID)
 }
 
+// CloneVersion creates a new draft by exactly copying a source version and all its locales.
+// Access validation is performed against the provided scope before delegating the atomic clone to the store.
+func (s *TemplateService) CloneVersion(
+	ctx context.Context,
+	templateID uuid.UUID,
+	sourceVersionID uuid.UUID,
+	wsID *uuid.UUID,
+	createdBy *uuid.UUID,
+) (*domain.TemplateVersion, error) {
+	tpl, err := s.store.GetTemplateByID(ctx, templateID)
+	if err != nil {
+		return nil, err
+	}
+
+	if wsID == nil {
+		if tpl.WorkspaceID != nil {
+			return nil, domain.ErrNotFound
+		}
+	} else if tpl.WorkspaceID == nil || *tpl.WorkspaceID != *wsID {
+		return nil, domain.ErrNotFound
+	}
+
+	sourceVersion, err := s.store.GetVersionByID(ctx, sourceVersionID)
+	if err != nil {
+		return nil, err
+	}
+	if sourceVersion.TemplateID != templateID {
+		return nil, domain.ErrNotFound
+	}
+
+	return s.store.CloneVersion(ctx, templateID, sourceVersionID, createdBy)
+}
+
 // ListVersions returns all versions for a template.
 func (s *TemplateService) ListVersions(ctx context.Context, templateID uuid.UUID) ([]*domain.TemplateVersion, error) {
 	return s.store.ListVersions(ctx, templateID)

--- a/internal/service/template_test.go
+++ b/internal/service/template_test.go
@@ -25,12 +25,15 @@ type mockTemplateStore struct {
 	getTemplateByIDFn       func(ctx context.Context, id uuid.UUID) (*domain.Template, error)
 	getTypeByIDFn           func(ctx context.Context, id uuid.UUID) (*domain.TemplateType, error)
 	createVersionFn         func(ctx context.Context, ver *domain.TemplateVersion) error
+	cloneVersionFn          func(ctx context.Context, templateID, sourceVersionID uuid.UUID, createdBy *uuid.UUID) (*domain.TemplateVersion, error)
+	getVersionByIDFn        func(ctx context.Context, versionID uuid.UUID) (*domain.TemplateVersion, error)
 	getPublishedVersionFn   func(ctx context.Context, templateID uuid.UUID) (*domain.TemplateVersion, error)
 	publishFn               func(ctx context.Context, versionID uuid.UUID) error
 	setDisabledFn           func(ctx context.Context, templateID uuid.UUID, wsID *uuid.UUID, disabled bool) error
 	listVersionsFn          func(ctx context.Context, templateID uuid.UUID) ([]*domain.TemplateVersion, error)
 	setLocaleFn             func(ctx context.Context, locale *domain.TemplateVersionLocale) error
 	getLocaleFn             func(ctx context.Context, versionID uuid.UUID, locale string) (*domain.TemplateVersionLocale, error)
+	listLocalesFn           func(ctx context.Context, versionID uuid.UUID) ([]*domain.TemplateVersionLocale, error)
 }
 
 func (m *mockTemplateStore) CreateType(ctx context.Context, tt *domain.TemplateType) error {
@@ -81,7 +84,16 @@ func (m *mockTemplateStore) CreateVersion(ctx context.Context, ver *domain.Templ
 	}
 	return nil
 }
-func (m *mockTemplateStore) GetVersionByID(_ context.Context, _ uuid.UUID) (*domain.TemplateVersion, error) {
+func (m *mockTemplateStore) CloneVersion(ctx context.Context, templateID, sourceVersionID uuid.UUID, createdBy *uuid.UUID) (*domain.TemplateVersion, error) {
+	if m.cloneVersionFn != nil {
+		return m.cloneVersionFn(ctx, templateID, sourceVersionID, createdBy)
+	}
+	return nil, nil
+}
+func (m *mockTemplateStore) GetVersionByID(ctx context.Context, versionID uuid.UUID) (*domain.TemplateVersion, error) {
+	if m.getVersionByIDFn != nil {
+		return m.getVersionByIDFn(ctx, versionID)
+	}
 	return nil, nil
 }
 func (m *mockTemplateStore) GetPublishedVersion(ctx context.Context, templateID uuid.UUID) (*domain.TemplateVersion, error) {
@@ -122,7 +134,10 @@ func (m *mockTemplateStore) GetLocale(ctx context.Context, versionID uuid.UUID, 
 	}
 	return nil, nil
 }
-func (m *mockTemplateStore) ListLocales(_ context.Context, _ uuid.UUID) ([]*domain.TemplateVersionLocale, error) {
+func (m *mockTemplateStore) ListLocales(ctx context.Context, versionID uuid.UUID) ([]*domain.TemplateVersionLocale, error) {
+	if m.listLocalesFn != nil {
+		return m.listLocalesFn(ctx, versionID)
+	}
 	return nil, nil
 }
 func (m *mockTemplateStore) DeleteLocale(_ context.Context, _ uuid.UUID, _ string) error {
@@ -381,6 +396,99 @@ func TestTemplateService_PublishVersion_Error(t *testing.T) {
 	err := svc.PublishVersion(context.Background(), uuid.Must(uuid.NewV7()))
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestTemplateService_CloneVersion_Success(t *testing.T) {
+	workspaceID := uuid.Must(uuid.NewV7())
+	templateID := uuid.Must(uuid.NewV7())
+	sourceVersionID := uuid.Must(uuid.NewV7())
+	clonedVersionID := uuid.Must(uuid.NewV7())
+
+	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return &domain.Template{ID: templateID, WorkspaceID: &workspaceID}, nil
+		},
+		getVersionByIDFn: func(_ context.Context, id uuid.UUID) (*domain.TemplateVersion, error) {
+			if id != sourceVersionID {
+				t.Fatalf("expected source version ID %s, got %s", sourceVersionID, id)
+			}
+			return &domain.TemplateVersion{ID: sourceVersionID, TemplateID: templateID, Status: domain.VersionStatusPublished}, nil
+		},
+		cloneVersionFn: func(_ context.Context, gotTemplateID, gotSourceVersionID uuid.UUID, _ *uuid.UUID) (*domain.TemplateVersion, error) {
+			if gotTemplateID != templateID {
+				t.Fatalf("expected clone template ID %s, got %s", templateID, gotTemplateID)
+			}
+			if gotSourceVersionID != sourceVersionID {
+				t.Fatalf("expected clone source version ID %s, got %s", sourceVersionID, gotSourceVersionID)
+			}
+			return &domain.TemplateVersion{
+				ID:            clonedVersionID,
+				TemplateID:    templateID,
+				VersionNumber: 3,
+				Status:        domain.VersionStatusDraft,
+				Subject:       "Cloned",
+			}, nil
+		},
+	}
+
+	svc := service.NewTemplateService(store, &mockTemplateCompiler{})
+
+	cloned, err := svc.CloneVersion(context.Background(), templateID, sourceVersionID, &workspaceID, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cloned.ID != clonedVersionID {
+		t.Fatalf("expected cloned version ID %s, got %s", clonedVersionID, cloned.ID)
+	}
+	if cloned.Status != domain.VersionStatusDraft {
+		t.Fatalf("expected draft clone, got %s", cloned.Status)
+	}
+}
+
+func TestTemplateService_CloneVersion_WorkspaceMismatch(t *testing.T) {
+	workspaceID := uuid.Must(uuid.NewV7())
+	otherWorkspaceID := uuid.Must(uuid.NewV7())
+	templateID := uuid.Must(uuid.NewV7())
+	sourceVersionID := uuid.Must(uuid.NewV7())
+
+	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, _ uuid.UUID) (*domain.Template, error) {
+			return &domain.Template{ID: templateID, WorkspaceID: &otherWorkspaceID}, nil
+		},
+	}
+
+	svc := service.NewTemplateService(store, &mockTemplateCompiler{})
+
+	_, err := svc.CloneVersion(context.Background(), templateID, sourceVersionID, &workspaceID, nil)
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for workspace mismatch, got %v", err)
+	}
+}
+
+func TestTemplateService_CloneVersion_SourceVersionMismatch(t *testing.T) {
+	workspaceID := uuid.Must(uuid.NewV7())
+	templateID := uuid.Must(uuid.NewV7())
+	otherTemplateID := uuid.Must(uuid.NewV7())
+	sourceVersionID := uuid.Must(uuid.NewV7())
+
+	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, _ uuid.UUID) (*domain.Template, error) {
+			return &domain.Template{ID: templateID, WorkspaceID: &workspaceID}, nil
+		},
+		getVersionByIDFn: func(_ context.Context, _ uuid.UUID) (*domain.TemplateVersion, error) {
+			return &domain.TemplateVersion{ID: sourceVersionID, TemplateID: otherTemplateID}, nil
+		},
+	}
+
+	svc := service.NewTemplateService(store, &mockTemplateCompiler{})
+
+	_, err := svc.CloneVersion(context.Background(), templateID, sourceVersionID, &workspaceID, nil)
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for source/template mismatch, got %v", err)
 	}
 }
 

--- a/web/src/components/templates/templates-list-content.tsx
+++ b/web/src/components/templates/templates-list-content.tsx
@@ -3,12 +3,13 @@
 import { useMemo } from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { useRouter, useParams } from "next/navigation";
-import { Plus, FileText, Pencil, Send, Trash2 } from "lucide-react";
+import { Plus, FileText, Pencil, Send, Trash2, Copy } from "lucide-react";
 import { useScope, useScopedPath } from "@/hooks/use-scope";
 import { useTemplateType } from "@/hooks/use-template-types";
 import {
   useTemplateVersions,
   useCreateTemplateVersion,
+  useCloneVersion,
   usePublishVersion,
   useDeleteVersion,
 } from "@/hooks/use-template-version";
@@ -65,6 +66,7 @@ export function TemplatesListContent() {
   const api = useApi();
   const createTemplate = useCreateTemplate(scopedPath);
   const createVersion = useCreateTemplateVersion(scopedPath, templateId);
+  const cloneVersion = useCloneVersion(scopedPath, templateId);
   const deleteVersion = useDeleteVersion(scopedPath, templateId);
 
   const [deleteVersionTarget, setDeleteVersionTarget] = useState<TemplateVersion | null>(null);
@@ -213,6 +215,28 @@ export function TemplatesListContent() {
               <TooltipContent>Publish</TooltipContent>
             </Tooltip>
           )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                disabled={cloneVersion.isPending}
+                onClick={() =>
+                  cloneVersion.mutate(row.original.id, {
+                    onSuccess: () =>
+                      toast.success(
+                        `Version ${row.original.version_number} cloned as draft`
+                      ),
+                    onError: () => toast.error("Failed to clone version"),
+                  })
+                }
+              >
+                <Copy className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Clone</TooltipContent>
+          </Tooltip>
           {row.original.status === "draft" && (
             <Tooltip>
               <TooltipTrigger asChild>

--- a/web/src/hooks/use-template-version.ts
+++ b/web/src/hooks/use-template-version.ts
@@ -2,6 +2,8 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useApi, useApiReady } from "@/hooks/use-api";
+import { cloneTemplateVersion } from "@/lib/clone-template-version";
+import { parseTemplateVersionMutationResponse } from "@/lib/template-version-response";
 import type {
   TemplateVersion,
   TemplateLocale,
@@ -68,6 +70,21 @@ export function useCreateTemplateVersion(
   });
 }
 
+export function useCloneVersion(scopedPath: string, templateId: string) {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (versionId: string) =>
+      cloneTemplateVersion(api, scopedPath, templateId, versionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QK_TEMPLATE_VERSIONS, scopedPath, templateId],
+      });
+    },
+  });
+}
+
 export function useSaveTemplateVersion(
   scopedPath: string,
   templateId: string,
@@ -108,7 +125,7 @@ export function usePublishVersion(
         .post(
           `${scopedPath}/templates/${templateId}/versions/${versionId}/publish`
         )
-        .json<TemplateVersion>(),
+        .then(parseTemplateVersionMutationResponse<TemplateVersion>),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QK_TEMPLATE_VERSIONS, scopedPath, templateId],

--- a/web/src/lib/clone-template-version.test.ts
+++ b/web/src/lib/clone-template-version.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { cloneTemplateVersion } = await import(
+  new URL("./clone-template-version.ts", import.meta.url).href,
+);
+
+test("cloneTemplateVersion posts to the explicit clone endpoint and returns the created draft", async () => {
+  let receivedPath = "";
+  const expected = {
+    id: "version-cloned",
+    template_id: "template-1",
+    version_number: 3,
+    status: "draft",
+    subject: "Cloned subject",
+    from_name: "Senda",
+    body_mjml: "<mjml></mjml>",
+    default_locale: "en",
+    created_at: "2026-04-09T00:00:00Z",
+  };
+
+  const api = {
+    post(path: string) {
+      receivedPath = path;
+      return {
+        json: async () => expected,
+      };
+    },
+  };
+
+  const result = await cloneTemplateVersion(
+    api as never,
+    "/api/v1/manage/tenants/acme/workspaces/default",
+    "template-1",
+    "version-2"
+  );
+
+  assert.equal(
+    receivedPath,
+    "/api/v1/manage/tenants/acme/workspaces/default/templates/template-1/versions/version-2/clone"
+  );
+  assert.deepEqual(result, expected);
+});

--- a/web/src/lib/clone-template-version.ts
+++ b/web/src/lib/clone-template-version.ts
@@ -1,0 +1,13 @@
+import type { KyInstance } from "ky";
+import type { TemplateVersion } from "@/types/templates";
+
+export function cloneTemplateVersion(
+  api: KyInstance,
+  scopedPath: string,
+  templateId: string,
+  versionId: string
+) {
+  return api
+    .post(`${scopedPath}/templates/${templateId}/versions/${versionId}/clone`)
+    .json<TemplateVersion>();
+}

--- a/web/src/lib/template-version-response.test.ts
+++ b/web/src/lib/template-version-response.test.ts
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { parseTemplateVersionMutationResponse } = await import(
+  new URL("./template-version-response.ts", import.meta.url).href,
+);
+
+test("publish mutation tolerates 204 no content responses", async () => {
+  const response = new Response(null, { status: 204 });
+
+  const result = await parseTemplateVersionMutationResponse(response);
+
+  assert.equal(result, undefined);
+});
+
+test("template version mutation still parses json payloads when present", async () => {
+  const payload = { id: "ver_123", status: "published" };
+  const response = new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+  const result = await parseTemplateVersionMutationResponse(response);
+
+  assert.deepEqual(result, payload);
+});

--- a/web/src/lib/template-version-response.ts
+++ b/web/src/lib/template-version-response.ts
@@ -1,0 +1,19 @@
+export async function parseTemplateVersionMutationResponse<T>(
+  response: Response,
+): Promise<T | undefined> {
+  if (response.status === 204) {
+    return undefined;
+  }
+
+  const contentLength = response.headers.get("content-length");
+  if (contentLength === "0") {
+    return undefined;
+  }
+
+  const rawBody = await response.text();
+  if (!rawBody.trim()) {
+    return undefined;
+  }
+
+  return JSON.parse(rawBody) as T;
+}


### PR DESCRIPTION
Closes #61

## Summary

- add an explicit clone-version backend endpoint that validates workspace/template/version ownership and clones the source version plus all locales atomically into a new draft
- expose a `Clone` action in the template versions list so the frontend requests the clone and refreshes the list without navigating away
- update OpenAPI/Swagger generation rules so the clone endpoint documents a bodyless `201 Created` response

## Context

- Related issue: #61
- Related story (if any): N/A
- Risk / tradeoffs: the backend now owns clone orchestration, which keeps the UI simple and safe but adds a new explicit API surface that must remain in sync with generated docs

## Validation

Mark everything you actually ran.

- [ ] `make ci-backend-pr` (if backend, infra, migrations, or tests changed)
- [ ] `make ci-frontend` (if `web/` changed)
- [x] `make ci-pr` (if both backend and frontend changed)
- [ ] `make ci-main` (required for pushes to `main` and systemic/cross-layer changes; fast gate, no Docker)

Optional deeper checks when you intentionally want Docker-backed coverage:

- [ ] `make test-integration`
- [ ] `make test-e2e`

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test-only
- [ ] Security-sensitive

## Contributor checklist

- [x] I kept the change focused and reviewable.
- [x] I added or updated tests where behavior changed.
- [x] I updated docs when behavior, setup, API, or workflows changed.
- [x] I did not add build-only validation as a substitute for the required local gates.
- [x] I did not add AI attribution or `Co-Authored-By` trailers.

## Compatibility / ops impact

- [x] No migration
- [ ] Migration included
- [x] No config changes
- [ ] Config changes included
- [x] No security impact
- [ ] Security impact described above
