### PR TITLE
feat(workspace): share _system defaults in workspaces

### DIFF
--- a/cmd/senda/docs/docs.go
+++ b/cmd/senda/docs/docs.go
@@ -11005,6 +11005,108 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml": {
             "post": {
                 "security": [
@@ -14966,7 +15068,13 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "inherited_from_system": {
+                    "type": "boolean"
+                },
                 "name": {
+                    "type": "string"
+                },
+                "owner_scope": {
                     "type": "string"
                 },
                 "updated_at": {
@@ -15368,8 +15476,20 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "inherited_from_system": {
+                    "type": "boolean"
+                },
                 "is_disabled": {
                     "type": "boolean"
+                },
+                "is_fork": {
+                    "type": "boolean"
+                },
+                "origin_template_id": {
+                    "type": "string"
+                },
+                "owner_scope": {
+                    "type": "string"
                 },
                 "template_type_id": {
                     "type": "string"
@@ -15414,7 +15534,13 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "inherited_from_system": {
+                    "type": "boolean"
+                },
                 "name": {
+                    "type": "string"
+                },
+                "owner_scope": {
                     "type": "string"
                 },
                 "sender_identity_id": {

--- a/cmd/senda/docs/openapi.yaml
+++ b/cmd/senda/docs/openapi.yaml
@@ -813,7 +813,11 @@ components:
                     type: array
                 id:
                     type: string
+                inherited_from_system:
+                    type: boolean
                 name:
+                    type: string
+                owner_scope:
                     type: string
                 updated_at:
                     type: string
@@ -1074,8 +1078,16 @@ components:
                     type: string
                 id:
                     type: string
+                inherited_from_system:
+                    type: boolean
                 is_disabled:
                     type: boolean
+                is_fork:
+                    type: boolean
+                origin_template_id:
+                    type: string
+                owner_scope:
+                    type: string
                 template_type_id:
                     type: string
                 updated_at:
@@ -1104,7 +1116,11 @@ components:
                     type: string
                 id:
                     type: string
+                inherited_from_system:
+                    type: boolean
                 name:
+                    type: string
+                owner_scope:
                     type: string
                 sender_identity_id:
                     type: string
@@ -10527,6 +10543,90 @@ paths:
             security:
                 - ManagementBearer: []
             summary: POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/enable
+            tags:
+                - templates
+    /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/cmd_senda.DocGenericBody'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork
             tags:
                 - templates
     /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml:

--- a/cmd/senda/docs/swagger.yaml
+++ b/cmd/senda/docs/swagger.yaml
@@ -813,7 +813,11 @@ definitions:
         type: array
       id:
         type: string
+      inherited_from_system:
+        type: boolean
       name:
+        type: string
+      owner_scope:
         type: string
       updated_at:
         type: string
@@ -1074,8 +1078,16 @@ definitions:
         type: string
       id:
         type: string
+      inherited_from_system:
+        type: boolean
       is_disabled:
         type: boolean
+      is_fork:
+        type: boolean
+      origin_template_id:
+        type: string
+      owner_scope:
+        type: string
       template_type_id:
         type: string
       updated_at:
@@ -1104,7 +1116,11 @@ definitions:
         type: string
       id:
         type: string
+      inherited_from_system:
+        type: boolean
       name:
+        type: string
+      owner_scope:
         type: string
       sender_identity_id:
         type: string
@@ -8479,6 +8495,73 @@ paths:
       security:
       - ManagementBearer: []
       summary: POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/enable
+      tags:
+      - templates
+  /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork:
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/cmd_senda.DocGenericBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork
       tags:
       - templates
   /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml:

--- a/cmd/senda/openapi_generated.go
+++ b/cmd/senda/openapi_generated.go
@@ -2544,6 +2544,28 @@ func doc_post_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_templa
 // @Router       /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/enable [post]
 func doc_post_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_templates_template_id_enable() {}
 
+// doc_post_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_templates_template_id_fork auto-generated route documentation.
+// @Summary      POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        body  body  DocGenericBody  true  "Request body"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork [post]
+func doc_post_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_templates_template_id_fork() {}
+
 // doc_post_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_templates_template_id_preview_mjml auto-generated route documentation.
 // @Summary      POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml
 // @Description  Auto-generated route stub for OpenAPI + MCP discovery.

--- a/internal/adapter/postgres/injector_repo.go
+++ b/internal/adapter/postgres/injector_repo.go
@@ -195,7 +195,7 @@ func (r *InjectorRepo) ListDefinitionsInChain(ctx context.Context, chain []uuid.
 		return nil, fmt.Errorf("listing injector definitions in chain: %w", err)
 	}
 
-	defs, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[domain.InjectorDefinition])
+	defs, err := pgx.CollectRows(rows, scanInjectorDefinitionRow)
 	if err != nil {
 		return nil, fmt.Errorf("collecting injector definitions: %w", err)
 	}
@@ -419,6 +419,15 @@ func scanInjectorDefinition(row pgx.Row) (*domain.InjectorDefinition, error) {
 			return nil, apperr.NotFound("injector definition not found")
 		}
 		return nil, fmt.Errorf("scanning injector definition: %w", err)
+	}
+	return &d, nil
+}
+
+func scanInjectorDefinitionRow(row pgx.CollectableRow) (*domain.InjectorDefinition, error) {
+	var d domain.InjectorDefinition
+	err := row.Scan(&d.ID, &d.Name, &d.WorkspaceID, &d.Description, &d.CreatedAt, &d.UpdatedAt, &d.DeletedAt)
+	if err != nil {
+		return nil, fmt.Errorf("scanning injector definition row: %w", err)
 	}
 	return &d, nil
 }

--- a/internal/adapter/postgres/template_repo.go
+++ b/internal/adapter/postgres/template_repo.go
@@ -95,18 +95,6 @@ func (r *TemplateRepo) SoftDeleteType(ctx context.Context, id uuid.UUID) error {
 func (r *TemplateRepo) GetTypeBySlug(ctx context.Context, slug string, chain []uuid.NullUUID) (*domain.TemplateType, error) {
 	scopes, includeGlobal := splitChain(chain)
 
-	// Build an array parameter for chain priority ordering.
-	// The chain is ordered from most specific to least specific.
-	// We use array_position to pick the most specific match.
-	chainArr := make([]any, len(chain))
-	for i, entry := range chain {
-		if entry.Valid {
-			chainArr[i] = entry.UUID
-		} else {
-			chainArr[i] = nil
-		}
-	}
-
 	row := r.pool.QueryRow(ctx,
 		`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema,
 		        created_at, updated_at, deleted_at
@@ -115,7 +103,11 @@ func (r *TemplateRepo) GetTypeBySlug(ctx context.Context, slug string, chain []u
 		   AND (workspace_id = ANY(@scopes) OR (@include_global::bool AND workspace_id IS NULL))
 		   AND deleted_at IS NULL
 		 ORDER BY
-		   CASE WHEN workspace_id IS NULL THEN 1 ELSE 0 END,
+		   CASE
+		     WHEN workspace_id IS NULL THEN cardinality(@scopes::uuid[]) + 1
+		     ELSE array_position(@scopes::uuid[], workspace_id)
+		   END ASC,
+		   created_at DESC,
 		   id DESC
 		 LIMIT 1`,
 		pgx.NamedArgs{
@@ -229,14 +221,16 @@ func (r *TemplateRepo) ListTypes(ctx context.Context, wsID *uuid.UUID, opts port
 
 func (r *TemplateRepo) CreateTemplate(ctx context.Context, tpl *domain.Template) error {
 	row := r.pool.QueryRow(ctx,
-		`INSERT INTO templates (id, template_type_id, workspace_id, is_disabled)
-		 VALUES (@id, @template_type_id, @workspace_id, @is_disabled)
+		`INSERT INTO templates (id, template_type_id, workspace_id, is_disabled, is_fork, origin_template_id)
+		 VALUES (@id, @template_type_id, @workspace_id, @is_disabled, @is_fork, @origin_template_id)
 		 RETURNING created_at, updated_at`,
 		pgx.NamedArgs{
-			"id":               tpl.ID,
-			"template_type_id": tpl.TemplateTypeID,
-			"workspace_id":     tpl.WorkspaceID,
-			"is_disabled":      tpl.IsDisabled,
+			"id":                 tpl.ID,
+			"template_type_id":   tpl.TemplateTypeID,
+			"workspace_id":       tpl.WorkspaceID,
+			"is_disabled":        tpl.IsDisabled,
+			"is_fork":            tpl.IsFork,
+			"origin_template_id": tpl.OriginTemplateID,
 		},
 	)
 
@@ -250,9 +244,112 @@ func (r *TemplateRepo) CreateTemplate(ctx context.Context, tpl *domain.Template)
 	return nil
 }
 
+func (r *TemplateRepo) ForkTemplate(
+	ctx context.Context,
+	sourceTemplateID uuid.UUID,
+	workspaceID uuid.UUID,
+	createdBy *uuid.UUID,
+) (*domain.Template, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("beginning template fork transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	sourceTemplate, err := loadTemplateForFork(ctx, tx, sourceTemplateID)
+	if err != nil {
+		return nil, err
+	}
+
+	forked := &domain.Template{
+		ID:               uuid.Must(uuid.NewV7()),
+		TemplateTypeID:   sourceTemplate.TemplateTypeID,
+		WorkspaceID:      &workspaceID,
+		IsDisabled:       sourceTemplate.IsDisabled,
+		IsFork:           true,
+		OriginTemplateID: &sourceTemplate.ID,
+	}
+
+	if err := tx.QueryRow(ctx,
+		`INSERT INTO templates (id, template_type_id, workspace_id, is_disabled, is_fork, origin_template_id)
+		 VALUES (@id, @template_type_id, @workspace_id, @is_disabled, @is_fork, @origin_template_id)
+		 RETURNING created_at, updated_at`,
+		pgx.NamedArgs{
+			"id":                 forked.ID,
+			"template_type_id":   forked.TemplateTypeID,
+			"workspace_id":       workspaceID,
+			"is_disabled":        forked.IsDisabled,
+			"is_fork":            forked.IsFork,
+			"origin_template_id": forked.OriginTemplateID,
+		},
+	).Scan(&forked.CreatedAt, &forked.UpdatedAt); err != nil {
+		if appErr := classifyPgError(err); appErr != nil {
+			return nil, appErr
+		}
+		return nil, fmt.Errorf("inserting forked template: %w", err)
+	}
+
+	sourceVersions, err := listTemplateVersionsForFork(ctx, tx, sourceTemplateID)
+	if err != nil {
+		return nil, err
+	}
+
+	versionIDMap := make(map[uuid.UUID]uuid.UUID, len(sourceVersions))
+	for _, sourceVersion := range sourceVersions {
+		targetVersionID := uuid.Must(uuid.NewV7())
+		versionIDMap[sourceVersion.ID] = targetVersionID
+
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO template_versions (
+			    id, template_id, version_number, status, subject, preview_text,
+			    from_name, reply_to, body_mjml, default_locale, editor_data,
+			    created_by, published_at, archived_at
+			)
+			 VALUES (
+			    @id, @template_id, @version_number, @status, @subject, @preview_text,
+			    @from_name, @reply_to, @body_mjml, @default_locale, @editor_data,
+			    @created_by, @published_at, @archived_at
+			)`,
+			pgx.NamedArgs{
+				"id":             targetVersionID,
+				"template_id":    forked.ID,
+				"version_number": sourceVersion.VersionNumber,
+				"status":         sourceVersion.Status,
+				"subject":        sourceVersion.Subject,
+				"preview_text":   sourceVersion.PreviewText,
+				"from_name":      sourceVersion.FromName,
+				"reply_to":       sourceVersion.ReplyTo,
+				"body_mjml":      sourceVersion.BodyMJML,
+				"default_locale": sourceVersion.DefaultLocale,
+				"editor_data":    sourceVersion.EditorData,
+				"created_by":     coalesceUUID(createdBy, sourceVersion.CreatedBy),
+				"published_at":   sourceVersion.PublishedAt,
+				"archived_at":    sourceVersion.ArchivedAt,
+			},
+		); err != nil {
+			if appErr := classifyPgError(err); appErr != nil {
+				return nil, appErr
+			}
+			return nil, fmt.Errorf("copying template version during fork: %w", err)
+		}
+	}
+
+	if err := copyTemplateLocalesForFork(ctx, tx, versionIDMap); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("committing template fork: %w", err)
+	}
+
+	return forked, nil
+}
+
 func (r *TemplateRepo) GetTemplateByID(ctx context.Context, id uuid.UUID) (*domain.Template, error) {
 	row := r.pool.QueryRow(ctx,
-		`SELECT id, template_type_id, workspace_id, is_disabled, created_at, updated_at, deleted_at
+		`SELECT id, template_type_id, workspace_id, is_disabled, is_fork, origin_template_id, created_at, updated_at, deleted_at
 		 FROM templates
 		 WHERE id = @id AND deleted_at IS NULL`,
 		pgx.NamedArgs{"id": id},
@@ -274,14 +371,14 @@ func (r *TemplateRepo) GetByTypeAndScope(ctx context.Context, typeID uuid.UUID, 
 	var row pgx.Row
 	if wsID == nil {
 		row = r.pool.QueryRow(ctx,
-			`SELECT id, template_type_id, workspace_id, is_disabled, created_at, updated_at, deleted_at
+			`SELECT id, template_type_id, workspace_id, is_disabled, is_fork, origin_template_id, created_at, updated_at, deleted_at
 			 FROM templates
 			 WHERE template_type_id = @type_id AND workspace_id IS NULL AND deleted_at IS NULL`,
 			pgx.NamedArgs{"type_id": typeID},
 		)
 	} else {
 		row = r.pool.QueryRow(ctx,
-			`SELECT id, template_type_id, workspace_id, is_disabled, created_at, updated_at, deleted_at
+			`SELECT id, template_type_id, workspace_id, is_disabled, is_fork, origin_template_id, created_at, updated_at, deleted_at
 			 FROM templates
 			 WHERE template_type_id = @type_id AND workspace_id = @workspace_id AND deleted_at IS NULL`,
 			pgx.NamedArgs{"type_id": typeID, "workspace_id": *wsID},
@@ -303,7 +400,7 @@ func (r *TemplateRepo) ListByType(ctx context.Context, typeID uuid.UUID, wsID *u
 	if wsID == nil {
 		if afterID != nil {
 			rows, err = r.pool.Query(ctx,
-				`SELECT id, template_type_id, workspace_id, is_disabled, created_at, updated_at, deleted_at
+				`SELECT id, template_type_id, workspace_id, is_disabled, is_fork, origin_template_id, created_at, updated_at, deleted_at
 				 FROM templates
 				 WHERE template_type_id = @type_id AND workspace_id IS NULL AND deleted_at IS NULL AND id < @after_id
 				 ORDER BY id DESC
@@ -312,7 +409,7 @@ func (r *TemplateRepo) ListByType(ctx context.Context, typeID uuid.UUID, wsID *u
 			)
 		} else {
 			rows, err = r.pool.Query(ctx,
-				`SELECT id, template_type_id, workspace_id, is_disabled, created_at, updated_at, deleted_at
+				`SELECT id, template_type_id, workspace_id, is_disabled, is_fork, origin_template_id, created_at, updated_at, deleted_at
 				 FROM templates
 				 WHERE template_type_id = @type_id AND workspace_id IS NULL AND deleted_at IS NULL
 				 ORDER BY id DESC
@@ -323,7 +420,7 @@ func (r *TemplateRepo) ListByType(ctx context.Context, typeID uuid.UUID, wsID *u
 	} else {
 		if afterID != nil {
 			rows, err = r.pool.Query(ctx,
-				`SELECT id, template_type_id, workspace_id, is_disabled, created_at, updated_at, deleted_at
+				`SELECT id, template_type_id, workspace_id, is_disabled, is_fork, origin_template_id, created_at, updated_at, deleted_at
 				 FROM templates
 				 WHERE template_type_id = @type_id AND workspace_id = @workspace_id AND deleted_at IS NULL AND id < @after_id
 				 ORDER BY id DESC
@@ -332,7 +429,7 @@ func (r *TemplateRepo) ListByType(ctx context.Context, typeID uuid.UUID, wsID *u
 			)
 		} else {
 			rows, err = r.pool.Query(ctx,
-				`SELECT id, template_type_id, workspace_id, is_disabled, created_at, updated_at, deleted_at
+				`SELECT id, template_type_id, workspace_id, is_disabled, is_fork, origin_template_id, created_at, updated_at, deleted_at
 				 FROM templates
 				 WHERE template_type_id = @type_id AND workspace_id = @workspace_id AND deleted_at IS NULL
 				 ORDER BY id DESC
@@ -363,13 +460,17 @@ func (r *TemplateRepo) ResolveTemplate(ctx context.Context, typeID uuid.UUID, ch
 	scopes, includeGlobal := splitChain(chain)
 
 	row := r.pool.QueryRow(ctx,
-		`SELECT id, template_type_id, workspace_id, is_disabled, created_at, updated_at, deleted_at
+		`SELECT id, template_type_id, workspace_id, is_disabled, is_fork, origin_template_id, created_at, updated_at, deleted_at
 		 FROM templates
 		 WHERE template_type_id = @type_id
 		   AND (workspace_id = ANY(@scopes) OR (@include_global::bool AND workspace_id IS NULL))
 		   AND deleted_at IS NULL
 		 ORDER BY
-		   CASE WHEN workspace_id IS NULL THEN 1 ELSE 0 END,
+		   CASE
+		     WHEN workspace_id IS NULL THEN cardinality(@scopes::uuid[]) + 1
+		     ELSE array_position(@scopes::uuid[], workspace_id)
+		   END ASC,
+		   created_at DESC,
 		   id DESC
 		 LIMIT 1`,
 		pgx.NamedArgs{
@@ -718,6 +819,93 @@ func insertClonedLocales(
 	return nil
 }
 
+func loadTemplateForFork(ctx context.Context, tx pgx.Tx, sourceTemplateID uuid.UUID) (*domain.Template, error) {
+	row := tx.QueryRow(ctx,
+		`SELECT id, template_type_id, workspace_id, is_disabled, is_fork, origin_template_id, created_at, updated_at, deleted_at
+		 FROM templates
+		 WHERE id = @id AND deleted_at IS NULL
+		 FOR UPDATE`,
+		pgx.NamedArgs{"id": sourceTemplateID},
+	)
+	return scanTemplate(row)
+}
+
+func listTemplateVersionsForFork(ctx context.Context, tx pgx.Tx, sourceTemplateID uuid.UUID) ([]*domain.TemplateVersion, error) {
+	rows, err := tx.Query(ctx,
+		`SELECT id, template_id, version_number, status, subject, preview_text,
+		        from_name, reply_to, body_mjml, default_locale,
+		        editor_data, created_by, published_at, archived_at, created_at, updated_at
+		 FROM template_versions
+		 WHERE template_id = @template_id
+		 ORDER BY version_number ASC`,
+		pgx.NamedArgs{"template_id": sourceTemplateID},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing template versions for fork: %w", err)
+	}
+
+	versions, err := pgx.CollectRows(rows, scanTemplateVersionRow)
+	if err != nil {
+		return nil, fmt.Errorf("collecting template versions for fork: %w", err)
+	}
+	return versions, nil
+}
+
+func copyTemplateLocalesForFork(ctx context.Context, tx pgx.Tx, versionIDMap map[uuid.UUID]uuid.UUID) error {
+	for sourceVersionID, targetVersionID := range versionIDMap {
+		rows, err := tx.Query(ctx,
+			`SELECT id, template_version_id, locale, subject, preview_text, from_name,
+			        body_mjml, editor_data, created_at, updated_at
+			 FROM template_version_locales
+			 WHERE template_version_id = @template_version_id
+			 ORDER BY created_at ASC`,
+			pgx.NamedArgs{"template_version_id": sourceVersionID},
+		)
+		if err != nil {
+			return fmt.Errorf("listing locales for forked template version: %w", err)
+		}
+
+		locales, err := pgx.CollectRows(rows, scanTemplateVersionLocaleRow)
+		if err != nil {
+			return fmt.Errorf("collecting locales for forked template version: %w", err)
+		}
+
+		for _, locale := range locales {
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO template_version_locales (
+				    id, template_version_id, locale, subject, preview_text, from_name, body_mjml, editor_data
+				)
+				 VALUES (
+				    @id, @template_version_id, @locale, @subject, @preview_text, @from_name, @body_mjml, @editor_data
+				)`,
+				pgx.NamedArgs{
+					"id":                  uuid.Must(uuid.NewV7()),
+					"template_version_id": targetVersionID,
+					"locale":              locale.Locale,
+					"subject":             locale.Subject,
+					"preview_text":        locale.PreviewText,
+					"from_name":           locale.FromName,
+					"body_mjml":           locale.BodyMJML,
+					"editor_data":         locale.EditorData,
+				},
+			); err != nil {
+				if appErr := classifyPgError(err); appErr != nil {
+					return appErr
+				}
+				return fmt.Errorf("copying locale %s during template fork: %w", locale.Locale, err)
+			}
+		}
+	}
+	return nil
+}
+
+func coalesceUUID(preferred, fallback *uuid.UUID) *uuid.UUID {
+	if preferred != nil {
+		return preferred
+	}
+	return fallback
+}
+
 func (r *TemplateRepo) GetVersionByID(ctx context.Context, versionID uuid.UUID) (*domain.TemplateVersion, error) {
 	row := r.pool.QueryRow(ctx,
 		`SELECT id, template_id, version_number, status, subject, preview_text,
@@ -995,7 +1183,7 @@ func scanTemplateType(row pgx.Row) (*domain.TemplateType, error) {
 func scanTemplateRow(row pgx.CollectableRow) (*domain.Template, error) {
 	var t domain.Template
 	err := row.Scan(
-		&t.ID, &t.TemplateTypeID, &t.WorkspaceID, &t.IsDisabled,
+		&t.ID, &t.TemplateTypeID, &t.WorkspaceID, &t.IsDisabled, &t.IsFork, &t.OriginTemplateID,
 		&t.CreatedAt, &t.UpdatedAt, &t.DeletedAt,
 	)
 	if err != nil {
@@ -1007,7 +1195,7 @@ func scanTemplateRow(row pgx.CollectableRow) (*domain.Template, error) {
 func scanTemplate(row pgx.Row) (*domain.Template, error) {
 	var t domain.Template
 	err := row.Scan(
-		&t.ID, &t.TemplateTypeID, &t.WorkspaceID, &t.IsDisabled,
+		&t.ID, &t.TemplateTypeID, &t.WorkspaceID, &t.IsDisabled, &t.IsFork, &t.OriginTemplateID,
 		&t.CreatedAt, &t.UpdatedAt, &t.DeletedAt,
 	)
 	if err != nil {
@@ -1017,6 +1205,21 @@ func scanTemplate(row pgx.Row) (*domain.Template, error) {
 		return nil, fmt.Errorf("scanning template: %w", err)
 	}
 	return &t, nil
+}
+
+func scanTemplateVersionRow(row pgx.CollectableRow) (*domain.TemplateVersion, error) {
+	var v domain.TemplateVersion
+	err := row.Scan(
+		&v.ID, &v.TemplateID, &v.VersionNumber, &v.Status,
+		&v.Subject, &v.PreviewText, &v.FromName,
+		&v.ReplyTo, &v.BodyMJML, &v.DefaultLocale,
+		&v.EditorData, &v.CreatedBy,
+		&v.PublishedAt, &v.ArchivedAt, &v.CreatedAt, &v.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("scanning template version row: %w", err)
+	}
+	return &v, nil
 }
 
 func scanTemplateVersion(row pgx.Row) (*domain.TemplateVersion, error) {

--- a/internal/adapter/postgres/template_repo_test.go
+++ b/internal/adapter/postgres/template_repo_test.go
@@ -135,6 +135,76 @@ func TestTemplateRepo_GetTypeBySlug(t *testing.T) {
 	}
 }
 
+func TestTemplateRepo_GetTypeBySlug_PrefersEarlierScopeInChainOverUUIDOrdering(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	repo := pgadapter.NewTemplateRepo(pool)
+	tenantRepo := pgadapter.NewTenantRepo(pool)
+	wsRepo := pgadapter.NewWorkspaceRepo(pool)
+
+	tenant := &domain.Tenant{ID: uuid.MustParse("11111111-1111-1111-1111-111111111111"), Code: "acme", Name: "Acme"}
+	if err := tenantRepo.Create(ctx, tenant); err != nil {
+		t.Fatalf("Create tenant error: %v", err)
+	}
+
+	systemWorkspace := &domain.Workspace{
+		ID:       uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+		TenantID: tenant.ID,
+		Code:     "_system",
+		Name:     "Default",
+		IsSystem: true,
+	}
+	if err := wsRepo.Create(ctx, systemWorkspace); err != nil {
+		t.Fatalf("Create system workspace error: %v", err)
+	}
+
+	localWorkspace := &domain.Workspace{
+		ID:       uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+		TenantID: tenant.ID,
+		Code:     "main",
+		Name:     "Main",
+	}
+	if err := wsRepo.Create(ctx, localWorkspace); err != nil {
+		t.Fatalf("Create local workspace error: %v", err)
+	}
+
+	systemType := &domain.TemplateType{
+		ID:             uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+		WorkspaceID:    &systemWorkspace.ID,
+		Slug:           "welcome-email",
+		Name:           "System",
+		VariableSchema: map[string]any{},
+	}
+	if err := repo.CreateType(ctx, systemType); err != nil {
+		t.Fatalf("CreateType(system) error: %v", err)
+	}
+
+	localType := &domain.TemplateType{
+		ID:             uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		WorkspaceID:    &localWorkspace.ID,
+		Slug:           "welcome-email",
+		Name:           "Local",
+		VariableSchema: map[string]any{},
+	}
+	if err := repo.CreateType(ctx, localType); err != nil {
+		t.Fatalf("CreateType(local) error: %v", err)
+	}
+
+	chain := []uuid.NullUUID{
+		{UUID: localWorkspace.ID, Valid: true},
+		{UUID: systemWorkspace.ID, Valid: true},
+		{Valid: false},
+	}
+
+	got, err := repo.GetTypeBySlug(ctx, "welcome-email", chain)
+	if err != nil {
+		t.Fatalf("GetTypeBySlug() error: %v", err)
+	}
+	if got.ID != localType.ID {
+		t.Fatalf("expected local type %s, got %s", localType.ID, got.ID)
+	}
+}
+
 func TestTemplateRepo_GetTypeBySlug_GlobalOnly(t *testing.T) {
 	ctx := context.Background()
 	pool := setupTestDB(ctx, t)
@@ -525,6 +595,83 @@ func TestTemplateRepo_ResolveTemplate(t *testing.T) {
 	}
 	if got.ID != wsTpl.ID {
 		t.Errorf("expected workspace template (most specific), got ID %s", got.ID)
+	}
+}
+
+func TestTemplateRepo_ResolveTemplate_PrefersEarlierScopeInChainOverUUIDOrdering(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	repo := pgadapter.NewTemplateRepo(pool)
+	tenantRepo := pgadapter.NewTenantRepo(pool)
+	wsRepo := pgadapter.NewWorkspaceRepo(pool)
+
+	tenant := &domain.Tenant{ID: uuid.MustParse("44444444-4444-4444-4444-444444444444"), Code: "acme", Name: "Acme"}
+	if err := tenantRepo.Create(ctx, tenant); err != nil {
+		t.Fatalf("Create tenant error: %v", err)
+	}
+
+	systemWorkspace := &domain.Workspace{
+		ID:       uuid.MustParse("55555555-5555-5555-5555-555555555555"),
+		TenantID: tenant.ID,
+		Code:     "_system",
+		Name:     "Default",
+		IsSystem: true,
+	}
+	if err := wsRepo.Create(ctx, systemWorkspace); err != nil {
+		t.Fatalf("Create system workspace error: %v", err)
+	}
+
+	localWorkspace := &domain.Workspace{
+		ID:       uuid.MustParse("66666666-6666-6666-6666-666666666666"),
+		TenantID: tenant.ID,
+		Code:     "main",
+		Name:     "Main",
+	}
+	if err := wsRepo.Create(ctx, localWorkspace); err != nil {
+		t.Fatalf("Create local workspace error: %v", err)
+	}
+
+	tt := &domain.TemplateType{
+		ID:             uuid.MustParse("77777777-7777-7777-7777-777777777777"),
+		WorkspaceID:    &systemWorkspace.ID,
+		Slug:           "welcome-email",
+		Name:           "Welcome",
+		VariableSchema: map[string]any{},
+	}
+	if err := repo.CreateType(ctx, tt); err != nil {
+		t.Fatalf("CreateType error: %v", err)
+	}
+
+	systemTemplate := &domain.Template{
+		ID:             uuid.MustParse("ffffffff-ffff-ffff-ffff-fffffffffffe"),
+		TemplateTypeID: tt.ID,
+		WorkspaceID:    &systemWorkspace.ID,
+	}
+	if err := repo.CreateTemplate(ctx, systemTemplate); err != nil {
+		t.Fatalf("CreateTemplate(system) error: %v", err)
+	}
+
+	localTemplate := &domain.Template{
+		ID:             uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+		TemplateTypeID: tt.ID,
+		WorkspaceID:    &localWorkspace.ID,
+	}
+	if err := repo.CreateTemplate(ctx, localTemplate); err != nil {
+		t.Fatalf("CreateTemplate(local) error: %v", err)
+	}
+
+	chain := []uuid.NullUUID{
+		{UUID: localWorkspace.ID, Valid: true},
+		{UUID: systemWorkspace.ID, Valid: true},
+		{Valid: false},
+	}
+
+	got, err := repo.ResolveTemplate(ctx, tt.ID, chain)
+	if err != nil {
+		t.Fatalf("ResolveTemplate() error: %v", err)
+	}
+	if got.ID != localTemplate.ID {
+		t.Fatalf("expected local template %s, got %s", localTemplate.ID, got.ID)
 	}
 }
 
@@ -923,6 +1070,142 @@ func TestTemplateRepo_CloneVersion_CopiesVersionAndLocales(t *testing.T) {
 	if gotLocales["fr"] == nil || gotLocales["fr"].Subject == nil || *gotLocales["fr"].Subject != frSubject {
 		t.Fatalf("expected fr locale to be cloned exactly")
 	}
+}
+
+func TestTemplateRepo_ForkTemplate_CopiesTemplateVersionsAndLocales(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	repo := pgadapter.NewTemplateRepo(pool)
+	tenantRepo := pgadapter.NewTenantRepo(pool)
+	wsRepo := pgadapter.NewWorkspaceRepo(pool)
+	ws := createTestWorkspaceWith(ctx, t, tenantRepo, wsRepo)
+
+	systemWorkspace := &domain.Workspace{
+		ID:       uuid.New(),
+		TenantID: ws.TenantID,
+		Code:     "_system",
+		Name:     "Default",
+		IsSystem: true,
+	}
+	if err := wsRepo.Create(ctx, systemWorkspace); err != nil {
+		t.Fatalf("Create system workspace error: %v", err)
+	}
+
+	tt := &domain.TemplateType{
+		ID:             uuid.New(),
+		WorkspaceID:    &systemWorkspace.ID,
+		Slug:           "welcome-email",
+		Name:           "Welcome",
+		VariableSchema: map[string]any{},
+	}
+	if err := repo.CreateType(ctx, tt); err != nil {
+		t.Fatalf("CreateType error: %v", err)
+	}
+
+	sourceTemplate := &domain.Template{
+		ID:             uuid.New(),
+		TemplateTypeID: tt.ID,
+		WorkspaceID:    &systemWorkspace.ID,
+		IsDisabled:     true,
+	}
+	if err := repo.CreateTemplate(ctx, sourceTemplate); err != nil {
+		t.Fatalf("CreateTemplate error: %v", err)
+	}
+
+	published := &domain.TemplateVersion{
+		ID:            uuid.New(),
+		TemplateID:    sourceTemplate.ID,
+		Status:        domain.VersionStatusDraft,
+		Subject:       "Published",
+		FromName:      "Senda",
+		BodyMJML:      "<mjml><mj-body><mj-text>published</mj-text></mj-body></mjml>",
+		DefaultLocale: "en",
+	}
+	if err := repo.CreateVersion(ctx, published); err != nil {
+		t.Fatalf("CreateVersion(published) error: %v", err)
+	}
+	if err := repo.Publish(ctx, published.ID); err != nil {
+		t.Fatalf("Publish error: %v", err)
+	}
+
+	draft := &domain.TemplateVersion{
+		ID:            uuid.New(),
+		TemplateID:    sourceTemplate.ID,
+		Status:        domain.VersionStatusDraft,
+		VersionNumber: 2,
+		Subject:       "Draft",
+		FromName:      "Senda",
+		BodyMJML:      "<mjml><mj-body><mj-text>draft</mj-text></mj-body></mjml>",
+		DefaultLocale: "en",
+	}
+	if err := repo.CreateVersion(ctx, draft); err != nil {
+		t.Fatalf("CreateVersion(draft) error: %v", err)
+	}
+
+	if err := repo.SetLocale(ctx, &domain.TemplateVersionLocale{
+		ID:                uuid.New(),
+		TemplateVersionID: draft.ID,
+		Locale:            "es",
+		Subject:           ptrValue("Hola"),
+		BodyMJML:          ptrValue("<mjml><mj-body><mj-text>hola</mj-text></mj-body></mjml>"),
+	}); err != nil {
+		t.Fatalf("SetLocale error: %v", err)
+	}
+
+	forked, err := repo.ForkTemplate(ctx, sourceTemplate.ID, ws.ID, nil)
+	if err != nil {
+		t.Fatalf("ForkTemplate() error: %v", err)
+	}
+
+	if forked.WorkspaceID == nil || *forked.WorkspaceID != ws.ID {
+		t.Fatalf("expected fork workspace %s, got %#v", ws.ID, forked.WorkspaceID)
+	}
+	if !forked.IsFork {
+		t.Fatal("expected forked template to be marked as fork")
+	}
+	if forked.OriginTemplateID == nil || *forked.OriginTemplateID != sourceTemplate.ID {
+		t.Fatalf("expected origin template %s, got %#v", sourceTemplate.ID, forked.OriginTemplateID)
+	}
+
+	versions, err := repo.ListVersions(ctx, forked.ID)
+	if err != nil {
+		t.Fatalf("ListVersions(forked) error: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("expected 2 versions on fork, got %d", len(versions))
+	}
+
+	var gotPublished, gotDraft *domain.TemplateVersion
+	for _, version := range versions {
+		switch version.Status {
+		case domain.VersionStatusPublished:
+			gotPublished = version
+		case domain.VersionStatusDraft:
+			gotDraft = version
+		}
+	}
+
+	if gotPublished == nil || gotDraft == nil {
+		t.Fatalf("expected published and draft versions on fork, got %#v", versions)
+	}
+	if gotPublished.VersionNumber != 1 {
+		t.Fatalf("expected published version number 1, got %d", gotPublished.VersionNumber)
+	}
+	if gotDraft.VersionNumber != 2 {
+		t.Fatalf("expected draft version number 2, got %d", gotDraft.VersionNumber)
+	}
+
+	locales, err := repo.ListLocales(ctx, gotDraft.ID)
+	if err != nil {
+		t.Fatalf("ListLocales(draft) error: %v", err)
+	}
+	if len(locales) != 1 || locales[0].Locale != "es" {
+		t.Fatalf("expected spanish locale on forked draft, got %#v", locales)
+	}
+}
+
+func ptrValue[T any](value T) *T {
+	return &value
 }
 
 // --- Locale tests ---

--- a/internal/adapter/postgres/workspace_repo.go
+++ b/internal/adapter/postgres/workspace_repo.go
@@ -26,17 +26,26 @@ func NewWorkspaceRepo(pool *pgxpool.Pool) *WorkspaceRepo {
 
 func (r *WorkspaceRepo) Create(ctx context.Context, ws *domain.Workspace) error {
 	row := r.pool.QueryRow(ctx,
-		`INSERT INTO workspaces (id, tenant_id, code, name, is_system, open_tracking_enabled, default_locale)
-		 VALUES (@id, @tenant_id, @code, @name, @is_system, @open_tracking_enabled, @default_locale)
+		`INSERT INTO workspaces (
+		    id, tenant_id, code, name, is_system, open_tracking_enabled, default_locale,
+		    allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors
+		)
+		 VALUES (
+		    @id, @tenant_id, @code, @name, @is_system, @open_tracking_enabled, @default_locale,
+		    @allow_workspace_local_templates, @allow_workspace_inherited_template_forks, @allow_workspace_local_injectors
+		)
 		 RETURNING is_active, created_at, updated_at`,
 		pgx.NamedArgs{
-			"id":                    ws.ID,
-			"tenant_id":             ws.TenantID,
-			"code":                  ws.Code,
-			"name":                  ws.Name,
-			"is_system":             ws.IsSystem,
-			"open_tracking_enabled": ws.OpenTrackingEnabled,
-			"default_locale":        ws.DefaultLocale,
+			"id":                              ws.ID,
+			"tenant_id":                       ws.TenantID,
+			"code":                            ws.Code,
+			"name":                            ws.Name,
+			"is_system":                       ws.IsSystem,
+			"open_tracking_enabled":           ws.OpenTrackingEnabled,
+			"default_locale":                  ws.DefaultLocale,
+			"allow_workspace_local_templates": effectiveWorkspacePolicyValue(ws.AllowWorkspaceLocalTemplates, ws.WorkspacePoliciesInitialized),
+			"allow_workspace_inherited_template_forks": effectiveWorkspacePolicyValue(ws.AllowWorkspaceInheritedTemplateForks, ws.WorkspacePoliciesInitialized),
+			"allow_workspace_local_injectors":          effectiveWorkspacePolicyValue(ws.AllowWorkspaceLocalInjectors, ws.WorkspacePoliciesInitialized),
 		},
 	)
 
@@ -46,6 +55,7 @@ func (r *WorkspaceRepo) Create(ctx context.Context, ws *domain.Workspace) error 
 		}
 		return fmt.Errorf("inserting workspace: %w", err)
 	}
+	ws.WorkspacePoliciesInitialized = true
 
 	return nil
 }
@@ -53,6 +63,7 @@ func (r *WorkspaceRepo) Create(ctx context.Context, ws *domain.Workspace) error 
 func (r *WorkspaceRepo) GetByID(ctx context.Context, id uuid.UUID) (*domain.Workspace, error) {
 	row := r.pool.QueryRow(ctx,
 		`SELECT id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale,
+		        allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors,
 		        created_at, updated_at, deleted_at
 		 FROM workspaces
 		 WHERE id = @id AND deleted_at IS NULL`,
@@ -65,6 +76,7 @@ func (r *WorkspaceRepo) GetByID(ctx context.Context, id uuid.UUID) (*domain.Work
 func (r *WorkspaceRepo) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
 	row := r.pool.QueryRow(ctx,
 		`SELECT id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale,
+		        allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors,
 		        created_at, updated_at, deleted_at
 		 FROM workspaces
 		 WHERE tenant_id = @tenant_id AND code = @code AND deleted_at IS NULL`,
@@ -77,6 +89,7 @@ func (r *WorkspaceRepo) GetByTenantAndCode(ctx context.Context, tenantID uuid.UU
 func (r *WorkspaceRepo) GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
 	row := r.pool.QueryRow(ctx,
 		`SELECT id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale,
+		        allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors,
 		        created_at, updated_at, deleted_at
 		 FROM workspaces
 		 WHERE tenant_id = @tenant_id AND is_system = true AND deleted_at IS NULL`,
@@ -96,7 +109,9 @@ func (r *WorkspaceRepo) ListByTenant(ctx context.Context, tenantID uuid.UUID, op
 	args := pgx.NamedArgs{"tenant_id": tenantID, "limit": fetchLimit}
 
 	var qb strings.Builder
-	qb.WriteString(`SELECT id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale, created_at, updated_at, deleted_at FROM workspaces WHERE tenant_id = @tenant_id AND deleted_at IS NULL`)
+	qb.WriteString(`SELECT id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale,
+	allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors,
+	created_at, updated_at, deleted_at FROM workspaces WHERE tenant_id = @tenant_id AND deleted_at IS NULL`)
 
 	if afterID != nil {
 		qb.WriteString(` AND id < @after_id`)
@@ -119,6 +134,9 @@ func (r *WorkspaceRepo) ListByTenant(ctx context.Context, tenantID uuid.UUID, op
 	if err != nil {
 		return nil, "", fmt.Errorf("collecting workspaces: %w", err)
 	}
+	for _, workspace := range workspaces {
+		workspace.WorkspacePoliciesInitialized = true
+	}
 
 	var nextCursor string
 	if len(workspaces) > limit {
@@ -136,15 +154,21 @@ func (r *WorkspaceRepo) Update(ctx context.Context, ws *domain.Workspace) error 
 		     is_active = @is_active,
 		     open_tracking_enabled = @open_tracking_enabled,
 		     default_locale = @default_locale,
+		     allow_workspace_local_templates = @allow_workspace_local_templates,
+		     allow_workspace_inherited_template_forks = @allow_workspace_inherited_template_forks,
+		     allow_workspace_local_injectors = @allow_workspace_local_injectors,
 		     updated_at = now()
 		 WHERE id = @id AND deleted_at IS NULL
 		 RETURNING updated_at`,
 		pgx.NamedArgs{
-			"id":                    ws.ID,
-			"name":                  ws.Name,
-			"is_active":             ws.IsActive,
-			"open_tracking_enabled": ws.OpenTrackingEnabled,
-			"default_locale":        ws.DefaultLocale,
+			"id":                              ws.ID,
+			"name":                            ws.Name,
+			"is_active":                       ws.IsActive,
+			"open_tracking_enabled":           ws.OpenTrackingEnabled,
+			"default_locale":                  ws.DefaultLocale,
+			"allow_workspace_local_templates": effectiveWorkspacePolicyValue(ws.AllowWorkspaceLocalTemplates, ws.WorkspacePoliciesInitialized),
+			"allow_workspace_inherited_template_forks": effectiveWorkspacePolicyValue(ws.AllowWorkspaceInheritedTemplateForks, ws.WorkspacePoliciesInitialized),
+			"allow_workspace_local_injectors":          effectiveWorkspacePolicyValue(ws.AllowWorkspaceLocalInjectors, ws.WorkspacePoliciesInitialized),
 		},
 	)
 
@@ -154,6 +178,7 @@ func (r *WorkspaceRepo) Update(ctx context.Context, ws *domain.Workspace) error 
 		}
 		return fmt.Errorf("updating workspace: %w", err)
 	}
+	ws.WorkspacePoliciesInitialized = true
 
 	return nil
 }
@@ -177,6 +202,7 @@ func scanWorkspace(row pgx.Row) (*domain.Workspace, error) {
 	err := row.Scan(
 		&ws.ID, &ws.TenantID, &ws.Code, &ws.Name, &ws.IsSystem, &ws.IsActive,
 		&ws.OpenTrackingEnabled, &ws.DefaultLocale,
+		&ws.AllowWorkspaceLocalTemplates, &ws.AllowWorkspaceInheritedTemplateForks, &ws.AllowWorkspaceLocalInjectors,
 		&ws.CreatedAt, &ws.UpdatedAt, &ws.DeletedAt,
 	)
 	if err != nil {
@@ -185,5 +211,13 @@ func scanWorkspace(row pgx.Row) (*domain.Workspace, error) {
 		}
 		return nil, fmt.Errorf("scanning workspace: %w", err)
 	}
+	ws.WorkspacePoliciesInitialized = true
 	return &ws, nil
+}
+
+func effectiveWorkspacePolicyValue(value bool, initialized bool) bool {
+	if initialized {
+		return value
+	}
+	return true
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -200,6 +200,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *slog.Logger, ext
 	// 11. HTTP handlers.
 	tenantH := handler.NewTenantHandler(tenantRepo, wsRepo, adapterRepo)
 	workspaceH := handler.NewWorkspaceHandler(tenantRepo, wsRepo)
+	workspacePolicyH := handler.NewWorkspacePolicyHandler(tenantRepo, wsRepo)
 	memberH := handler.NewMemberHandler(memberRepo, tenantRepo, wsRepo)
 	configH := handler.NewConfigHandler(configRepo, handler.OIDCInfo{
 		DiscoveryURL:    cfg.OIDC.DiscoveryURL,
@@ -287,6 +288,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *slog.Logger, ext
 		sendahttp.WithConfigStore(configRepo),
 		sendahttp.WithTenantHandler(tenantH),
 		sendahttp.WithWorkspaceHandler(workspaceH),
+		sendahttp.WithWorkspacePolicyHandler(workspacePolicyH),
 		sendahttp.WithMemberHandler(memberH),
 		sendahttp.WithConfigHandler(configH),
 		sendahttp.WithInjectorHandler(injectorH),

--- a/internal/domain/injector.go
+++ b/internal/domain/injector.go
@@ -18,13 +18,15 @@ const (
 )
 
 type InjectorDefinition struct {
-	ID          uuid.UUID
-	WorkspaceID *uuid.UUID // nil = global
-	Name        string
-	Description *string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	DeletedAt   *time.Time
+	ID                  uuid.UUID
+	WorkspaceID         *uuid.UUID // nil = global
+	Name                string
+	Description         *string
+	OwnerScope          string
+	InheritedFromSystem bool
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	DeletedAt           *time.Time
 }
 
 type InjectorField struct {

--- a/internal/domain/template.go
+++ b/internal/domain/template.go
@@ -15,27 +15,33 @@ const (
 )
 
 type TemplateType struct {
-	ID               uuid.UUID
-	WorkspaceID      *uuid.UUID     // nil = global
-	Slug             string
-	Name             string
-	Description      *string
-	AdapterID        *uuid.UUID     // nil = not configured yet
-	SenderIdentityID *uuid.UUID     // nil = use adapter default
-	VariableSchema   map[string]any // JSON Schema for event variables
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
-	DeletedAt        *time.Time
+	ID                  uuid.UUID
+	WorkspaceID         *uuid.UUID // nil = global
+	Slug                string
+	Name                string
+	Description         *string
+	AdapterID           *uuid.UUID     // nil = not configured yet
+	SenderIdentityID    *uuid.UUID     // nil = use adapter default
+	VariableSchema      map[string]any // JSON Schema for event variables
+	OwnerScope          string
+	InheritedFromSystem bool
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	DeletedAt           *time.Time
 }
 
 type Template struct {
-	ID             uuid.UUID
-	TemplateTypeID uuid.UUID
-	WorkspaceID    *uuid.UUID // nil = global
-	IsDisabled     bool       // kill switch
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	DeletedAt      *time.Time
+	ID                  uuid.UUID
+	TemplateTypeID      uuid.UUID
+	WorkspaceID         *uuid.UUID // nil = global
+	IsDisabled          bool       // kill switch
+	IsFork              bool
+	OriginTemplateID    *uuid.UUID
+	OwnerScope          string
+	InheritedFromSystem bool
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	DeletedAt           *time.Time
 }
 
 type TemplateVersion struct {
@@ -47,7 +53,7 @@ type TemplateVersion struct {
 	PreviewText   string
 	FromName      string
 	ReplyTo       *string
-	BodyMJML      string         // MJML source
+	BodyMJML      string // MJML source
 	DefaultLocale string
 	EditorData    map[string]any // JSONB editor state
 	CreatedBy     *uuid.UUID     // member who created the version

--- a/internal/domain/tenant.go
+++ b/internal/domain/tenant.go
@@ -17,15 +17,19 @@ type Tenant struct {
 }
 
 type Workspace struct {
-	ID                  uuid.UUID
-	TenantID            uuid.UUID
-	Code                string
-	Name                string
-	IsSystem            bool
-	IsActive            bool
-	OpenTrackingEnabled bool
-	DefaultLocale       *string
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
-	DeletedAt           *time.Time
+	ID                                   uuid.UUID
+	TenantID                             uuid.UUID
+	Code                                 string
+	Name                                 string
+	IsSystem                             bool
+	IsActive                             bool
+	OpenTrackingEnabled                  bool
+	DefaultLocale                        *string
+	AllowWorkspaceLocalTemplates         bool
+	AllowWorkspaceInheritedTemplateForks bool
+	AllowWorkspaceLocalInjectors         bool
+	WorkspacePoliciesInitialized         bool
+	CreatedAt                            time.Time
+	UpdatedAt                            time.Time
+	DeletedAt                            *time.Time
 }

--- a/internal/http/handler/injector.go
+++ b/internal/http/handler/injector.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/rendis/senda/internal/http/request"
 	"github.com/rendis/senda/internal/http/response"
 	"github.com/rendis/senda/internal/port"
+	"github.com/rendis/senda/pkg/apperr"
 )
 
 // InjectorHandler handles CRUD operations for injector definitions and values.
@@ -32,6 +34,15 @@ func (h *InjectorHandler) Create(c *echo.Context) error {
 	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
 	if err != nil {
 		return mapStoreError(c, err)
+	}
+	if !ws.IsSystem {
+		systemWorkspace, err := resolveSystemWorkspace(c.Request().Context(), ws, h.wsStore)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+		if !effectiveWorkspacePolicies(systemWorkspace).AllowWorkspaceLocalInjectors {
+			return writePolicyForbidden(c, "WORKSPACE_LOCAL_INJECTORS_DISABLED", "workspace local injectors are disabled by tenant policy")
+		}
 	}
 
 	return h.create(c, &ws.ID)
@@ -101,7 +112,7 @@ func (h *InjectorHandler) Update(c *echo.Context) error {
 		return mapStoreError(c, err)
 	}
 
-	return h.update(c, &ws.ID)
+	return h.update(c, ws)
 }
 
 // UpdateGlobal handles PUT /global/injectors/:name.
@@ -109,8 +120,22 @@ func (h *InjectorHandler) UpdateGlobal(c *echo.Context) error {
 	return h.update(c, nil)
 }
 
-func (h *InjectorHandler) update(c *echo.Context, workspaceID *uuid.UUID) error {
+func (h *InjectorHandler) update(c *echo.Context, workspace *domain.Workspace) error {
 	currentName := c.Param("name")
+	var workspaceID *uuid.UUID
+	if workspace != nil {
+		workspaceID = &workspace.ID
+		def, _, policies, err := h.loadWorkspaceDefinitionAccess(c.Request().Context(), workspace, currentName)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+		if !isOwnedByCurrentWorkspace(def.WorkspaceID, workspace) {
+			return writePolicyForbidden(c, "READ_ONLY_INHERITED_INJECTOR", "inherited injectors are read-only in workspace scope")
+		}
+		if !workspace.IsSystem && !policies.AllowWorkspaceLocalInjectors {
+			return writePolicyForbidden(c, "WORKSPACE_LOCAL_INJECTORS_DISABLED", "workspace local injectors are disabled by tenant policy")
+		}
+	}
 
 	var req request.UpdateInjectorRequest
 	if err := c.Bind(&req); err != nil {
@@ -170,6 +195,10 @@ func (h *InjectorHandler) ListGlobal(c *echo.Context) error {
 
 func (h *InjectorHandler) list(c *echo.Context, workspace *domain.Workspace) error {
 	ctx := c.Request().Context()
+	systemWorkspace, err := resolveSystemWorkspace(ctx, workspace, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
 
 	chain, err := h.listChain(ctx, workspace, includeInheritedInjectors(c))
 	if err != nil {
@@ -191,6 +220,9 @@ func (h *InjectorHandler) list(c *echo.Context, workspace *domain.Workspace) err
 	if err != nil {
 		return mapStoreError(c, err)
 	}
+	for _, def := range defs {
+		annotateInjectorScope(def, workspace, systemWorkspace)
+	}
 
 	return c.JSON(http.StatusOK, response.NewInjectorListResponse(defs, fieldsByDefinition))
 }
@@ -207,10 +239,16 @@ func (h *InjectorHandler) listChain(ctx context.Context, workspace *domain.Works
 
 	systemWorkspace, err := h.wsStore.GetSystemWorkspace(ctx, workspace.TenantID)
 	if err != nil {
+		if apperr.IsNotFound(err) || errorsIsNotFound(err) {
+			return chain, nil
+		}
 		return nil, err
 	}
+	if systemWorkspace != nil && systemWorkspace.ID != workspace.ID {
+		chain = append(chain, uuidToNullUUID(&systemWorkspace.ID))
+	}
 
-	return append(chain, uuidToNullUUID(&systemWorkspace.ID), uuid.NullUUID{}), nil
+	return chain, nil
 }
 
 func includeInheritedInjectors(c *echo.Context) bool {
@@ -268,7 +306,7 @@ func (h *InjectorHandler) Get(c *echo.Context) error {
 		return mapStoreError(c, err)
 	}
 
-	return h.get(c, &ws.ID)
+	return h.get(c, ws)
 }
 
 // GetGlobal handles GET /global/injectors/:name.
@@ -276,21 +314,36 @@ func (h *InjectorHandler) GetGlobal(c *echo.Context) error {
 	return h.get(c, nil)
 }
 
-func (h *InjectorHandler) get(c *echo.Context, workspaceID *uuid.UUID) error {
+func (h *InjectorHandler) get(c *echo.Context, workspace *domain.Workspace) error {
 	name := c.Param("name")
 	ctx := c.Request().Context()
 
-	def, err := h.store.FindDefinitionByName(ctx, name, workspaceID)
+	var (
+		def             *domain.InjectorDefinition
+		systemWorkspace *domain.Workspace
+		err             error
+		chain           []uuid.NullUUID
+	)
+	if workspace == nil {
+		def, err = h.store.FindDefinitionByName(ctx, name, nil)
+		chain = []uuid.NullUUID{uuid.NullUUID{}}
+	} else {
+		def, systemWorkspace, _, err = h.loadWorkspaceDefinitionAccess(ctx, workspace, name)
+		if err == nil {
+			chain, _, err = workspaceResolutionChain(ctx, workspace, h.wsStore)
+		}
+	}
 	if err != nil {
 		return mapStoreError(c, err)
 	}
+	annotateInjectorScope(def, workspace, systemWorkspace)
 
 	fields, err := h.store.GetFieldsByDefinition(ctx, def.ID)
 	if err != nil {
 		return mapStoreError(c, err)
 	}
 
-	values, err := h.store.GetValues(ctx, def.ID, []uuid.NullUUID{uuidToNullUUID(workspaceID)})
+	values, err := h.store.GetValues(ctx, def.ID, chain)
 	if err != nil {
 		return mapStoreError(c, err)
 	}
@@ -304,7 +357,7 @@ func (h *InjectorHandler) Delete(c *echo.Context) error {
 	if err != nil {
 		return mapStoreError(c, err)
 	}
-	return h.deleteInjector(c, &ws.ID)
+	return h.deleteInjector(c, ws)
 }
 
 // DeleteGlobal handles DELETE /global/injectors/:name.
@@ -312,14 +365,28 @@ func (h *InjectorHandler) DeleteGlobal(c *echo.Context) error {
 	return h.deleteInjector(c, nil)
 }
 
-func (h *InjectorHandler) deleteInjector(c *echo.Context, workspaceID *uuid.UUID) error {
+func (h *InjectorHandler) deleteInjector(c *echo.Context, workspace *domain.Workspace) error {
 	name := c.Param("name")
-	def, err := h.store.FindDefinitionByName(c.Request().Context(), name, workspaceID)
+	if workspace == nil {
+		def, err := h.store.FindDefinitionByName(c.Request().Context(), name, nil)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+		if err := h.store.SoftDeleteDefinition(c.Request().Context(), def.ID); err != nil {
+			return mapStoreError(c, err)
+		}
+		return c.NoContent(http.StatusNoContent)
+	}
+
+	def, _, policies, err := h.loadWorkspaceDefinitionAccess(c.Request().Context(), workspace, name)
 	if err != nil {
 		return mapStoreError(c, err)
 	}
-	if !sameScope(def.WorkspaceID, workspaceID) {
-		return response.WriteError(c, http.StatusNotFound, "NOT_FOUND", "resource not found")
+	if !isOwnedByCurrentWorkspace(def.WorkspaceID, workspace) {
+		return writePolicyForbidden(c, "READ_ONLY_INHERITED_INJECTOR", "inherited injectors are read-only in workspace scope")
+	}
+	if !workspace.IsSystem && !policies.AllowWorkspaceLocalInjectors {
+		return writePolicyForbidden(c, "WORKSPACE_LOCAL_INJECTORS_DISABLED", "workspace local injectors are disabled by tenant policy")
 	}
 	if err := h.store.SoftDeleteDefinition(c.Request().Context(), def.ID); err != nil {
 		return mapStoreError(c, err)
@@ -344,7 +411,7 @@ func (h *InjectorHandler) UpdateField(c *echo.Context) error {
 		return mapStoreError(c, err)
 	}
 
-	return h.updateField(c, &ws.ID)
+	return h.updateField(c, ws)
 }
 
 // UpdateFieldGlobal handles PUT /global/injectors/:name/fields/:field_name.
@@ -352,10 +419,25 @@ func (h *InjectorHandler) UpdateFieldGlobal(c *echo.Context) error {
 	return h.updateField(c, nil)
 }
 
-func (h *InjectorHandler) updateField(c *echo.Context, workspaceID *uuid.UUID) error {
+func (h *InjectorHandler) updateField(c *echo.Context, workspace *domain.Workspace) error {
 	name := c.Param("name")
 	fieldName := c.Param("field_name")
 	ctx := c.Request().Context()
+
+	var workspaceID *uuid.UUID
+	if workspace != nil {
+		workspaceID = &workspace.ID
+		def, _, policies, err := h.loadWorkspaceDefinitionAccess(ctx, workspace, name)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+		if !isOwnedByCurrentWorkspace(def.WorkspaceID, workspace) {
+			return writePolicyForbidden(c, "READ_ONLY_INHERITED_INJECTOR", "inherited injectors are read-only in workspace scope")
+		}
+		if !workspace.IsSystem && !policies.AllowWorkspaceLocalInjectors {
+			return writePolicyForbidden(c, "WORKSPACE_LOCAL_INJECTORS_DISABLED", "workspace local injectors are disabled by tenant policy")
+		}
+	}
 
 	def, err := h.store.FindDefinitionByName(ctx, name, workspaceID)
 	if err != nil {
@@ -411,6 +493,23 @@ func (h *InjectorHandler) setValues(c *echo.Context, workspaceID *uuid.UUID) err
 	name := c.Param("name")
 	ctx := c.Request().Context()
 
+	if workspaceID != nil {
+		workspace, err := resolveWorkspace(c, h.tsStore, h.wsStore)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+		def, _, policies, err := h.loadWorkspaceDefinitionAccess(ctx, workspace, name)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+		if !isOwnedByCurrentWorkspace(def.WorkspaceID, workspace) {
+			return writePolicyForbidden(c, "READ_ONLY_INHERITED_INJECTOR", "inherited injectors are read-only in workspace scope")
+		}
+		if !workspace.IsSystem && !policies.AllowWorkspaceLocalInjectors {
+			return writePolicyForbidden(c, "WORKSPACE_LOCAL_INJECTORS_DISABLED", "workspace local injectors are disabled by tenant policy")
+		}
+	}
+
 	def, err := h.store.FindDefinitionByName(ctx, name, workspaceID)
 	if err != nil {
 		return mapStoreError(c, err)
@@ -443,6 +542,43 @@ func (h *InjectorHandler) setValues(c *echo.Context, workspaceID *uuid.UUID) err
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+func (h *InjectorHandler) loadWorkspaceDefinitionAccess(
+	ctx context.Context,
+	workspace *domain.Workspace,
+	name string,
+) (*domain.InjectorDefinition, *domain.Workspace, workspacePolicies, error) {
+	systemWorkspace, err := resolveSystemWorkspace(ctx, workspace, h.wsStore)
+	if err != nil {
+		return nil, nil, workspacePolicies{}, err
+	}
+
+	def, err := h.store.FindDefinitionByName(ctx, name, &workspace.ID)
+	if err != nil {
+		if !apperr.IsNotFound(err) && !errorsIsNotFound(err) {
+			return nil, nil, workspacePolicies{}, err
+		}
+		def = nil
+	}
+	if def == nil && systemWorkspace != nil && systemWorkspace.ID != workspace.ID {
+		def, err = h.store.FindDefinitionByName(ctx, name, &systemWorkspace.ID)
+		if err != nil {
+			if !apperr.IsNotFound(err) && !errorsIsNotFound(err) {
+				return nil, nil, workspacePolicies{}, err
+			}
+			def = nil
+		}
+	}
+	if def == nil {
+		return nil, systemWorkspace, workspacePolicies{}, apperr.NotFound("injector not found in workspace scope")
+	}
+	annotateInjectorScope(def, workspace, systemWorkspace)
+	return def, systemWorkspace, effectiveWorkspacePolicies(systemWorkspace), nil
+}
+
+func errorsIsNotFound(err error) bool {
+	return err != nil && (apperr.IsNotFound(err) || errors.Is(err, domain.ErrNotFound))
 }
 
 func isValidFieldType(ft string) bool {

--- a/internal/http/handler/injector_test.go
+++ b/internal/http/handler/injector_test.go
@@ -21,16 +21,16 @@ import (
 // --- Mock InjectorStore ---
 
 type mockInjectorStore struct {
-	createDefinitionFn     func(ctx context.Context, def *domain.InjectorDefinition) error
+	createDefinitionFn       func(ctx context.Context, def *domain.InjectorDefinition) error
 	updateDefinitionSchemaFn func(ctx context.Context, currentName string, workspaceID *uuid.UUID, def *domain.InjectorDefinition, fields []*domain.InjectorField) error
-	getDefinitionByIDFn    func(ctx context.Context, id uuid.UUID) (*domain.InjectorDefinition, error)
-	findDefinitionByNameFn func(ctx context.Context, name string, workspaceID *uuid.UUID) (*domain.InjectorDefinition, error)
+	getDefinitionByIDFn      func(ctx context.Context, id uuid.UUID) (*domain.InjectorDefinition, error)
+	findDefinitionByNameFn   func(ctx context.Context, name string, workspaceID *uuid.UUID) (*domain.InjectorDefinition, error)
 	listDefinitionsInChainFn func(ctx context.Context, chain []uuid.NullUUID) ([]*domain.InjectorDefinition, error)
-	createFieldFn          func(ctx context.Context, field *domain.InjectorField) error
-	updateFieldFn          func(ctx context.Context, field *domain.InjectorField) error
-	getFieldsByDefinitionFn func(ctx context.Context, defID uuid.UUID) ([]*domain.InjectorField, error)
-	setValueFn             func(ctx context.Context, val *domain.InjectorValue) error
-	getValuesFn            func(ctx context.Context, defID uuid.UUID, chain []uuid.NullUUID) ([]*domain.InjectorValue, error)
+	createFieldFn            func(ctx context.Context, field *domain.InjectorField) error
+	updateFieldFn            func(ctx context.Context, field *domain.InjectorField) error
+	getFieldsByDefinitionFn  func(ctx context.Context, defID uuid.UUID) ([]*domain.InjectorField, error)
+	setValueFn               func(ctx context.Context, val *domain.InjectorValue) error
+	getValuesFn              func(ctx context.Context, defID uuid.UUID, chain []uuid.NullUUID) ([]*domain.InjectorValue, error)
 }
 
 func (m *mockInjectorStore) CreateDefinition(ctx context.Context, def *domain.InjectorDefinition) error {
@@ -279,8 +279,8 @@ func TestInjectorHandler_List_IncludeInheritedUsesResolutionChain(t *testing.T) 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if len(gotChain) != 3 {
-		t.Fatalf("expected workspace/system/global chain, got %+v", gotChain)
+	if len(gotChain) != 2 {
+		t.Fatalf("expected workspace/system chain, got %+v", gotChain)
 	}
 	if !gotChain[0].Valid || gotChain[0].UUID != ws.ID {
 		t.Fatalf("expected workspace scope first, got %+v", gotChain)
@@ -288,8 +288,118 @@ func TestInjectorHandler_List_IncludeInheritedUsesResolutionChain(t *testing.T) 
 	if !gotChain[1].Valid || gotChain[1].UUID != systemID {
 		t.Fatalf("expected system scope second, got %+v", gotChain)
 	}
-	if gotChain[2].Valid {
-		t.Fatalf("expected global scope last, got %+v", gotChain)
+}
+
+func TestInjectorHandler_Get_ResolvesInheritedSystemInjectorInWorkspace(t *testing.T) {
+	tenant, _, ts, wsStore := testTenantAndWorkspace()
+	systemID := uuid.Must(uuid.NewV7())
+	defID := uuid.Must(uuid.NewV7())
+
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+		if tenantID != tenant.ID {
+			t.Fatalf("unexpected tenant id %s", tenantID)
+		}
+		return &domain.Workspace{
+			ID:       systemID,
+			TenantID: tenant.ID,
+			Code:     "_system",
+			Name:     "Default",
+			IsSystem: true,
+		}, nil
+	}
+
+	is := &mockInjectorStore{
+		findDefinitionByNameFn: func(_ context.Context, name string, workspaceID *uuid.UUID) (*domain.InjectorDefinition, error) {
+			if workspaceID == nil || *workspaceID != systemID {
+				return nil, domain.ErrNotFound
+			}
+			if name != "company_info" {
+				t.Fatalf("unexpected name %q", name)
+			}
+			return &domain.InjectorDefinition{
+				ID:          defID,
+				WorkspaceID: &systemID,
+				Name:        "company_info",
+			}, nil
+		},
+		getFieldsByDefinitionFn: func(_ context.Context, id uuid.UUID) ([]*domain.InjectorField, error) {
+			if id != defID {
+				t.Fatalf("expected definition id %s, got %s", defID, id)
+			}
+			return []*domain.InjectorField{
+				{ID: uuid.Must(uuid.NewV7()), InjectorDefinitionID: defID, FieldName: "company_name", FieldType: domain.FieldTypeText, Position: 0},
+			}, nil
+		},
+		getValuesFn: func(_ context.Context, id uuid.UUID, chain []uuid.NullUUID) ([]*domain.InjectorValue, error) {
+			if id != defID {
+				t.Fatalf("expected definition id %s, got %s", defID, id)
+			}
+			return nil, nil
+		},
+	}
+
+	e, _ := setupInjectorTest(is, ts, wsStore)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/manage/tenants/acme/workspaces/default/injectors/company_info", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp response.InjectorDetailResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.OwnerScope != "system" {
+		t.Fatalf("expected owner_scope system, got %q", resp.OwnerScope)
+	}
+	if !resp.InheritedFromSystem {
+		t.Fatal("expected inherited system marker")
+	}
+}
+
+func TestInjectorHandler_Get_DoesNotFallbackToGlobalInjectorInWorkspace(t *testing.T) {
+	tenant, _, ts, wsStore := testTenantAndWorkspace()
+	systemID := uuid.Must(uuid.NewV7())
+
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+		if tenantID != tenant.ID {
+			t.Fatalf("unexpected tenant id %s", tenantID)
+		}
+		return &domain.Workspace{
+			ID:       systemID,
+			TenantID: tenant.ID,
+			Code:     "_system",
+			Name:     "Default",
+			IsSystem: true,
+		}, nil
+	}
+
+	is := &mockInjectorStore{
+		findDefinitionByNameFn: func(_ context.Context, name string, workspaceID *uuid.UUID) (*domain.InjectorDefinition, error) {
+			if name != "global_only" {
+				t.Fatalf("unexpected name %q", name)
+			}
+			if workspaceID == nil {
+				return &domain.InjectorDefinition{
+					ID:   uuid.Must(uuid.NewV7()),
+					Name: "global_only",
+				}, nil
+			}
+			return nil, domain.ErrNotFound
+		},
+	}
+
+	e, _ := setupInjectorTest(is, ts, wsStore)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/manage/tenants/acme/workspaces/default/injectors/global_only", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -595,13 +705,26 @@ func TestInjectorHandler_Update_Success(t *testing.T) {
 	_, ws, ts, wsStore := testTenantAndWorkspace()
 
 	var (
-		currentName string
+		currentName    string
 		gotWorkspaceID *uuid.UUID
-		updatedDef *domain.InjectorDefinition
-		updatedFields []*domain.InjectorField
+		updatedDef     *domain.InjectorDefinition
+		updatedFields  []*domain.InjectorField
 	)
 
 	is := &mockInjectorStore{
+		findDefinitionByNameFn: func(_ context.Context, name string, workspaceID *uuid.UUID) (*domain.InjectorDefinition, error) {
+			if name != "student" {
+				t.Fatalf("expected lookup for student, got %q", name)
+			}
+			if workspaceID == nil || *workspaceID != ws.ID {
+				t.Fatalf("expected workspace lookup %s, got %v", ws.ID, workspaceID)
+			}
+			return &domain.InjectorDefinition{
+				ID:          uuid.Must(uuid.NewV7()),
+				WorkspaceID: &ws.ID,
+				Name:        name,
+			}, nil
+		},
 		updateDefinitionSchemaFn: func(_ context.Context, name string, workspaceID *uuid.UUID, def *domain.InjectorDefinition, fields []*domain.InjectorField) error {
 			currentName = name
 			gotWorkspaceID = workspaceID
@@ -655,9 +778,23 @@ func TestInjectorHandler_Update_Success(t *testing.T) {
 }
 
 func TestInjectorHandler_Update_RejectsDuplicateFieldNames(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
-	is := &mockInjectorStore{}
+	is := &mockInjectorStore{
+		findDefinitionByNameFn: func(_ context.Context, name string, workspaceID *uuid.UUID) (*domain.InjectorDefinition, error) {
+			if name != "student" {
+				t.Fatalf("expected lookup for student, got %q", name)
+			}
+			if workspaceID == nil || *workspaceID != ws.ID {
+				t.Fatalf("expected workspace lookup %s, got %v", ws.ID, workspaceID)
+			}
+			return &domain.InjectorDefinition{
+				ID:          uuid.Must(uuid.NewV7()),
+				WorkspaceID: &ws.ID,
+				Name:        name,
+			}, nil
+		},
+	}
 	e, _ := setupInjectorTest(is, ts, wsStore)
 
 	body := `{"name":"student","fields":[{"field_name":"full name","field_type":"text","position":0},{"field_name":"full name","field_type":"text","position":1}]}`
@@ -673,10 +810,10 @@ func TestInjectorHandler_Update_RejectsDuplicateFieldNames(t *testing.T) {
 
 func TestInjectorHandler_GlobalUpdate_Success(t *testing.T) {
 	var (
-		currentName string
+		currentName    string
 		gotWorkspaceID *uuid.UUID
-		updatedDef *domain.InjectorDefinition
-		updatedFields []*domain.InjectorField
+		updatedDef     *domain.InjectorDefinition
+		updatedFields  []*domain.InjectorField
 	)
 
 	is := &mockInjectorStore{

--- a/internal/http/handler/scope_inheritance.go
+++ b/internal/http/handler/scope_inheritance.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/http/response"
+	"github.com/rendis/senda/internal/port"
+	"github.com/rendis/senda/pkg/apperr"
+)
+
+type workspacePolicies struct {
+	AllowWorkspaceLocalTemplates         bool
+	AllowWorkspaceInheritedTemplateForks bool
+	AllowWorkspaceLocalInjectors         bool
+}
+
+func defaultWorkspacePolicies() workspacePolicies {
+	return workspacePolicies{
+		AllowWorkspaceLocalTemplates:         true,
+		AllowWorkspaceInheritedTemplateForks: true,
+		AllowWorkspaceLocalInjectors:         true,
+	}
+}
+
+func effectiveWorkspacePolicies(systemWorkspace *domain.Workspace) workspacePolicies {
+	if systemWorkspace == nil || !systemWorkspace.WorkspacePoliciesInitialized {
+		return defaultWorkspacePolicies()
+	}
+	return workspacePolicies{
+		AllowWorkspaceLocalTemplates:         systemWorkspace.AllowWorkspaceLocalTemplates,
+		AllowWorkspaceInheritedTemplateForks: systemWorkspace.AllowWorkspaceInheritedTemplateForks,
+		AllowWorkspaceLocalInjectors:         systemWorkspace.AllowWorkspaceLocalInjectors,
+	}
+}
+
+func resolveSystemWorkspace(ctx context.Context, current *domain.Workspace, wsStore port.WorkspaceStore) (*domain.Workspace, error) {
+	if current == nil {
+		return nil, nil
+	}
+	if current.IsSystem {
+		return current, nil
+	}
+
+	systemWorkspace, err := wsStore.GetSystemWorkspace(ctx, current.TenantID)
+	if err != nil {
+		if apperr.IsNotFound(err) || errors.Is(err, domain.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return systemWorkspace, nil
+}
+
+func workspaceResolutionChain(ctx context.Context, current *domain.Workspace, wsStore port.WorkspaceStore) ([]uuid.NullUUID, *domain.Workspace, error) {
+	if current == nil {
+		return []uuid.NullUUID{{Valid: false}}, nil, nil
+	}
+
+	systemWorkspace, err := resolveSystemWorkspace(ctx, current, wsStore)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	chain := []uuid.NullUUID{uuidToNullUUID(&current.ID)}
+	if systemWorkspace != nil && systemWorkspace.ID != current.ID {
+		chain = append(chain, uuidToNullUUID(&systemWorkspace.ID))
+	}
+	return chain, systemWorkspace, nil
+}
+
+func resourceOwnerScope(resourceWorkspaceID *uuid.UUID, current *domain.Workspace, system *domain.Workspace) string {
+	if resourceWorkspaceID == nil {
+		return "global"
+	}
+	if current != nil && *resourceWorkspaceID == current.ID {
+		if current.IsSystem {
+			return "system"
+		}
+		return "local"
+	}
+	if system != nil && *resourceWorkspaceID == system.ID {
+		return "system"
+	}
+	return "workspace"
+}
+
+func inheritedFromSystem(resourceWorkspaceID *uuid.UUID, current *domain.Workspace, system *domain.Workspace) bool {
+	if current == nil || current.IsSystem || resourceWorkspaceID == nil || system == nil {
+		return false
+	}
+	return *resourceWorkspaceID == system.ID
+}
+
+func annotateTemplateTypeScope(tt *domain.TemplateType, current *domain.Workspace, system *domain.Workspace) {
+	if tt == nil {
+		return
+	}
+	tt.OwnerScope = resourceOwnerScope(tt.WorkspaceID, current, system)
+	tt.InheritedFromSystem = inheritedFromSystem(tt.WorkspaceID, current, system)
+}
+
+func annotateTemplateScope(tpl *domain.Template, current *domain.Workspace, system *domain.Workspace) {
+	if tpl == nil {
+		return
+	}
+	tpl.OwnerScope = resourceOwnerScope(tpl.WorkspaceID, current, system)
+	tpl.InheritedFromSystem = inheritedFromSystem(tpl.WorkspaceID, current, system)
+}
+
+func annotateInjectorScope(def *domain.InjectorDefinition, current *domain.Workspace, system *domain.Workspace) {
+	if def == nil {
+		return
+	}
+	def.OwnerScope = resourceOwnerScope(def.WorkspaceID, current, system)
+	def.InheritedFromSystem = inheritedFromSystem(def.WorkspaceID, current, system)
+}
+
+func isOwnedByCurrentWorkspace(resourceWorkspaceID *uuid.UUID, current *domain.Workspace) bool {
+	return current != nil && resourceWorkspaceID != nil && *resourceWorkspaceID == current.ID
+}
+
+func templateVisibleInWorkspace(tpl *domain.Template, current *domain.Workspace, system *domain.Workspace) bool {
+	if tpl == nil {
+		return false
+	}
+	if current == nil {
+		return tpl.WorkspaceID == nil
+	}
+	if isOwnedByCurrentWorkspace(tpl.WorkspaceID, current) {
+		return true
+	}
+	return tpl.WorkspaceID != nil && system != nil && *tpl.WorkspaceID == system.ID
+}
+
+func writePolicyForbidden(c *echo.Context, code, message string) error {
+	return response.WriteError(c, 403, code, message)
+}

--- a/internal/http/handler/template.go
+++ b/internal/http/handler/template.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rendis/senda/internal/http/response"
 	"github.com/rendis/senda/internal/port"
 	"github.com/rendis/senda/internal/service"
+	"github.com/rendis/senda/pkg/apperr"
 )
 
 type resolvedTemplateInvalidator interface {
@@ -83,6 +84,15 @@ func (h *TemplateHandler) CreateTemplate(c *echo.Context) error {
 	if err != nil {
 		return mapStoreError(c, err)
 	}
+	if !ws.IsSystem {
+		systemWorkspace, err := resolveSystemWorkspace(c.Request().Context(), ws, h.wsStore)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+		if !effectiveWorkspacePolicies(systemWorkspace).AllowWorkspaceLocalTemplates {
+			return writePolicyForbidden(c, "WORKSPACE_LOCAL_TEMPLATES_DISABLED", "workspace local templates are disabled by tenant policy")
+		}
+	}
 
 	return h.createTemplate(c, &ws.ID)
 }
@@ -126,7 +136,7 @@ func (h *TemplateHandler) ListByTemplateType(c *echo.Context) error {
 		return mapStoreError(c, err)
 	}
 
-	return h.listByTemplateType(c, &ws.ID)
+	return h.listByTemplateType(c, ws)
 }
 
 // ListByTemplateTypeGlobal handles GET /global/template-types/:slug/templates.
@@ -134,30 +144,57 @@ func (h *TemplateHandler) ListByTemplateTypeGlobal(c *echo.Context) error {
 	return h.listByTemplateType(c, nil)
 }
 
-func (h *TemplateHandler) listByTemplateType(c *echo.Context, wsID *uuid.UUID) error {
+func (h *TemplateHandler) listByTemplateType(c *echo.Context, workspace *domain.Workspace) error {
 	slugParam := c.Param("slug")
+	ctx := c.Request().Context()
 
-	tt, err := h.store.FindTypeBySlugInScope(c.Request().Context(), slugParam, wsID)
+	if workspace == nil {
+		tt, err := h.store.FindTypeBySlugInScope(ctx, slugParam, nil)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+
+		opts := pagination.ParseListOptions(c)
+		templates, nextCursor, err := h.svc.ListByType(ctx, tt.ID, nil, opts)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+
+		items := make([]response.TemplateResponse, len(templates))
+		for i, tpl := range templates {
+			items[i] = response.NewTemplateResponse(tpl)
+		}
+
+		return c.JSON(http.StatusOK, response.TemplateListResponse{
+			Items:      items,
+			NextCursor: nextCursor,
+			HasMore:    nextCursor != "",
+		})
+	}
+
+	chain, systemWorkspace, err := workspaceResolutionChain(ctx, workspace, h.wsStore)
 	if err != nil {
 		return mapStoreError(c, err)
 	}
 
-	opts := pagination.ParseListOptions(c)
-
-	templates, nextCursor, err := h.svc.ListByType(c.Request().Context(), tt.ID, wsID, opts)
+	tt, err := h.store.GetTypeBySlug(ctx, slugParam, chain)
 	if err != nil {
 		return mapStoreError(c, err)
 	}
+	annotateTemplateTypeScope(tt, workspace, systemWorkspace)
 
-	items := make([]response.TemplateResponse, len(templates))
-	for i, tpl := range templates {
-		items[i] = response.NewTemplateResponse(tpl)
+	tpl, err := h.store.ResolveTemplate(ctx, tt.ID, chain)
+	if err != nil {
+		if errors.Is(err, domain.ErrTemplateNotFound) || errors.Is(err, domain.ErrNotFound) || apperr.IsNotFound(err) {
+			return c.JSON(http.StatusOK, response.TemplateListResponse{Items: []response.TemplateResponse{}, HasMore: false})
+		}
+		return mapStoreError(c, err)
 	}
+	annotateTemplateScope(tpl, workspace, systemWorkspace)
 
 	return c.JSON(http.StatusOK, response.TemplateListResponse{
-		Items:      items,
-		NextCursor: nextCursor,
-		HasMore:    nextCursor != "",
+		Items:   []response.TemplateResponse{response.NewTemplateResponse(tpl)},
+		HasMore: false,
 	})
 }
 
@@ -167,7 +204,7 @@ func (h *TemplateHandler) DisableTemplate(c *echo.Context) error {
 	if err != nil {
 		return mapStoreError(c, err)
 	}
-	return h.setTemplateDisabled(c, &ws.ID, true)
+	return h.setTemplateDisabled(c, ws, true)
 }
 
 // EnableTemplate handles POST .../templates/:template_id/enable.
@@ -176,7 +213,7 @@ func (h *TemplateHandler) EnableTemplate(c *echo.Context) error {
 	if err != nil {
 		return mapStoreError(c, err)
 	}
-	return h.setTemplateDisabled(c, &ws.ID, false)
+	return h.setTemplateDisabled(c, ws, false)
 }
 
 // DisableTemplateGlobal handles POST /global/templates/:template_id/disable.
@@ -189,10 +226,28 @@ func (h *TemplateHandler) EnableTemplateGlobal(c *echo.Context) error {
 	return h.setTemplateDisabled(c, nil, false)
 }
 
-func (h *TemplateHandler) setTemplateDisabled(c *echo.Context, wsID *uuid.UUID, disabled bool) error {
+func (h *TemplateHandler) setTemplateDisabled(c *echo.Context, workspace *domain.Workspace, disabled bool) error {
 	templateID, err := uuid.Parse(c.Param("template_id"))
 	if err != nil {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
+	}
+
+	var wsID *uuid.UUID
+	if workspace != nil {
+		wsID = &workspace.ID
+		tpl, _, policies, err := h.loadWorkspaceTemplateAccess(c.Request().Context(), workspace, templateID)
+		if err != nil {
+			return mapTemplateError(c, err)
+		}
+		if tpl.IsFork {
+			if !policies.AllowWorkspaceInheritedTemplateForks {
+				return writePolicyForbidden(c, "WORKSPACE_INHERITED_TEMPLATE_FORKS_DISABLED", "workspace inherited template forks are disabled by tenant policy")
+			}
+		} else {
+			if !policies.AllowWorkspaceLocalTemplates {
+				return writePolicyForbidden(c, "WORKSPACE_LOCAL_TEMPLATES_DISABLED", "workspace local templates are disabled by tenant policy")
+			}
+		}
 	}
 
 	if disabled {
@@ -237,6 +292,18 @@ func (h *TemplateHandler) GetVersion(c *echo.Context) error {
 
 // UpdateVersion handles PUT .../templates/:template_id/versions/:version_id.
 func (h *TemplateHandler) UpdateVersion(c *echo.Context) error {
+	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+	templateID, err := uuid.Parse(c.Param("template_id"))
+	if err != nil {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
+	}
+	if _, _, err := h.requireMutableWorkspaceTemplate(c.Request().Context(), ws, templateID); err != nil {
+		return mapTemplateError(c, err)
+	}
+
 	versionID, err := uuid.Parse(c.Param("version_id"))
 	if err != nil {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid version ID")
@@ -254,6 +321,9 @@ func (h *TemplateHandler) UpdateVersion(c *echo.Context) error {
 
 	if ver.Status != domain.VersionStatusDraft {
 		return response.WriteError(c, http.StatusConflict, "CONFLICT", "only draft versions can be updated")
+	}
+	if ver.TemplateID != templateID {
+		return response.WriteError(c, http.StatusNotFound, "NOT_FOUND", "resource not found")
 	}
 
 	if req.Subject != "" {
@@ -510,9 +580,26 @@ func mapTestSendError(c *echo.Context, err error) error {
 
 // DeleteTemplate handles DELETE .../templates/:template_id.
 func (h *TemplateHandler) DeleteTemplate(c *echo.Context) error {
+	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
 	templateID, err := uuid.Parse(c.Param("template_id"))
 	if err != nil {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
+	}
+	tpl, _, policies, err := h.loadWorkspaceTemplateAccess(c.Request().Context(), ws, templateID)
+	if err != nil {
+		return mapTemplateError(c, err)
+	}
+	if tpl.IsFork {
+		if !policies.AllowWorkspaceInheritedTemplateForks {
+			return writePolicyForbidden(c, "WORKSPACE_INHERITED_TEMPLATE_FORKS_DISABLED", "workspace inherited template forks are disabled by tenant policy")
+		}
+	} else {
+		if !policies.AllowWorkspaceLocalTemplates {
+			return writePolicyForbidden(c, "WORKSPACE_LOCAL_TEMPLATES_DISABLED", "workspace local templates are disabled by tenant policy")
+		}
 	}
 	if err := h.svc.DeleteTemplate(c.Request().Context(), templateID); err != nil {
 		if errors.Is(err, domain.ErrHasPublishedVersion) {
@@ -525,6 +612,18 @@ func (h *TemplateHandler) DeleteTemplate(c *echo.Context) error {
 
 // DeleteVersion handles DELETE .../templates/:template_id/versions/:version_id.
 func (h *TemplateHandler) DeleteVersion(c *echo.Context) error {
+	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+	templateID, err := uuid.Parse(c.Param("template_id"))
+	if err != nil {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
+	}
+	if _, _, err := h.requireMutableWorkspaceTemplate(c.Request().Context(), ws, templateID); err != nil {
+		return mapTemplateError(c, err)
+	}
+
 	versionID, err := uuid.Parse(c.Param("version_id"))
 	if err != nil {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid version ID")
@@ -555,9 +654,16 @@ func (h *TemplateHandler) ListVersions(c *echo.Context) error {
 
 // CreateVersion handles POST .../templates/:template_id/versions.
 func (h *TemplateHandler) CreateVersion(c *echo.Context) error {
+	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
 	templateID, err := uuid.Parse(c.Param("template_id"))
 	if err != nil {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
+	}
+	if _, _, err := h.requireMutableWorkspaceTemplate(c.Request().Context(), ws, templateID); err != nil {
+		return mapTemplateError(c, err)
 	}
 
 	var req request.CreateVersionRequest
@@ -604,6 +710,18 @@ func (h *TemplateHandler) CreateVersion(c *echo.Context) error {
 
 // PublishVersion handles POST .../templates/:template_id/versions/:version_id/publish.
 func (h *TemplateHandler) PublishVersion(c *echo.Context) error {
+	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+	templateID, err := uuid.Parse(c.Param("template_id"))
+	if err != nil {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
+	}
+	if _, _, err := h.requireMutableWorkspaceTemplate(c.Request().Context(), ws, templateID); err != nil {
+		return mapTemplateError(c, err)
+	}
+
 	versionID, err := uuid.Parse(c.Param("version_id"))
 	if err != nil {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid version ID")
@@ -622,7 +740,7 @@ func (h *TemplateHandler) CloneVersion(c *echo.Context) error {
 	if err != nil {
 		return mapStoreError(c, err)
 	}
-	return h.cloneVersion(c, &ws.ID)
+	return h.cloneVersion(c, ws)
 }
 
 // CloneVersionGlobal handles POST /global/templates/:template_id/versions/:version_id/clone.
@@ -630,7 +748,7 @@ func (h *TemplateHandler) CloneVersionGlobal(c *echo.Context) error {
 	return h.cloneVersion(c, nil)
 }
 
-func (h *TemplateHandler) cloneVersion(c *echo.Context, wsID *uuid.UUID) error {
+func (h *TemplateHandler) cloneVersion(c *echo.Context, workspace *domain.Workspace) error {
 	templateID, err := uuid.Parse(c.Param("template_id"))
 	if err != nil {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
@@ -641,6 +759,14 @@ func (h *TemplateHandler) cloneVersion(c *echo.Context, wsID *uuid.UUID) error {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid version ID")
 	}
 
+	var wsID *uuid.UUID
+	if workspace != nil {
+		wsID = &workspace.ID
+		if _, _, err := h.requireMutableWorkspaceTemplate(c.Request().Context(), workspace, templateID); err != nil {
+			return mapTemplateError(c, err)
+		}
+	}
+
 	cloned, err := h.svc.CloneVersion(c.Request().Context(), templateID, versionID, wsID, nil)
 	if err != nil {
 		return mapTemplateError(c, err)
@@ -649,8 +775,53 @@ func (h *TemplateHandler) cloneVersion(c *echo.Context, wsID *uuid.UUID) error {
 	return c.JSON(http.StatusCreated, response.NewTemplateVersionResponse(cloned))
 }
 
+// ForkTemplate handles POST .../templates/:template_id/fork.
+func (h *TemplateHandler) ForkTemplate(c *echo.Context) error {
+	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+
+	templateID, err := uuid.Parse(c.Param("template_id"))
+	if err != nil {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
+	}
+
+	tpl, _, policies, err := h.loadWorkspaceTemplateAccess(c.Request().Context(), ws, templateID)
+	if err != nil {
+		return mapTemplateError(c, err)
+	}
+	if isOwnedByCurrentWorkspace(tpl.WorkspaceID, ws) {
+		return response.WriteError(c, http.StatusConflict, "TEMPLATE_ALREADY_LOCAL", "template already belongs to this workspace")
+	}
+	if !policies.AllowWorkspaceInheritedTemplateForks {
+		return writePolicyForbidden(c, "WORKSPACE_INHERITED_TEMPLATE_FORKS_DISABLED", "workspace inherited template forks are disabled by tenant policy")
+	}
+
+	forked, err := h.svc.ForkTemplate(c.Request().Context(), templateID, ws.ID, nil)
+	if err != nil {
+		return mapTemplateError(c, err)
+	}
+	annotateTemplateScope(forked, ws, nil)
+	h.invalidateResolvedTemplates(c.Request().Context(), &ws.ID)
+
+	return c.JSON(http.StatusCreated, response.NewTemplateResponse(forked))
+}
+
 // SetLocale handles POST .../templates/:template_id/versions/:version_id/locales.
 func (h *TemplateHandler) SetLocale(c *echo.Context) error { //nolint:dupl // structurally similar to UpdateLocale
+	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+	templateID, err := uuid.Parse(c.Param("template_id"))
+	if err != nil {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
+	}
+	if _, _, err := h.requireMutableWorkspaceTemplate(c.Request().Context(), ws, templateID); err != nil {
+		return mapTemplateError(c, err)
+	}
+
 	versionID, err := uuid.Parse(c.Param("version_id"))
 	if err != nil {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid version ID")
@@ -687,6 +858,18 @@ func (h *TemplateHandler) SetLocale(c *echo.Context) error { //nolint:dupl // st
 
 // UpdateLocale handles PUT .../templates/:template_id/versions/:version_id/locales/:locale.
 func (h *TemplateHandler) UpdateLocale(c *echo.Context) error { //nolint:dupl // structurally similar to SetLocale
+	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+	templateID, err := uuid.Parse(c.Param("template_id"))
+	if err != nil {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
+	}
+	if _, _, err := h.requireMutableWorkspaceTemplate(c.Request().Context(), ws, templateID); err != nil {
+		return mapTemplateError(c, err)
+	}
+
 	versionID, err := uuid.Parse(c.Param("version_id"))
 	if err != nil {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid version ID")
@@ -763,6 +946,18 @@ func (h *TemplateHandler) ListLocales(c *echo.Context) error {
 
 // DeleteLocale handles DELETE .../templates/:template_id/versions/:version_id/locales/:locale.
 func (h *TemplateHandler) DeleteLocale(c *echo.Context) error {
+	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+	templateID, err := uuid.Parse(c.Param("template_id"))
+	if err != nil {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid template ID")
+	}
+	if _, _, err := h.requireMutableWorkspaceTemplate(c.Request().Context(), ws, templateID); err != nil {
+		return mapTemplateError(c, err)
+	}
+
 	versionID, err := uuid.Parse(c.Param("version_id"))
 	if err != nil {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid version ID")
@@ -778,6 +973,52 @@ func (h *TemplateHandler) DeleteLocale(c *echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+func (h *TemplateHandler) loadWorkspaceTemplateAccess(
+	ctx context.Context,
+	workspace *domain.Workspace,
+	templateID uuid.UUID,
+) (*domain.Template, *domain.Workspace, workspacePolicies, error) {
+	systemWorkspace, err := resolveSystemWorkspace(ctx, workspace, h.wsStore)
+	if err != nil {
+		return nil, nil, workspacePolicies{}, err
+	}
+
+	tpl, err := h.store.GetTemplateByID(ctx, templateID)
+	if err != nil {
+		return nil, nil, workspacePolicies{}, err
+	}
+	if !templateVisibleInWorkspace(tpl, workspace, systemWorkspace) {
+		return nil, systemWorkspace, workspacePolicies{}, apperr.NotFound("template not found in workspace scope")
+	}
+	annotateTemplateScope(tpl, workspace, systemWorkspace)
+
+	return tpl, systemWorkspace, effectiveWorkspacePolicies(systemWorkspace), nil
+}
+
+func (h *TemplateHandler) requireMutableWorkspaceTemplate(
+	ctx context.Context,
+	workspace *domain.Workspace,
+	templateID uuid.UUID,
+) (*domain.Template, workspacePolicies, error) {
+	tpl, systemWorkspace, policies, err := h.loadWorkspaceTemplateAccess(ctx, workspace, templateID)
+	if err != nil {
+		return nil, workspacePolicies{}, err
+	}
+	if !isOwnedByCurrentWorkspace(tpl.WorkspaceID, workspace) {
+		return nil, workspacePolicies{}, apperr.Forbidden("inherited templates are read-only in workspace scope")
+	}
+	if tpl.IsFork {
+		if !policies.AllowWorkspaceInheritedTemplateForks {
+			return nil, workspacePolicies{}, apperr.Forbidden("workspace inherited template forks are disabled by tenant policy")
+		}
+	} else if !workspace.IsSystem && !policies.AllowWorkspaceLocalTemplates {
+		return nil, workspacePolicies{}, apperr.Forbidden("workspace local templates are disabled by tenant policy")
+	}
+
+	annotateTemplateScope(tpl, workspace, systemWorkspace)
+	return tpl, policies, nil
 }
 
 // mapTemplateError maps template-specific domain errors to HTTP responses.

--- a/internal/http/handler/template_test.go
+++ b/internal/http/handler/template_test.go
@@ -106,9 +106,12 @@ func setupTemplateTestWithOptions(
 	base := "/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code"
 
 	e.POST(base+"/templates", h.CreateTemplate)
+	e.GET(base+"/template-types/:slug/templates", h.ListByTemplateType)
+	e.POST(base+"/templates/:template_id/fork", h.ForkTemplate)
 	e.POST("/api/v1/manage/global/templates", h.CreateTemplateGlobal)
 	e.GET(base+"/templates/:template_id/versions", h.ListVersions)
 	e.POST(base+"/templates/:template_id/versions", h.CreateVersion)
+	e.PUT(base+"/templates/:template_id/versions/:version_id", h.UpdateVersion)
 	e.POST(base+"/templates/:template_id/versions/:version_id/clone", h.CloneVersion)
 	e.POST(base+"/templates/:template_id/versions/:version_id/publish", h.PublishVersion)
 	e.POST(base+"/templates/:template_id/versions/:version_id/locales/:locale", h.SetLocale)
@@ -125,6 +128,14 @@ func setupTemplateTestWithOptions(
 	e.POST("/api/v1/manage/global/templates/:template_id/enable", h.EnableTemplateGlobal)
 
 	return e, h
+}
+
+func workspaceOwnedTemplate(templateID, workspaceID uuid.UUID) *domain.Template {
+	return &domain.Template{
+		ID:             templateID,
+		TemplateTypeID: uuid.Must(uuid.NewV7()),
+		WorkspaceID:    &workspaceID,
+	}
 }
 
 // --- Tests ---
@@ -215,6 +226,12 @@ func TestTemplateHandler_DisableTemplate_InvalidatesResolvedTemplateCache(t *tes
 	invalidatedWorkspace := uuid.Nil
 
 	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
 		setDisabledFn: func(_ context.Context, gotTemplateID uuid.UUID, gotWSID *uuid.UUID, disabled bool) error {
 			if gotTemplateID != templateID {
 				t.Fatalf("expected template ID %s, got %s", templateID, gotTemplateID)
@@ -265,11 +282,17 @@ func TestTemplateHandler_CreateTemplate_InvalidTypeID(t *testing.T) {
 }
 
 func TestTemplateHandler_CreateVersion_Success(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
 	templateID := uuid.Must(uuid.NewV7())
 	var created *domain.TemplateVersion
 	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
 		createVersionFn: func(_ context.Context, ver *domain.TemplateVersion) error {
 			ver.VersionNumber = 1
 			created = ver
@@ -303,11 +326,18 @@ func TestTemplateHandler_CreateVersion_Success(t *testing.T) {
 }
 
 func TestTemplateHandler_CreateVersion_MissingRequired(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
-
-	e, _ := setupTemplateTest(&mockTemplateStore{}, &mockTemplateCompiler{}, ts, wsStore)
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
 	templateID := uuid.Must(uuid.NewV7())
+	e, _ := setupTemplateTest(&mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
+	}, &mockTemplateCompiler{}, ts, wsStore)
+
 	body := `{"preview_text":"Preview only"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -371,13 +401,285 @@ func TestTemplateHandler_ListVersions_Success(t *testing.T) {
 	}
 }
 
+func TestTemplateHandler_ListByTemplateType_ResolvesVisibleSystemTemplateInWorkspace(t *testing.T) {
+	tenant, _, ts, wsStore := testTenantAndWorkspace()
+	systemWorkspace := uuid.Must(uuid.NewV7())
+	typeID := uuid.Must(uuid.NewV7())
+	templateID := uuid.Must(uuid.NewV7())
+
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+		if tenantID != tenant.ID {
+			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
+		}
+		return &domain.Workspace{
+			ID:       systemWorkspace,
+			TenantID: tenant.ID,
+			Code:     "_system",
+			Name:     "Default",
+			IsSystem: true,
+		}, nil
+	}
+
+	store := &mockTemplateStore{
+		getTypeBySlugFn: func(_ context.Context, slug string, chain []uuid.NullUUID) (*domain.TemplateType, error) {
+			if slug != "welcome-email" {
+				t.Fatalf("unexpected slug %q", slug)
+			}
+			if len(chain) != 2 {
+				t.Fatalf("expected 2 scopes, got %d", len(chain))
+			}
+			return &domain.TemplateType{
+				ID:          typeID,
+				WorkspaceID: &systemWorkspace,
+				Slug:        "welcome-email",
+				Name:        "Welcome",
+			}, nil
+		},
+		resolveTemplateFn: func(_ context.Context, gotTypeID uuid.UUID, chain []uuid.NullUUID) (*domain.Template, error) {
+			if gotTypeID != typeID {
+				t.Fatalf("expected type id %s, got %s", typeID, gotTypeID)
+			}
+			return &domain.Template{
+				ID:             templateID,
+				TemplateTypeID: typeID,
+				WorkspaceID:    &systemWorkspace,
+			}, nil
+		},
+	}
+
+	e, _ := setupTemplateTest(store, &mockTemplateCompiler{}, ts, wsStore)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/manage/tenants/acme/workspaces/default/template-types/welcome-email/templates", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp response.TemplateListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 visible template, got %d", len(resp.Items))
+	}
+	if !resp.Items[0].InheritedFromSystem {
+		t.Fatal("expected template to be marked as inherited from system")
+	}
+	if resp.Items[0].OwnerScope != "system" {
+		t.Fatalf("expected owner_scope system, got %q", resp.Items[0].OwnerScope)
+	}
+}
+
+func TestTemplateHandler_CreateVersion_BlocksInheritedSystemTemplateInWorkspace(t *testing.T) {
+	tenant, _, ts, wsStore := testTenantAndWorkspace()
+	systemWorkspace := uuid.Must(uuid.NewV7())
+	templateID := uuid.Must(uuid.NewV7())
+
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+		if tenantID != tenant.ID {
+			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
+		}
+		return &domain.Workspace{
+			ID:       systemWorkspace,
+			TenantID: tenant.ID,
+			Code:     "_system",
+			Name:     "Default",
+			IsSystem: true,
+		}, nil
+	}
+
+	createCalled := false
+	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template id %s, got %s", templateID, id)
+			}
+			return &domain.Template{
+				ID:             templateID,
+				TemplateTypeID: uuid.Must(uuid.NewV7()),
+				WorkspaceID:    &systemWorkspace,
+			}, nil
+		},
+		createVersionFn: func(_ context.Context, _ *domain.TemplateVersion) error {
+			createCalled = true
+			return nil
+		},
+	}
+
+	e, _ := setupTemplateTest(store, &mockTemplateCompiler{}, ts, wsStore)
+
+	body := `{"subject":"Welcome","from_name":"Acme","body_mjml":"<mjml></mjml>","default_locale":"en"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if createCalled {
+		t.Fatal("expected inherited template version creation to be blocked")
+	}
+}
+
+func TestTemplateHandler_UpdateVersion_BlocksInheritedSystemTemplateInWorkspace(t *testing.T) {
+	tenant, _, ts, wsStore := testTenantAndWorkspace()
+	systemWorkspace := uuid.Must(uuid.NewV7())
+	templateID := uuid.Must(uuid.NewV7())
+	versionID := uuid.Must(uuid.NewV7())
+
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+		if tenantID != tenant.ID {
+			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
+		}
+		return &domain.Workspace{
+			ID:       systemWorkspace,
+			TenantID: tenant.ID,
+			Code:     "_system",
+			Name:     "Default",
+			IsSystem: true,
+		}, nil
+	}
+
+	updateCalled := false
+	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template id %s, got %s", templateID, id)
+			}
+			return &domain.Template{
+				ID:             templateID,
+				TemplateTypeID: uuid.Must(uuid.NewV7()),
+				WorkspaceID:    &systemWorkspace,
+			}, nil
+		},
+		getVersionByIDFn: func(_ context.Context, id uuid.UUID) (*domain.TemplateVersion, error) {
+			if id != versionID {
+				t.Fatalf("expected version id %s, got %s", versionID, id)
+			}
+			return &domain.TemplateVersion{
+				ID:         versionID,
+				TemplateID: templateID,
+				Status:     domain.VersionStatusDraft,
+			}, nil
+		},
+		updateVersionFn: func(_ context.Context, _ *domain.TemplateVersion) error {
+			updateCalled = true
+			return nil
+		},
+	}
+
+	e, _ := setupTemplateTest(store, &mockTemplateCompiler{}, ts, wsStore)
+
+	body := `{"subject":"Updated subject"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions/"+versionID.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if updateCalled {
+		t.Fatal("expected inherited template version updates to be blocked")
+	}
+}
+
+func TestTemplateHandler_ForkTemplate_Success(t *testing.T) {
+	tenant, ws, ts, wsStore := testTenantAndWorkspace()
+	templateID := uuid.Must(uuid.NewV7())
+	forkedTemplateID := uuid.Must(uuid.NewV7())
+	systemWorkspace := uuid.Must(uuid.NewV7())
+	invalidatedWorkspace := uuid.Nil
+
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+		if tenantID != tenant.ID {
+			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
+		}
+		return &domain.Workspace{
+			ID:       systemWorkspace,
+			TenantID: tenant.ID,
+			Code:     "_system",
+			Name:     "Default",
+			IsSystem: true,
+		}, nil
+	}
+
+	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template %s, got %s", templateID, id)
+			}
+			return &domain.Template{
+				ID:             templateID,
+				TemplateTypeID: uuid.Must(uuid.NewV7()),
+				WorkspaceID:    &systemWorkspace,
+			}, nil
+		},
+		forkTemplateFn: func(_ context.Context, sourceTemplateID uuid.UUID, workspaceID uuid.UUID, createdBy *uuid.UUID) (*domain.Template, error) {
+			if sourceTemplateID != templateID {
+				t.Fatalf("expected source template %s, got %s", templateID, sourceTemplateID)
+			}
+			if workspaceID != ws.ID {
+				t.Fatalf("expected workspace %s, got %s", ws.ID, workspaceID)
+			}
+			if createdBy != nil {
+				t.Fatalf("expected nil createdBy in handler test, got %s", *createdBy)
+			}
+			return &domain.Template{
+				ID:               forkedTemplateID,
+				TemplateTypeID:   uuid.Must(uuid.NewV7()),
+				WorkspaceID:      &workspaceID,
+				IsFork:           true,
+				OriginTemplateID: &sourceTemplateID,
+			}, nil
+		},
+	}
+
+	e, _ := setupTemplateTestWithInvalidator(store, &mockTemplateCompiler{}, ts, wsStore, &mockResolvedTemplateInvalidator{
+		invalidateResolvedTemplatesFn: func(_ context.Context, workspaceID uuid.UUID) {
+			invalidatedWorkspace = workspaceID
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/fork", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp response.TemplateResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !resp.IsFork {
+		t.Fatal("expected response template to be marked as fork")
+	}
+	if resp.OriginTemplateID == nil || *resp.OriginTemplateID != templateID.String() {
+		t.Fatalf("expected origin template %s, got %#v", templateID, resp.OriginTemplateID)
+	}
+	if invalidatedWorkspace != ws.ID {
+		t.Fatalf("expected resolved template cache invalidation for workspace %s, got %s", ws.ID, invalidatedWorkspace)
+	}
+}
+
 func TestTemplateHandler_PublishVersion_Success(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
 	versionID := uuid.Must(uuid.NewV7())
 	templateID := uuid.Must(uuid.NewV7())
 	var publishedID uuid.UUID
 	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
 		publishFn: func(_ context.Context, id uuid.UUID) error {
 			publishedID = id
 			return nil
@@ -399,11 +701,18 @@ func TestTemplateHandler_PublishVersion_Success(t *testing.T) {
 }
 
 func TestTemplateHandler_PublishVersion_InvalidVersionID(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
-
-	e, _ := setupTemplateTest(&mockTemplateStore{}, &mockTemplateCompiler{}, ts, wsStore)
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
 	templateID := uuid.Must(uuid.NewV7())
+	e, _ := setupTemplateTest(&mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
+	}, &mockTemplateCompiler{}, ts, wsStore)
+
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions/bad-id/publish", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
@@ -414,9 +723,16 @@ func TestTemplateHandler_PublishVersion_InvalidVersionID(t *testing.T) {
 }
 
 func TestTemplateHandler_PublishVersion_NotFound(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
+	templateID := uuid.Must(uuid.NewV7())
 	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
 		publishFn: func(_ context.Context, _ uuid.UUID) error {
 			return domain.ErrNotFound
 		},
@@ -424,7 +740,6 @@ func TestTemplateHandler_PublishVersion_NotFound(t *testing.T) {
 
 	e, _ := setupTemplateTest(store, &mockTemplateCompiler{}, ts, wsStore)
 
-	templateID := uuid.Must(uuid.NewV7())
 	versionID := uuid.Must(uuid.NewV7())
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions/"+versionID.String()+"/publish", nil)
 	rec := httptest.NewRecorder()
@@ -531,6 +846,12 @@ func TestTemplateHandler_DisableTemplate_Success(t *testing.T) {
 	)
 
 	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
 		setDisabledFn: func(_ context.Context, id uuid.UUID, scope *uuid.UUID, disabled bool) error {
 			gotTemplateID = id
 			gotScope = scope
@@ -570,6 +891,12 @@ func TestTemplateHandler_DisableTemplate_WithoutInvalidator(t *testing.T) {
 	)
 
 	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
 		setDisabledFn: func(_ context.Context, id uuid.UUID, scope *uuid.UUID, disabled bool) error {
 			gotTemplateID = id
 			gotScope = scope
@@ -599,11 +926,17 @@ func TestTemplateHandler_DisableTemplate_WithoutInvalidator(t *testing.T) {
 }
 
 func TestTemplateHandler_EnableTemplate_Success(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
 	templateID := uuid.Must(uuid.NewV7())
 	var gotDisabled bool
 	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
 		setDisabledFn: func(_ context.Context, _ uuid.UUID, _ *uuid.UUID, disabled bool) error {
 			gotDisabled = disabled
 			return nil
@@ -649,10 +982,17 @@ func TestTemplateHandler_DisableTemplateGlobal_Success(t *testing.T) {
 }
 
 func TestTemplateHandler_SetLocale_Success(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
 	var set *domain.TemplateVersionLocale
+	templateID := uuid.Must(uuid.NewV7())
 	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
 		setLocaleFn: func(_ context.Context, loc *domain.TemplateVersionLocale) error {
 			set = loc
 			return nil
@@ -661,7 +1001,6 @@ func TestTemplateHandler_SetLocale_Success(t *testing.T) {
 
 	e, _ := setupTemplateTest(store, &mockTemplateCompiler{}, ts, wsStore)
 
-	templateID := uuid.Must(uuid.NewV7())
 	versionID := uuid.Must(uuid.NewV7())
 	body := `{"subject":"Bienvenido","preview_text":"Hola!"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions/"+versionID.String()+"/locales/es", strings.NewReader(body))
@@ -684,9 +1023,16 @@ func TestTemplateHandler_SetLocale_Success(t *testing.T) {
 }
 
 func TestTemplateHandler_UpdateLocale_Success(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
+	templateID := uuid.Must(uuid.NewV7())
 	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
 		setLocaleFn: func(_ context.Context, _ *domain.TemplateVersionLocale) error {
 			return nil
 		},
@@ -694,7 +1040,6 @@ func TestTemplateHandler_UpdateLocale_Success(t *testing.T) {
 
 	e, _ := setupTemplateTest(store, &mockTemplateCompiler{}, ts, wsStore)
 
-	templateID := uuid.Must(uuid.NewV7())
 	versionID := uuid.Must(uuid.NewV7())
 	body := `{"subject":"Updated Subject"}`
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions/"+versionID.String()+"/locales/fr", strings.NewReader(body))
@@ -772,11 +1117,18 @@ func TestTemplateHandler_GetLocale_NotFound(t *testing.T) {
 }
 
 func TestTemplateHandler_DeleteLocale_Success(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
-
-	e, _ := setupTemplateTest(&mockTemplateStore{}, &mockTemplateCompiler{}, ts, wsStore)
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
 	templateID := uuid.Must(uuid.NewV7())
+	e, _ := setupTemplateTest(&mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
+	}, &mockTemplateCompiler{}, ts, wsStore)
+
 	versionID := uuid.Must(uuid.NewV7())
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions/"+versionID.String()+"/locales/es", nil)
 	rec := httptest.NewRecorder()
@@ -788,16 +1140,22 @@ func TestTemplateHandler_DeleteLocale_Success(t *testing.T) {
 }
 
 func TestTemplateHandler_DeleteLocale_NotFound(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
+	templateID := uuid.Must(uuid.NewV7())
 	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
 		deleteLocaleFn: func(_ context.Context, _ uuid.UUID, _ string) error {
 			return domain.ErrNotFound
 		},
 	}
 	e, _ := setupTemplateTest(store, &mockTemplateCompiler{}, ts, wsStore)
 
-	templateID := uuid.Must(uuid.NewV7())
 	versionID := uuid.Must(uuid.NewV7())
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions/"+versionID.String()+"/locales/zh", nil)
 	rec := httptest.NewRecorder()
@@ -905,11 +1263,18 @@ func TestTemplateHandler_PreviewMJML_CompilerError(t *testing.T) {
 }
 
 func TestTemplateHandler_SetLocale_InvalidVersionID(t *testing.T) {
-	_, _, ts, wsStore := testTenantAndWorkspace()
-
-	e, _ := setupTemplateTest(&mockTemplateStore{}, &mockTemplateCompiler{}, ts, wsStore)
+	_, ws, ts, wsStore := testTenantAndWorkspace()
 
 	templateID := uuid.Must(uuid.NewV7())
+	e, _ := setupTemplateTest(&mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return workspaceOwnedTemplate(templateID, ws.ID), nil
+		},
+	}, &mockTemplateCompiler{}, ts, wsStore)
+
 	body := `{"subject":"Test"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/versions/not-valid/locales/en", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/http/handler/template_type.go
+++ b/internal/http/handler/template_type.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rendis/senda/internal/http/response"
 	"github.com/rendis/senda/internal/port"
 	"github.com/rendis/senda/internal/service"
+	"github.com/rendis/senda/pkg/apperr"
 	"github.com/rendis/senda/pkg/slug"
 )
 
@@ -46,6 +47,15 @@ func (h *TemplateTypeHandler) Create(c *echo.Context) error {
 	ws, err := resolveWorkspace(c, h.tsStore, h.wsStore)
 	if err != nil {
 		return mapStoreError(c, err)
+	}
+	if !ws.IsSystem {
+		systemWorkspace, err := resolveSystemWorkspace(c.Request().Context(), ws, h.wsStore)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+		if !effectiveWorkspacePolicies(systemWorkspace).AllowWorkspaceLocalTemplates {
+			return writePolicyForbidden(c, "WORKSPACE_LOCAL_TEMPLATES_DISABLED", "workspace local templates are disabled by tenant policy")
+		}
 	}
 
 	return h.create(c, ws)
@@ -123,7 +133,7 @@ func (h *TemplateTypeHandler) Delete(c *echo.Context) error {
 	if err != nil {
 		return mapStoreError(c, err)
 	}
-	return h.deleteType(c, &ws.ID)
+	return h.deleteType(c, ws)
 }
 
 // DeleteGlobal handles DELETE /global/template-types/:slug.
@@ -131,19 +141,44 @@ func (h *TemplateTypeHandler) DeleteGlobal(c *echo.Context) error {
 	return h.deleteType(c, nil)
 }
 
-func (h *TemplateTypeHandler) deleteType(c *echo.Context, workspaceID *uuid.UUID) error {
+func (h *TemplateTypeHandler) deleteType(c *echo.Context, workspace *domain.Workspace) error {
 	slugParam := c.Param("slug")
+	ctx := c.Request().Context()
 
-	tt, err := h.svc.FindBySlugInScope(c.Request().Context(), slugParam, workspaceID)
+	var (
+		tt              *domain.TemplateType
+		workspaceID     *uuid.UUID
+		systemWorkspace *domain.Workspace
+		err             error
+	)
+	if workspace == nil {
+		tt, err = h.svc.FindBySlugInScope(ctx, slugParam, nil)
+	} else {
+		workspaceID = &workspace.ID
+		var chain []uuid.NullUUID
+		chain, systemWorkspace, err = workspaceResolutionChain(ctx, workspace, h.wsStore)
+		if err == nil {
+			tt, err = h.svc.GetBySlug(ctx, slugParam, chain)
+		}
+	}
 	if err != nil {
 		return mapStoreError(c, err)
 	}
-	if !sameScope(tt.WorkspaceID, workspaceID) {
-		return response.WriteError(c, http.StatusNotFound, "NOT_FOUND", "resource not found")
+	if workspace != nil {
+		annotateTemplateTypeScope(tt, workspace, systemWorkspace)
+		if !isOwnedByCurrentWorkspace(tt.WorkspaceID, workspace) {
+			return writePolicyForbidden(c, "READ_ONLY_INHERITED_TEMPLATE_TYPE", "inherited template types are read-only in workspace scope")
+		}
+		if !workspace.IsSystem && !effectiveWorkspacePolicies(systemWorkspace).AllowWorkspaceLocalTemplates {
+			return writePolicyForbidden(c, "WORKSPACE_LOCAL_TEMPLATES_DISABLED", "workspace local templates are disabled by tenant policy")
+		}
 	}
 
-	if err := h.svc.DeleteType(c.Request().Context(), tt.ID); err != nil {
+	if err := h.svc.DeleteType(ctx, tt.ID); err != nil {
 		return mapStoreError(c, err)
+	}
+	if workspace != nil {
+		workspaceID = &workspace.ID
 	}
 	h.invalidateResolvedTemplates(c.Request().Context(), workspaceID)
 
@@ -165,18 +200,12 @@ func (h *TemplateTypeHandler) UpdateGlobal(c *echo.Context) error {
 }
 
 func (h *TemplateTypeHandler) update(c *echo.Context, workspace *domain.Workspace) error {
-	var workspaceID *uuid.UUID
-	if workspace != nil {
-		workspaceID = &workspace.ID
-	}
 	slugParam := c.Param("slug")
+	ctx := c.Request().Context()
 
-	tt, err := h.svc.FindBySlugInScope(c.Request().Context(), slugParam, workspaceID)
+	tt, _, err := h.loadTemplateTypeForUpdate(ctx, workspace, slugParam)
 	if err != nil {
 		return mapStoreError(c, err)
-	}
-	if !sameScope(tt.WorkspaceID, workspaceID) {
-		return response.WriteError(c, http.StatusNotFound, "NOT_FOUND", "resource not found")
 	}
 
 	var req request.UpdateTemplateTypeRequest
@@ -184,6 +213,62 @@ func (h *TemplateTypeHandler) update(c *echo.Context, workspace *domain.Workspac
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
 	}
 
+	fieldErrors := validateTemplateTypeUpdateRequest(req)
+	if len(fieldErrors) > 0 {
+		return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed", fieldErrors...)
+	}
+
+	previousSlug := tt.Slug
+	if field, err := applyTemplateTypeUpdateRequest(tt, req); err != nil {
+		return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "invalid "+field)
+	}
+
+	if h.accessSvc != nil {
+		if err := h.accessSvc.ValidateTemplateTypeSelection(ctx, workspace, tt.AdapterID, tt.SenderIdentityID); err != nil {
+			return mapTemplateTypeAccessError(c, err)
+		}
+	}
+
+	if err := h.svc.Update(ctx, tt, previousSlug); err != nil {
+		return mapStoreError(c, err)
+	}
+	h.invalidateResolvedTemplates(ctx, workspaceIDFor(workspace))
+
+	return c.JSON(http.StatusOK, response.NewTemplateTypeResponse(tt))
+}
+
+func (h *TemplateTypeHandler) loadTemplateTypeForUpdate(
+	ctx context.Context,
+	workspace *domain.Workspace,
+	slugParam string,
+) (*domain.TemplateType, *domain.Workspace, error) {
+	if workspace == nil {
+		tt, err := h.svc.FindBySlugInScope(ctx, slugParam, nil)
+		return tt, nil, err
+	}
+
+	chain, systemWorkspace, err := workspaceResolutionChain(ctx, workspace, h.wsStore)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tt, err := h.svc.GetBySlug(ctx, slugParam, chain)
+	if err != nil {
+		return nil, nil, err
+	}
+	annotateTemplateTypeScope(tt, workspace, systemWorkspace)
+
+	if !isOwnedByCurrentWorkspace(tt.WorkspaceID, workspace) {
+		return nil, nil, apperr.Forbidden("inherited template types are read-only in workspace scope")
+	}
+	if !workspace.IsSystem && !effectiveWorkspacePolicies(systemWorkspace).AllowWorkspaceLocalTemplates {
+		return nil, nil, apperr.Forbidden("workspace local templates are disabled by tenant policy")
+	}
+
+	return tt, systemWorkspace, nil
+}
+
+func validateTemplateTypeUpdateRequest(req request.UpdateTemplateTypeRequest) []response.FieldError {
 	var fieldErrors []response.FieldError
 	if req.Slug != nil {
 		if err := slug.Validate(*req.Slug); err != nil {
@@ -197,11 +282,10 @@ func (h *TemplateTypeHandler) update(c *echo.Context, workspace *domain.Workspac
 			fieldErrors = append(fieldErrors, response.FieldError{Field: "name", Message: "must be at most 255 characters"})
 		}
 	}
-	if len(fieldErrors) > 0 {
-		return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed", fieldErrors...)
-	}
+	return fieldErrors
+}
 
-	previousSlug := tt.Slug
+func applyTemplateTypeUpdateRequest(tt *domain.TemplateType, req request.UpdateTemplateTypeRequest) (string, error) {
 	if req.Slug != nil {
 		tt.Slug = *req.Slug
 	}
@@ -211,39 +295,34 @@ func (h *TemplateTypeHandler) update(c *echo.Context, workspace *domain.Workspac
 	if req.AdapterID != nil {
 		if *req.AdapterID == "" {
 			tt.AdapterID = nil
-			tt.SenderIdentityID = nil // clear sender when adapter is cleared
+			tt.SenderIdentityID = nil
 		} else {
-			parsed, err := uuid.Parse(*req.AdapterID)
+			adapterID, err := parseOptionalUUID(req.AdapterID)
 			if err != nil {
-				return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "invalid adapter_id")
+				return "adapter_id", err
 			}
-			tt.AdapterID = &parsed
+			tt.AdapterID = adapterID
 		}
 	}
 	if req.SenderIdentityID != nil {
 		if *req.SenderIdentityID == "" {
 			tt.SenderIdentityID = nil
 		} else {
-			parsed, err := uuid.Parse(*req.SenderIdentityID)
+			senderIdentityID, err := parseOptionalUUID(req.SenderIdentityID)
 			if err != nil {
-				return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "invalid sender_identity_id")
+				return "sender_identity_id", err
 			}
-			tt.SenderIdentityID = &parsed
+			tt.SenderIdentityID = senderIdentityID
 		}
 	}
+	return "", nil
+}
 
-	if h.accessSvc != nil {
-		if err := h.accessSvc.ValidateTemplateTypeSelection(c.Request().Context(), workspace, tt.AdapterID, tt.SenderIdentityID); err != nil {
-			return mapTemplateTypeAccessError(c, err)
-		}
+func workspaceIDFor(workspace *domain.Workspace) *uuid.UUID {
+	if workspace == nil {
+		return nil
 	}
-
-	if err := h.svc.Update(c.Request().Context(), tt, previousSlug); err != nil {
-		return mapStoreError(c, err)
-	}
-	h.invalidateResolvedTemplates(c.Request().Context(), workspaceID)
-
-	return c.JSON(http.StatusOK, response.NewTemplateTypeResponse(tt))
+	return &workspace.ID
 }
 
 func mapTemplateTypeAccessError(c *echo.Context, err error) error {
@@ -294,14 +373,27 @@ func (h *TemplateTypeHandler) GetGlobal(c *echo.Context) error {
 func (h *TemplateTypeHandler) get(c *echo.Context, workspaceID *uuid.UUID) error {
 	slugParam := c.Param("slug")
 
-	tt, err := h.svc.FindBySlugInScope(c.Request().Context(), slugParam, workspaceID)
+	if workspaceID == nil {
+		tt, err := h.svc.FindBySlugInScope(c.Request().Context(), slugParam, nil)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+		return c.JSON(http.StatusOK, response.NewTemplateTypeResponse(tt))
+	}
+
+	workspace, err := resolveWorkspace(c, h.tsStore, h.wsStore)
 	if err != nil {
 		return mapStoreError(c, err)
 	}
-
-	if !sameScope(tt.WorkspaceID, workspaceID) {
-		return response.WriteError(c, http.StatusNotFound, "NOT_FOUND", "resource not found")
+	chain, systemWorkspace, err := workspaceResolutionChain(c.Request().Context(), workspace, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
 	}
+	tt, err := h.svc.GetBySlug(c.Request().Context(), slugParam, chain)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+	annotateTemplateTypeScope(tt, workspace, systemWorkspace)
 
 	return c.JSON(http.StatusOK, response.NewTemplateTypeResponse(tt))
 }
@@ -313,7 +405,7 @@ func (h *TemplateTypeHandler) List(c *echo.Context) error {
 		return mapStoreError(c, err)
 	}
 
-	return h.listTypes(c, &ws.ID)
+	return h.listTypes(c, ws)
 }
 
 // ListGlobal handles GET /global/template-types.
@@ -321,22 +413,68 @@ func (h *TemplateTypeHandler) ListGlobal(c *echo.Context) error {
 	return h.listTypes(c, nil)
 }
 
-func (h *TemplateTypeHandler) listTypes(c *echo.Context, wsID *uuid.UUID) error {
+func (h *TemplateTypeHandler) listTypes(c *echo.Context, workspace *domain.Workspace) error {
 	opts := pagination.ParseListOptions(c)
+	ctx := c.Request().Context()
 
-	types, nextCursor, err := h.svc.ListTypes(c.Request().Context(), wsID, opts)
+	if workspace == nil {
+		types, nextCursor, err := h.svc.ListTypes(ctx, nil, opts)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+
+		items := make([]response.TemplateTypeResponse, len(types))
+		for i, tt := range types {
+			items[i] = response.NewTemplateTypeResponse(tt)
+		}
+
+		return c.JSON(http.StatusOK, response.TemplateTypeListResponse{
+			Items:      items,
+			NextCursor: nextCursor,
+			HasMore:    nextCursor != "",
+		})
+	}
+
+	systemWorkspace, err := resolveSystemWorkspace(ctx, workspace, h.wsStore)
 	if err != nil {
 		return mapStoreError(c, err)
 	}
 
-	items := make([]response.TemplateTypeResponse, len(types))
-	for i, tt := range types {
+	visible := make([]*domain.TemplateType, 0)
+	seen := make(map[string]struct{})
+	appendUnique := func(list []*domain.TemplateType) {
+		for _, tt := range list {
+			if _, ok := seen[tt.Slug]; ok {
+				continue
+			}
+			annotateTemplateTypeScope(tt, workspace, systemWorkspace)
+			visible = append(visible, tt)
+			seen[tt.Slug] = struct{}{}
+		}
+	}
+
+	localTypes, _, err := h.svc.ListTypes(ctx, &workspace.ID, opts)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+	appendUnique(localTypes)
+
+	if systemWorkspace != nil && systemWorkspace.ID != workspace.ID {
+		systemTypes, _, err := h.svc.ListTypes(ctx, &systemWorkspace.ID, opts)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+		appendUnique(systemTypes)
+	}
+
+	items := make([]response.TemplateTypeResponse, len(visible))
+	for i, tt := range visible {
 		items[i] = response.NewTemplateTypeResponse(tt)
 	}
 
 	return c.JSON(http.StatusOK, response.TemplateTypeListResponse{
 		Items:      items,
-		NextCursor: nextCursor,
-		HasMore:    nextCursor != "",
+		NextCursor: "",
+		HasMore:    false,
 	})
 }

--- a/internal/http/handler/template_type_test.go
+++ b/internal/http/handler/template_type_test.go
@@ -33,6 +33,7 @@ type mockTemplateStore struct {
 	getVersionByIDFn        func(ctx context.Context, versionID uuid.UUID) (*domain.TemplateVersion, error)
 	getPublishedVersionFn   func(ctx context.Context, templateID uuid.UUID) (*domain.TemplateVersion, error)
 	publishFn               func(ctx context.Context, versionID uuid.UUID) error
+	updateVersionFn         func(ctx context.Context, ver *domain.TemplateVersion) error
 	setDisabledFn           func(ctx context.Context, templateID uuid.UUID, wsID *uuid.UUID, disabled bool) error
 	listVersionsFn          func(ctx context.Context, templateID uuid.UUID) ([]*domain.TemplateVersion, error)
 	setLocaleFn             func(ctx context.Context, locale *domain.TemplateVersionLocale) error
@@ -40,6 +41,7 @@ type mockTemplateStore struct {
 	listLocalesFn           func(ctx context.Context, versionID uuid.UUID) ([]*domain.TemplateVersionLocale, error)
 	deleteLocaleFn          func(ctx context.Context, versionID uuid.UUID, locale string) error
 	listTypesFn             func(ctx context.Context, wsID *uuid.UUID, opts port.ListOptions) ([]*domain.TemplateType, string, error)
+	forkTemplateFn          func(ctx context.Context, sourceTemplateID uuid.UUID, workspaceID uuid.UUID, createdBy *uuid.UUID) (*domain.Template, error)
 	updateTypeFn            func(ctx context.Context, tt *domain.TemplateType) error
 	getTemplateByIDFn       func(ctx context.Context, id uuid.UUID) (*domain.Template, error)
 	getTypeByIDFn           func(ctx context.Context, id uuid.UUID) (*domain.TemplateType, error)
@@ -114,7 +116,10 @@ func (m *mockTemplateStore) GetPublishedVersion(ctx context.Context, templateID 
 	}
 	return nil, nil
 }
-func (m *mockTemplateStore) UpdateVersion(_ context.Context, _ *domain.TemplateVersion) error {
+func (m *mockTemplateStore) UpdateVersion(ctx context.Context, ver *domain.TemplateVersion) error {
+	if m.updateVersionFn != nil {
+		return m.updateVersionFn(ctx, ver)
+	}
 	return nil
 }
 func (m *mockTemplateStore) Publish(ctx context.Context, versionID uuid.UUID) error {
@@ -169,6 +174,12 @@ func (m *mockTemplateStore) UpdateType(ctx context.Context, tt *domain.TemplateT
 		return m.updateTypeFn(ctx, tt)
 	}
 	return nil
+}
+func (m *mockTemplateStore) ForkTemplate(ctx context.Context, sourceTemplateID uuid.UUID, workspaceID uuid.UUID, createdBy *uuid.UUID) (*domain.Template, error) {
+	if m.forkTemplateFn != nil {
+		return m.forkTemplateFn(ctx, sourceTemplateID, workspaceID, createdBy)
+	}
+	return nil, domain.ErrNotFound
 }
 func (m *mockTemplateStore) SoftDeleteType(_ context.Context, _ uuid.UUID) error { return nil }
 func (m *mockTemplateStore) GetTemplateByID(ctx context.Context, id uuid.UUID) (*domain.Template, error) {
@@ -477,10 +488,16 @@ func TestTemplateTypeHandler_Get_Success(t *testing.T) {
 
 	ttID := uuid.Must(uuid.NewV7())
 	store := &mockTemplateStore{
-		findTypeBySlugInScopeFn: func(_ context.Context, slug string, wsID *uuid.UUID) (*domain.TemplateType, error) {
+		getTypeBySlugFn: func(_ context.Context, slug string, chain []uuid.NullUUID) (*domain.TemplateType, error) {
 			if slug == "welcome-email" {
+				if len(chain) != 1 {
+					t.Fatalf("expected 1 scope, got %d", len(chain))
+				}
+				if !chain[0].Valid || chain[0].UUID != ws.ID {
+					t.Fatalf("expected workspace scope %s, got %#v", ws.ID, chain[0])
+				}
 				return &domain.TemplateType{
-					ID: ttID, WorkspaceID: wsID, Slug: "welcome-email", Name: "Welcome",
+					ID: ttID, WorkspaceID: &ws.ID, Slug: "welcome-email", Name: "Welcome",
 				}, nil
 			}
 			return nil, domain.ErrNotFound
@@ -503,14 +520,69 @@ func TestTemplateTypeHandler_Get_Success(t *testing.T) {
 	if resp.Slug != "welcome-email" {
 		t.Fatalf("expected slug 'welcome-email', got %q", resp.Slug)
 	}
-	_ = ws // used indirectly via wsStore
+}
+
+func TestTemplateTypeHandler_Get_ResolvesInheritedSystemTypeInWorkspace(t *testing.T) {
+	tenant, _, ts, wsStore := testTenantAndWorkspace()
+	systemWorkspace := uuid.Must(uuid.NewV7())
+	ttID := uuid.Must(uuid.NewV7())
+
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+		if tenantID != tenant.ID {
+			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
+		}
+		return &domain.Workspace{
+			ID:       systemWorkspace,
+			TenantID: tenant.ID,
+			Code:     "_system",
+			Name:     "Default",
+			IsSystem: true,
+		}, nil
+	}
+
+	store := &mockTemplateStore{
+		getTypeBySlugFn: func(_ context.Context, slug string, chain []uuid.NullUUID) (*domain.TemplateType, error) {
+			if slug != "welcome-email" {
+				t.Fatalf("unexpected slug %q", slug)
+			}
+			if len(chain) != 2 {
+				t.Fatalf("expected workspace -> system chain, got %d", len(chain))
+			}
+			return &domain.TemplateType{
+				ID:          ttID,
+				WorkspaceID: &systemWorkspace,
+				Slug:        "welcome-email",
+				Name:        "Welcome",
+			}, nil
+		},
+	}
+	e, _ := setupTemplateTypeTest(store, ts, wsStore)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/manage/tenants/acme/workspaces/default/template-types/welcome-email", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp response.TemplateTypeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.OwnerScope != "system" {
+		t.Fatalf("expected owner_scope system, got %q", resp.OwnerScope)
+	}
+	if !resp.InheritedFromSystem {
+		t.Fatal("expected inherited system marker")
+	}
 }
 
 func TestTemplateTypeHandler_Get_NotFound(t *testing.T) {
 	_, _, ts, wsStore := testTenantAndWorkspace()
 
 	store := &mockTemplateStore{
-		findTypeBySlugInScopeFn: func(_ context.Context, _ string, _ *uuid.UUID) (*domain.TemplateType, error) {
+		getTypeBySlugFn: func(_ context.Context, _ string, _ []uuid.NullUUID) (*domain.TemplateType, error) {
 			return nil, domain.ErrNotFound
 		},
 	}
@@ -561,7 +633,13 @@ func TestTemplateTypeHandler_Update_Success(t *testing.T) {
 
 	var updated *domain.TemplateType
 	store := &mockTemplateStore{
-		findTypeBySlugInScopeFn: func(_ context.Context, slug string, wsID *uuid.UUID) (*domain.TemplateType, error) {
+		getTypeBySlugFn: func(_ context.Context, slug string, chain []uuid.NullUUID) (*domain.TemplateType, error) {
+			if len(chain) != 1 {
+				t.Fatalf("expected 1 scope, got %d", len(chain))
+			}
+			if !chain[0].Valid || chain[0].UUID != ws.ID {
+				t.Fatalf("expected workspace scope %s, got %#v", ws.ID, chain[0])
+			}
 			switch slug {
 			case "welcome-email":
 				return original, nil
@@ -602,7 +680,13 @@ func TestTemplateTypeHandler_Update_InvalidSlug(t *testing.T) {
 	_, ws, ts, wsStore := testTenantAndWorkspace()
 	ttID := uuid.Must(uuid.NewV7())
 	store := &mockTemplateStore{
-		findTypeBySlugInScopeFn: func(_ context.Context, slug string, _ *uuid.UUID) (*domain.TemplateType, error) {
+		getTypeBySlugFn: func(_ context.Context, slug string, chain []uuid.NullUUID) (*domain.TemplateType, error) {
+			if len(chain) != 1 {
+				t.Fatalf("expected 1 scope, got %d", len(chain))
+			}
+			if !chain[0].Valid || chain[0].UUID != ws.ID {
+				t.Fatalf("expected workspace scope %s, got %#v", ws.ID, chain[0])
+			}
 			if slug == "welcome-email" {
 				return &domain.TemplateType{ID: ttID, WorkspaceID: &ws.ID, Slug: slug, Name: "Welcome"}, nil
 			}
@@ -646,6 +730,75 @@ func TestTemplateTypeHandler_List_Success(t *testing.T) {
 	}
 	if resp.HasMore {
 		t.Fatal("expected has_more=false for empty list")
+	}
+}
+
+func TestTemplateTypeHandler_List_ExcludesGlobalTemplateTypesForWorkspace(t *testing.T) {
+	tenant, ws, ts, wsStore := testTenantAndWorkspace()
+	systemWorkspaceID := uuid.Must(uuid.NewV7())
+	now := time.Now().UTC()
+
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+		if tenantID != tenant.ID {
+			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
+		}
+		return &domain.Workspace{
+			ID:        systemWorkspaceID,
+			TenantID:  tenant.ID,
+			Code:      "_system",
+			Name:      "Default",
+			IsSystem:  true,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}, nil
+	}
+
+	var seenScopes []string
+	store := &mockTemplateStore{
+		listTypesFn: func(_ context.Context, wsID *uuid.UUID, _ port.ListOptions) ([]*domain.TemplateType, string, error) {
+			switch {
+			case wsID != nil && *wsID == ws.ID:
+				seenScopes = append(seenScopes, "workspace")
+				return []*domain.TemplateType{}, "", nil
+			case wsID != nil && *wsID == systemWorkspaceID:
+				seenScopes = append(seenScopes, "system")
+				return []*domain.TemplateType{
+					{ID: uuid.New(), WorkspaceID: &systemWorkspaceID, Slug: "welcome", Name: "Welcome", CreatedAt: now, UpdatedAt: now},
+				}, "", nil
+			case wsID == nil:
+				seenScopes = append(seenScopes, "global")
+				return []*domain.TemplateType{
+					{ID: uuid.New(), Slug: "global-only", Name: "Global", CreatedAt: now, UpdatedAt: now},
+				}, "", nil
+			default:
+				t.Fatalf("unexpected workspace scope %#v", wsID)
+				return nil, "", nil
+			}
+		},
+	}
+	e, _ := setupTemplateTypeTest(store, ts, wsStore)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/manage/tenants/acme/workspaces/default/template-types", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp response.TemplateTypeListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 visible template type, got %d", len(resp.Items))
+	}
+	if resp.Items[0].Slug != "welcome" {
+		t.Fatalf("expected only system template type to be visible, got %q", resp.Items[0].Slug)
+	}
+	if len(seenScopes) != 2 || seenScopes[0] != "workspace" || seenScopes[1] != "system" {
+		t.Fatalf("expected workspace and system scopes only, got %#v", seenScopes)
 	}
 }
 

--- a/internal/http/handler/tenant.go
+++ b/internal/http/handler/tenant.go
@@ -68,14 +68,18 @@ func (h *TenantHandler) Create(c *echo.Context) error {
 
 	// Create the _system workspace for the new tenant.
 	sysWS := &domain.Workspace{
-		ID:        uuid.Must(uuid.NewV7()),
-		TenantID:  tenant.ID,
-		Code:      "_system",
-		Name:      "System",
-		IsSystem:  true,
-		IsActive:  true,
-		CreatedAt: now,
-		UpdatedAt: now,
+		ID:                                   uuid.Must(uuid.NewV7()),
+		TenantID:                             tenant.ID,
+		Code:                                 "_system",
+		Name:                                 "System",
+		IsSystem:                             true,
+		IsActive:                             true,
+		AllowWorkspaceLocalTemplates:         true,
+		AllowWorkspaceInheritedTemplateForks: true,
+		AllowWorkspaceLocalInjectors:         true,
+		WorkspacePoliciesInitialized:         true,
+		CreatedAt:                            now,
+		UpdatedAt:                            now,
 	}
 	if err := h.wsStore.Create(ctx, sysWS); err != nil {
 		return mapStoreError(c, err)

--- a/internal/http/handler/workspace_policy.go
+++ b/internal/http/handler/workspace_policy.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v5"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/http/request"
+	"github.com/rendis/senda/internal/http/response"
+	"github.com/rendis/senda/internal/port"
+)
+
+// WorkspacePolicyResponse exposes tenant-local workspace policies stored on the _system workspace.
+type WorkspacePolicyResponse struct {
+	AllowWorkspaceLocalTemplates         bool `json:"allow_workspace_local_templates"`
+	AllowWorkspaceInheritedTemplateForks bool `json:"allow_workspace_inherited_template_forks"`
+	AllowWorkspaceLocalInjectors         bool `json:"allow_workspace_local_injectors"`
+}
+
+type WorkspacePolicyHandler struct {
+	tenantStore port.TenantStore
+	wsStore     port.WorkspaceStore
+}
+
+func NewWorkspacePolicyHandler(ts port.TenantStore, ws port.WorkspaceStore) *WorkspacePolicyHandler {
+	return &WorkspacePolicyHandler{tenantStore: ts, wsStore: ws}
+}
+
+func (h *WorkspacePolicyHandler) Get(c *echo.Context) error {
+	ws, err := resolveWorkspace(c, h.tenantStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+
+	policyWorkspace := ws
+	if !ws.IsSystem {
+		policyWorkspace, err = resolveSystemWorkspace(c.Request().Context(), ws, h.wsStore)
+		if err != nil {
+			return mapStoreError(c, err)
+		}
+	}
+
+	return c.JSON(http.StatusOK, newWorkspacePolicyResponse(policyWorkspace))
+}
+
+func (h *WorkspacePolicyHandler) Update(c *echo.Context) error {
+	ws, err := resolveWorkspace(c, h.tenantStore, h.wsStore)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+	if !ws.IsSystem {
+		return response.WriteError(c, http.StatusNotFound, "NOT_FOUND", "resource not found")
+	}
+
+	var req request.UpdateWorkspacePolicyRequest
+	if err := c.Bind(&req); err != nil {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
+	}
+
+	if req.AllowWorkspaceLocalTemplates != nil {
+		ws.AllowWorkspaceLocalTemplates = *req.AllowWorkspaceLocalTemplates
+	}
+	if req.AllowWorkspaceInheritedTemplateForks != nil {
+		ws.AllowWorkspaceInheritedTemplateForks = *req.AllowWorkspaceInheritedTemplateForks
+	}
+	if req.AllowWorkspaceLocalInjectors != nil {
+		ws.AllowWorkspaceLocalInjectors = *req.AllowWorkspaceLocalInjectors
+	}
+	ws.WorkspacePoliciesInitialized = true
+	ws.UpdatedAt = time.Now().UTC()
+
+	if err := h.wsStore.Update(c.Request().Context(), ws); err != nil {
+		return mapStoreError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, newWorkspacePolicyResponse(ws))
+}
+
+func newWorkspacePolicyResponse(ws *domain.Workspace) WorkspacePolicyResponse {
+	return WorkspacePolicyResponse(effectiveWorkspacePolicies(ws))
+}

--- a/internal/http/handler/workspace_policy_test.go
+++ b/internal/http/handler/workspace_policy_test.go
@@ -1,0 +1,271 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/http/handler"
+	"github.com/rendis/senda/internal/http/middleware"
+	"github.com/rendis/senda/internal/http/response"
+)
+
+func setupWorkspacePolicyTest(ts *mockTenantStore, ws *mockWorkspaceStore) *echo.Echo {
+	e := echo.New()
+	e.HTTPErrorHandler = response.HTTPErrorHandler
+	e.Use(middleware.RequestID())
+	e.Use(middleware.Scope())
+
+	h := handler.NewWorkspacePolicyHandler(ts, ws)
+	e.GET("/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code/policies", h.Get)
+	e.PUT("/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code/policies", h.Update)
+	return e
+}
+
+func TestWorkspacePolicyHandler_Get_SystemWorkspaceSuccess(t *testing.T) {
+	tenantID := uuid.New()
+	now := time.Now().UTC()
+
+	ts := &mockTenantStore{
+		getByCodeFn: func(_ context.Context, code string) (*domain.Tenant, error) {
+			return &domain.Tenant{ID: tenantID, Code: code}, nil
+		},
+	}
+	ws := &mockWorkspaceStore{
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+			if tid != tenantID {
+				t.Fatalf("expected tenant id %s, got %s", tenantID, tid)
+			}
+			if code != "_system" {
+				t.Fatalf("expected _system workspace, got %q", code)
+			}
+			return &domain.Workspace{
+				ID:                                   uuid.New(),
+				TenantID:                             tenantID,
+				Code:                                 "_system",
+				Name:                                 "Default",
+				IsSystem:                             true,
+				AllowWorkspaceLocalTemplates:         false,
+				AllowWorkspaceInheritedTemplateForks: true,
+				AllowWorkspaceLocalInjectors:         false,
+				WorkspacePoliciesInitialized:         true,
+				CreatedAt:                            now,
+				UpdatedAt:                            now,
+			}, nil
+		},
+	}
+
+	e := setupWorkspacePolicyTest(ts, ws)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/manage/tenants/acme/workspaces/_system/policies", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp handler.WorkspacePolicyResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.AllowWorkspaceLocalTemplates {
+		t.Fatal("expected local templates disabled")
+	}
+	if !resp.AllowWorkspaceInheritedTemplateForks {
+		t.Fatal("expected inherited template forks enabled")
+	}
+	if resp.AllowWorkspaceLocalInjectors {
+		t.Fatal("expected local injectors disabled")
+	}
+}
+
+func TestWorkspacePolicyHandler_Get_WorkspaceReturnsSystemPolicies(t *testing.T) {
+	tenantID := uuid.New()
+	now := time.Now().UTC()
+	systemWorkspaceID := uuid.New()
+
+	ts := &mockTenantStore{
+		getByCodeFn: func(_ context.Context, code string) (*domain.Tenant, error) {
+			return &domain.Tenant{ID: tenantID, Code: code}, nil
+		},
+	}
+	ws := &mockWorkspaceStore{
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+			if tid != tenantID {
+				t.Fatalf("expected tenant id %s, got %s", tenantID, tid)
+			}
+			if code != "main" {
+				t.Fatalf("expected main workspace, got %q", code)
+			}
+			return &domain.Workspace{
+				ID:        uuid.New(),
+				TenantID:  tenantID,
+				Code:      "main",
+				Name:      "Main",
+				IsSystem:  false,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}, nil
+		},
+		getSystemWorkspaceFn: func(_ context.Context, tid uuid.UUID) (*domain.Workspace, error) {
+			if tid != tenantID {
+				t.Fatalf("expected tenant id %s, got %s", tenantID, tid)
+			}
+			return &domain.Workspace{
+				ID:                                   systemWorkspaceID,
+				TenantID:                             tenantID,
+				Code:                                 "_system",
+				Name:                                 "System",
+				IsSystem:                             true,
+				AllowWorkspaceLocalTemplates:         false,
+				AllowWorkspaceInheritedTemplateForks: true,
+				AllowWorkspaceLocalInjectors:         false,
+				WorkspacePoliciesInitialized:         true,
+				CreatedAt:                            now,
+				UpdatedAt:                            now,
+			}, nil
+		},
+	}
+
+	e := setupWorkspacePolicyTest(ts, ws)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/manage/tenants/acme/workspaces/main/policies", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp handler.WorkspacePolicyResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.AllowWorkspaceLocalTemplates {
+		t.Fatal("expected local templates disabled")
+	}
+	if !resp.AllowWorkspaceInheritedTemplateForks {
+		t.Fatal("expected inherited template forks enabled")
+	}
+	if resp.AllowWorkspaceLocalInjectors {
+		t.Fatal("expected local injectors disabled")
+	}
+}
+
+func TestWorkspacePolicyHandler_Update_SystemWorkspaceSuccess(t *testing.T) {
+	tenantID := uuid.New()
+	now := time.Now().UTC()
+	systemWorkspace := &domain.Workspace{
+		ID:                                   uuid.New(),
+		TenantID:                             tenantID,
+		Code:                                 "_system",
+		Name:                                 "Default",
+		IsSystem:                             true,
+		AllowWorkspaceLocalTemplates:         true,
+		AllowWorkspaceInheritedTemplateForks: true,
+		AllowWorkspaceLocalInjectors:         true,
+		WorkspacePoliciesInitialized:         true,
+		CreatedAt:                            now,
+		UpdatedAt:                            now,
+	}
+
+	ts := &mockTenantStore{
+		getByCodeFn: func(_ context.Context, code string) (*domain.Tenant, error) {
+			return &domain.Tenant{ID: tenantID, Code: code}, nil
+		},
+	}
+
+	var updated *domain.Workspace
+	ws := &mockWorkspaceStore{
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+			if tid != tenantID || code != "_system" {
+				t.Fatalf("unexpected lookup %s %q", tid, code)
+			}
+			copy := *systemWorkspace
+			return &copy, nil
+		},
+		updateFn: func(_ context.Context, ws *domain.Workspace) error {
+			updated = ws
+			return nil
+		},
+	}
+
+	e := setupWorkspacePolicyTest(ts, ws)
+
+	body := `{"allow_workspace_local_templates":false,"allow_workspace_inherited_template_forks":true,"allow_workspace_local_injectors":false}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/_system/policies", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if updated == nil {
+		t.Fatal("expected workspace update")
+	}
+	if updated.AllowWorkspaceLocalTemplates {
+		t.Fatal("expected local templates disabled")
+	}
+	if !updated.AllowWorkspaceInheritedTemplateForks {
+		t.Fatal("expected template forks enabled")
+	}
+	if updated.AllowWorkspaceLocalInjectors {
+		t.Fatal("expected local injectors disabled")
+	}
+}
+
+func TestWorkspacePolicyHandler_Update_RejectsNonSystemWorkspace(t *testing.T) {
+	tenantID := uuid.New()
+	now := time.Now().UTC()
+
+	ts := &mockTenantStore{
+		getByCodeFn: func(_ context.Context, code string) (*domain.Tenant, error) {
+			return &domain.Tenant{ID: tenantID, Code: code}, nil
+		},
+	}
+
+	var updateCalled bool
+	ws := &mockWorkspaceStore{
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+			return &domain.Workspace{
+				ID:        uuid.New(),
+				TenantID:  tid,
+				Code:      code,
+				Name:      "Main",
+				IsSystem:  false,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}, nil
+		},
+		updateFn: func(_ context.Context, _ *domain.Workspace) error {
+			updateCalled = true
+			return nil
+		},
+	}
+
+	e := setupWorkspacePolicyTest(ts, ws)
+
+	body := `{"allow_workspace_local_templates":false}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/main/policies", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if updateCalled {
+		t.Fatal("expected non-system workspace policies update to be blocked")
+	}
+}

--- a/internal/http/request/workspace.go
+++ b/internal/http/request/workspace.go
@@ -14,3 +14,10 @@ type UpdateWorkspaceRequest struct {
 	OpenTrackingEnabled *bool   `json:"open_tracking_enabled"`
 	DefaultLocale       *string `json:"default_locale"`
 }
+
+// UpdateWorkspacePolicyRequest is the request body for PUT /api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code/policies.
+type UpdateWorkspacePolicyRequest struct {
+	AllowWorkspaceLocalTemplates         *bool `json:"allow_workspace_local_templates"`
+	AllowWorkspaceInheritedTemplateForks *bool `json:"allow_workspace_inherited_template_forks"`
+	AllowWorkspaceLocalInjectors         *bool `json:"allow_workspace_local_injectors"`
+}

--- a/internal/http/response/injector.go
+++ b/internal/http/response/injector.go
@@ -8,12 +8,14 @@ import (
 
 // InjectorDefinitionResponse is the JSON response for an injector definition.
 type InjectorDefinitionResponse struct {
-	ID          string  `json:"id"`
-	WorkspaceID *string `json:"workspace_id,omitempty"`
-	Name        string  `json:"name"`
-	Description *string `json:"description,omitempty"`
-	CreatedAt   string  `json:"created_at"`
-	UpdatedAt   string  `json:"updated_at"`
+	ID                  string  `json:"id"`
+	WorkspaceID         *string `json:"workspace_id,omitempty"`
+	Name                string  `json:"name"`
+	Description         *string `json:"description,omitempty"`
+	OwnerScope          string  `json:"owner_scope,omitempty"`
+	InheritedFromSystem bool    `json:"inherited_from_system"`
+	CreatedAt           string  `json:"created_at"`
+	UpdatedAt           string  `json:"updated_at"`
 }
 
 // InjectorFieldResponse is the JSON response for an injector field.
@@ -51,11 +53,13 @@ type InjectorListResponse struct {
 // NewInjectorDefinitionResponse maps a domain InjectorDefinition to a response.
 func NewInjectorDefinitionResponse(d *domain.InjectorDefinition) InjectorDefinitionResponse {
 	resp := InjectorDefinitionResponse{
-		ID:          d.ID.String(),
-		Name:        d.Name,
-		Description: d.Description,
-		CreatedAt:   d.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt:   d.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		ID:                  d.ID.String(),
+		Name:                d.Name,
+		Description:         d.Description,
+		OwnerScope:          d.OwnerScope,
+		InheritedFromSystem: d.InheritedFromSystem,
+		CreatedAt:           d.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:           d.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
 	}
 	if d.WorkspaceID != nil {
 		s := d.WorkspaceID.String()

--- a/internal/http/response/template.go
+++ b/internal/http/response/template.go
@@ -11,16 +11,18 @@ import (
 
 // TemplateTypeResponse is the JSON response for a template type.
 type TemplateTypeResponse struct {
-	ID               string           `json:"id"`
-	WorkspaceID      *string          `json:"workspace_id,omitempty"`
-	Slug             string           `json:"slug"`
-	Name             string           `json:"name"`
-	Description      *string          `json:"description,omitempty"`
-	AdapterID        *string          `json:"adapter_id,omitempty"`
-	SenderIdentityID *string          `json:"sender_identity_id,omitempty"`
-	VariableSchema   *json.RawMessage `json:"variable_schema,omitempty"`
-	CreatedAt        string           `json:"created_at"`
-	UpdatedAt        string           `json:"updated_at"`
+	ID                  string           `json:"id"`
+	WorkspaceID         *string          `json:"workspace_id,omitempty"`
+	Slug                string           `json:"slug"`
+	Name                string           `json:"name"`
+	Description         *string          `json:"description,omitempty"`
+	AdapterID           *string          `json:"adapter_id,omitempty"`
+	SenderIdentityID    *string          `json:"sender_identity_id,omitempty"`
+	VariableSchema      *json.RawMessage `json:"variable_schema,omitempty"`
+	OwnerScope          string           `json:"owner_scope,omitempty"`
+	InheritedFromSystem bool             `json:"inherited_from_system"`
+	CreatedAt           string           `json:"created_at"`
+	UpdatedAt           string           `json:"updated_at"`
 }
 
 // TemplateTypeListResponse is the JSON response for a paginated list of template types.
@@ -33,11 +35,13 @@ type TemplateTypeListResponse struct {
 // NewTemplateTypeResponse maps a domain TemplateType to a TemplateTypeResponse.
 func NewTemplateTypeResponse(tt *domain.TemplateType) TemplateTypeResponse {
 	resp := TemplateTypeResponse{
-		ID:        tt.ID.String(),
-		Slug:      tt.Slug,
-		Name:      tt.Name,
-		CreatedAt: formatTime(tt.CreatedAt),
-		UpdatedAt: formatTime(tt.UpdatedAt),
+		ID:                  tt.ID.String(),
+		Slug:                tt.Slug,
+		Name:                tt.Name,
+		OwnerScope:          tt.OwnerScope,
+		InheritedFromSystem: tt.InheritedFromSystem,
+		CreatedAt:           formatTime(tt.CreatedAt),
+		UpdatedAt:           formatTime(tt.UpdatedAt),
 	}
 	if tt.WorkspaceID != nil {
 		s := tt.WorkspaceID.String()
@@ -77,26 +81,37 @@ func NewTemplateTypeListResponse(types []*domain.TemplateType) TemplateTypeListR
 
 // TemplateResponse is the JSON response for a template.
 type TemplateResponse struct {
-	ID             string  `json:"id"`
-	TemplateTypeID string  `json:"template_type_id"`
-	WorkspaceID    *string `json:"workspace_id,omitempty"`
-	IsDisabled     bool    `json:"is_disabled"`
-	CreatedAt      string  `json:"created_at"`
-	UpdatedAt      string  `json:"updated_at"`
+	ID                  string  `json:"id"`
+	TemplateTypeID      string  `json:"template_type_id"`
+	WorkspaceID         *string `json:"workspace_id,omitempty"`
+	IsDisabled          bool    `json:"is_disabled"`
+	OwnerScope          string  `json:"owner_scope,omitempty"`
+	InheritedFromSystem bool    `json:"inherited_from_system"`
+	IsFork              bool    `json:"is_fork"`
+	OriginTemplateID    *string `json:"origin_template_id,omitempty"`
+	CreatedAt           string  `json:"created_at"`
+	UpdatedAt           string  `json:"updated_at"`
 }
 
 // NewTemplateResponse maps a domain Template to a TemplateResponse.
 func NewTemplateResponse(t *domain.Template) TemplateResponse {
 	resp := TemplateResponse{
-		ID:             t.ID.String(),
-		TemplateTypeID: t.TemplateTypeID.String(),
-		IsDisabled:     t.IsDisabled,
-		CreatedAt:      formatTime(t.CreatedAt),
-		UpdatedAt:      formatTime(t.UpdatedAt),
+		ID:                  t.ID.String(),
+		TemplateTypeID:      t.TemplateTypeID.String(),
+		IsDisabled:          t.IsDisabled,
+		OwnerScope:          t.OwnerScope,
+		InheritedFromSystem: t.InheritedFromSystem,
+		IsFork:              t.IsFork,
+		CreatedAt:           formatTime(t.CreatedAt),
+		UpdatedAt:           formatTime(t.UpdatedAt),
 	}
 	if t.WorkspaceID != nil {
 		s := t.WorkspaceID.String()
 		resp.WorkspaceID = &s
+	}
+	if t.OriginTemplateID != nil {
+		s := t.OriginTemplateID.String()
+		resp.OriginTemplateID = &s
 	}
 	return resp
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -38,10 +38,11 @@ type Server struct {
 	configStore port.GlobalConfigStore
 
 	// Handlers.
-	tenantHandler    *handler.TenantHandler
-	workspaceHandler *handler.WorkspaceHandler
-	memberHandler    *handler.MemberHandler
-	configHandler    *handler.ConfigHandler
+	tenantHandler          *handler.TenantHandler
+	workspaceHandler       *handler.WorkspaceHandler
+	workspacePolicyHandler *handler.WorkspacePolicyHandler
+	memberHandler          *handler.MemberHandler
+	configHandler          *handler.ConfigHandler
 
 	// HT-20 handlers.
 	injectorHandler *handler.InjectorHandler
@@ -139,6 +140,13 @@ func WithTenantHandler(h *handler.TenantHandler) ServerOption {
 func WithWorkspaceHandler(h *handler.WorkspaceHandler) ServerOption {
 	return func(s *Server) {
 		s.workspaceHandler = h
+	}
+}
+
+// WithWorkspacePolicyHandler sets the WorkspacePolicyHandler for _system policy routes.
+func WithWorkspacePolicyHandler(h *handler.WorkspacePolicyHandler) ServerOption {
+	return func(s *Server) {
+		s.workspacePolicyHandler = h
 	}
 }
 
@@ -403,6 +411,10 @@ func (s *Server) registerRoutes() { //nolint:gocognit,gocyclo,funlen // route re
 			mgmt.PUT("/tenants/:tenant_code/workspaces/:workspace_code", s.workspaceHandler.Update, middleware.RequireRole(domain.RoleWorkspaceAdmin, s.tenantStore, s.wsStore))
 			mgmt.DELETE("/tenants/:tenant_code/workspaces/:workspace_code", s.workspaceHandler.SoftDelete, middleware.RequireRole(domain.RoleTenantAdmin, s.tenantStore, s.wsStore))
 		}
+		if s.workspacePolicyHandler != nil {
+			mgmt.GET("/tenants/:tenant_code/workspaces/:workspace_code/policies", s.workspacePolicyHandler.Get, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
+			mgmt.PUT("/tenants/:tenant_code/workspaces/:workspace_code/policies", s.workspacePolicyHandler.Update, middleware.RequireRole(domain.RoleTenantAdmin, s.tenantStore, s.wsStore))
+		}
 
 		// Tenant dashboard stats.
 		if s.dashboardHandler != nil {
@@ -482,6 +494,7 @@ func (s *Server) registerRoutes() { //nolint:gocognit,gocyclo,funlen // route re
 			if s.templateHandler != nil {
 				ws.GET("/template-types/:slug/templates", s.templateHandler.ListByTemplateType, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
 				ws.POST("/templates", s.templateHandler.CreateTemplate, middleware.RequireRole(domain.RoleWorkspaceAdmin, s.tenantStore, s.wsStore))
+				ws.POST("/templates/:template_id/fork", s.templateHandler.ForkTemplate, middleware.RequireRole(domain.RoleWorkspaceEditor, s.tenantStore, s.wsStore))
 				ws.GET("/templates/:template_id/versions", s.templateHandler.ListVersions, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
 				ws.GET("/templates/:template_id/versions/:version_id", s.templateHandler.GetVersion, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
 				ws.POST("/templates/:template_id/versions", s.templateHandler.CreateVersion, middleware.RequireRole(domain.RoleWorkspaceEditor, s.tenantStore, s.wsStore))

--- a/internal/port/store.go
+++ b/internal/port/store.go
@@ -95,6 +95,7 @@ type TemplateStore interface {
 
 	// Core template methods
 	CreateTemplate(ctx context.Context, tpl *domain.Template) error
+	ForkTemplate(ctx context.Context, sourceTemplateID uuid.UUID, workspaceID uuid.UUID, createdBy *uuid.UUID) (*domain.Template, error)
 	GetTemplateByID(ctx context.Context, id uuid.UUID) (*domain.Template, error)
 	GetTypeByID(ctx context.Context, id uuid.UUID) (*domain.TemplateType, error)
 	GetByTypeAndScope(ctx context.Context, typeID uuid.UUID, wsID *uuid.UUID) (*domain.Template, error)

--- a/internal/resolution/chain.go
+++ b/internal/resolution/chain.go
@@ -12,17 +12,17 @@ import (
 
 const chainCacheTTL = 5 * time.Minute
 
-// ResolutionChain holds the ordered scopes for hierarchical resolution.
-// Scopes are ordered from highest priority (workspace) to lowest (global).
+// ResolutionChain holds the ordered scopes for tenant-local hierarchical resolution.
+// Scopes are ordered from highest priority (workspace) to lowest (_system).
 type ResolutionChain struct {
-	WorkspaceID       uuid.UUID        `json:"workspace_id"`
-	SystemWorkspaceID uuid.UUID        `json:"system_workspace_id"`
-	TenantID          uuid.UUID        `json:"tenant_id"`
-	Scopes            []uuid.NullUUID  `json:"scopes"`
+	WorkspaceID       uuid.UUID       `json:"workspace_id"`
+	SystemWorkspaceID uuid.UUID       `json:"system_workspace_id"`
+	TenantID          uuid.UUID       `json:"tenant_id"`
+	Scopes            []uuid.NullUUID `json:"scopes"`
 }
 
 // ChainResolver builds a ResolutionChain for a given workspace,
-// using the 3-level hierarchy: workspace → _system → global.
+// using the tenant-local hierarchy: workspace → _system.
 type ChainResolver struct {
 	workspaceStore port.WorkspaceStore
 	cache          port.Cache
@@ -64,7 +64,6 @@ func (r *ChainResolver) Resolve(ctx context.Context, workspaceID uuid.UUID) (*Re
 			TenantID:          ws.TenantID,
 			Scopes: []uuid.NullUUID{
 				{UUID: ws.ID, Valid: true},
-				{Valid: false}, // global
 			},
 		}
 	} else {
@@ -79,7 +78,6 @@ func (r *ChainResolver) Resolve(ctx context.Context, workspaceID uuid.UUID) (*Re
 			Scopes: []uuid.NullUUID{
 				{UUID: ws.ID, Valid: true},
 				{UUID: sysWS.ID, Valid: true},
-				{Valid: false}, // global
 			},
 		}
 	}

--- a/internal/resolution/chain_test.go
+++ b/internal/resolution/chain_test.go
@@ -105,8 +105,8 @@ func TestChainResolver_RegularWorkspace(t *testing.T) {
 	if chain.TenantID != tenantID {
 		t.Errorf("TenantID = %v, want %v", chain.TenantID, tenantID)
 	}
-	if len(chain.Scopes) != 3 {
-		t.Fatalf("Scopes length = %d, want 3", len(chain.Scopes))
+	if len(chain.Scopes) != 2 {
+		t.Fatalf("Scopes length = %d, want 2", len(chain.Scopes))
 	}
 	// scope[0] = workspace
 	if !chain.Scopes[0].Valid || chain.Scopes[0].UUID != wsID {
@@ -115,10 +115,6 @@ func TestChainResolver_RegularWorkspace(t *testing.T) {
 	// scope[1] = system workspace
 	if !chain.Scopes[1].Valid || chain.Scopes[1].UUID != sysID {
 		t.Errorf("Scopes[1] = %v, want {UUID: %v, Valid: true}", chain.Scopes[1], sysID)
-	}
-	// scope[2] = global (NULL)
-	if chain.Scopes[2].Valid {
-		t.Errorf("Scopes[2].Valid = true, want false (global scope)")
 	}
 }
 
@@ -143,14 +139,11 @@ func TestChainResolver_SystemWorkspace(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(chain.Scopes) != 2 {
-		t.Fatalf("Scopes length = %d, want 2", len(chain.Scopes))
+	if len(chain.Scopes) != 1 {
+		t.Fatalf("Scopes length = %d, want 1", len(chain.Scopes))
 	}
 	if !chain.Scopes[0].Valid || chain.Scopes[0].UUID != sysID {
 		t.Errorf("Scopes[0] = %v, want {UUID: %v, Valid: true}", chain.Scopes[0], sysID)
-	}
-	if chain.Scopes[1].Valid {
-		t.Errorf("Scopes[1].Valid = true, want false (global scope)")
 	}
 	// SystemWorkspaceID should equal the workspace itself
 	if chain.SystemWorkspaceID != sysID {
@@ -170,7 +163,6 @@ func TestChainResolver_CacheHit(t *testing.T) {
 		Scopes: []uuid.NullUUID{
 			{UUID: wsID, Valid: true},
 			{UUID: sysID, Valid: true},
-			{Valid: false},
 		},
 	}
 
@@ -201,8 +193,8 @@ func TestChainResolver_CacheHit(t *testing.T) {
 	if chain.WorkspaceID != wsID {
 		t.Errorf("WorkspaceID = %v, want %v", chain.WorkspaceID, wsID)
 	}
-	if len(chain.Scopes) != 3 {
-		t.Errorf("Scopes length = %d, want 3", len(chain.Scopes))
+	if len(chain.Scopes) != 2 {
+		t.Errorf("Scopes length = %d, want 2", len(chain.Scopes))
 	}
 }
 
@@ -275,7 +267,7 @@ func TestChainResolver_CacheSetFailureStillReturns(t *testing.T) {
 	if chain.WorkspaceID != wsID {
 		t.Errorf("WorkspaceID = %v, want %v", chain.WorkspaceID, wsID)
 	}
-	if len(chain.Scopes) != 3 {
-		t.Errorf("Scopes length = %d, want 3", len(chain.Scopes))
+	if len(chain.Scopes) != 2 {
+		t.Errorf("Scopes length = %d, want 2", len(chain.Scopes))
 	}
 }

--- a/internal/resolution/injector_merger_test.go
+++ b/internal/resolution/injector_merger_test.go
@@ -105,18 +105,18 @@ func newErrorChainResolver(retErr error) *resolution.ChainResolver {
 
 // --- Tests ---
 
-func TestInjectorMerger_IncludesGlobalDefinitionsAsFallback(t *testing.T) {
+func TestInjectorMerger_IncludesSystemDefinitionsAsFallback(t *testing.T) {
 	defID := uuid.New()
 	wsID := uuid.New()
 	sysID := uuid.New()
 
 	injStore := &mockInjectorStore{
 		listDefsFn: func(_ context.Context, chain []uuid.NullUUID) ([]*domain.InjectorDefinition, error) {
-			if len(chain) != 3 {
+			if len(chain) != 2 {
 				t.Fatalf("expected full resolution chain, got %+v", chain)
 			}
 			return []*domain.InjectorDefinition{
-				{ID: defID, WorkspaceID: nil, Name: "brand"},
+				{ID: defID, WorkspaceID: &sysID, Name: "brand"},
 			}, nil
 		},
 		getFieldsFn: func(_ context.Context, _ uuid.UUID) ([]*domain.InjectorField, error) {
@@ -126,7 +126,7 @@ func TestInjectorMerger_IncludesGlobalDefinitionsAsFallback(t *testing.T) {
 		},
 		getValuesFn: func(_ context.Context, _ uuid.UUID, _ []uuid.NullUUID) ([]*domain.InjectorValue, error) {
 			return []*domain.InjectorValue{
-				{ID: uuid.New(), InjectorDefinitionID: defID, FieldName: "logo_url", WorkspaceID: nil, Value: `"global-logo"`},
+				{ID: uuid.New(), InjectorDefinitionID: defID, FieldName: "logo_url", WorkspaceID: &sysID, Value: `"system-logo"`},
 			}, nil
 		},
 	}
@@ -135,7 +135,7 @@ func TestInjectorMerger_IncludesGlobalDefinitionsAsFallback(t *testing.T) {
 		WorkspaceID:       wsID,
 		SystemWorkspaceID: sysID,
 		TenantID:          uuid.New(),
-		Scopes:            []uuid.NullUUID{{UUID: wsID, Valid: true}, {UUID: sysID, Valid: true}, {Valid: false}},
+		Scopes:            []uuid.NullUUID{{UUID: wsID, Valid: true}, {UUID: sysID, Valid: true}},
 	}
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
@@ -145,8 +145,8 @@ func TestInjectorMerger_IncludesGlobalDefinitionsAsFallback(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got := result["brand"]["logo_url"]; got != "global-logo" {
-		t.Fatalf("brand.logo_url = %v, want global-logo", got)
+	if got := result["brand"]["logo_url"]; got != "system-logo" {
+		t.Fatalf("brand.logo_url = %v, want system-logo", got)
 	}
 }
 
@@ -373,22 +373,22 @@ func TestInjectorMerger_DuplicateDefNames_WorkspaceWins(t *testing.T) {
 	}
 }
 
-func TestInjectorMerger_UsesInheritedValueBeforeFieldDefault(t *testing.T) {
-	globalDefID := uuid.New()
+func TestInjectorMerger_UsesSystemInheritedValueBeforeFieldDefault(t *testing.T) {
+	systemDefID := uuid.New()
 	wsID := uuid.New()
 	sysID := uuid.New()
 
 	injStore := &mockInjectorStore{
 		listDefsFn: func(_ context.Context, _ []uuid.NullUUID) ([]*domain.InjectorDefinition, error) {
 			return []*domain.InjectorDefinition{
-				{ID: globalDefID, WorkspaceID: nil, Name: "brand"},
+				{ID: systemDefID, WorkspaceID: &sysID, Name: "brand"},
 			}, nil
 		},
 		getFieldsFn: func(_ context.Context, _ uuid.UUID) ([]*domain.InjectorField, error) {
 			return []*domain.InjectorField{
 				{
 					ID:                   uuid.New(),
-					InjectorDefinitionID: globalDefID,
+					InjectorDefinitionID: systemDefID,
 					FieldName:            "color",
 					FieldType:            domain.FieldTypeText,
 					Position:             0,
@@ -399,7 +399,7 @@ func TestInjectorMerger_UsesInheritedValueBeforeFieldDefault(t *testing.T) {
 		},
 		getValuesFn: func(_ context.Context, _ uuid.UUID, _ []uuid.NullUUID) ([]*domain.InjectorValue, error) {
 			return []*domain.InjectorValue{
-				{ID: uuid.New(), InjectorDefinitionID: globalDefID, FieldName: "color", WorkspaceID: nil, Value: `"global-blue"`},
+				{ID: uuid.New(), InjectorDefinitionID: systemDefID, FieldName: "color", WorkspaceID: &sysID, Value: `"system-blue"`},
 			}, nil
 		},
 	}
@@ -408,7 +408,7 @@ func TestInjectorMerger_UsesInheritedValueBeforeFieldDefault(t *testing.T) {
 		WorkspaceID:       wsID,
 		SystemWorkspaceID: sysID,
 		TenantID:          uuid.New(),
-		Scopes:            []uuid.NullUUID{{UUID: wsID, Valid: true}, {UUID: sysID, Valid: true}, {Valid: false}},
+		Scopes:            []uuid.NullUUID{{UUID: wsID, Valid: true}, {UUID: sysID, Valid: true}},
 	}
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
@@ -418,8 +418,8 @@ func TestInjectorMerger_UsesInheritedValueBeforeFieldDefault(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got := result["brand"]["color"]; got != "global-blue" {
-		t.Fatalf("brand.color = %v, want global-blue", got)
+	if got := result["brand"]["color"]; got != "system-blue" {
+		t.Fatalf("brand.color = %v, want system-blue", got)
 	}
 }
 
@@ -977,12 +977,12 @@ func TestResolveWithContext_LockedFieldAlwaysUsesDefault(t *testing.T) {
 		WorkspaceID:       wsID,
 		SystemWorkspaceID: sysID,
 		TenantID:          uuid.New(),
-		Scopes:            []uuid.NullUUID{{UUID: wsID, Valid: true}, {UUID: sysID, Valid: true}, {Valid: false}},
+		Scopes:            []uuid.NullUUID{{UUID: wsID, Valid: true}, {UUID: sysID, Valid: true}},
 	}
 
 	injStore := &mockInjectorStore{
 		listDefsFn: func(_ context.Context, _ []uuid.NullUUID) ([]*domain.InjectorDefinition, error) {
-			return []*domain.InjectorDefinition{{ID: defID, WorkspaceID: nil, Name: "student"}}, nil
+			return []*domain.InjectorDefinition{{ID: defID, WorkspaceID: &sysID, Name: "student"}}, nil
 		},
 		getFieldsFn: func(_ context.Context, _ uuid.UUID) ([]*domain.InjectorField, error) {
 			return []*domain.InjectorField{
@@ -999,7 +999,7 @@ func TestResolveWithContext_LockedFieldAlwaysUsesDefault(t *testing.T) {
 		},
 		getValuesFn: func(_ context.Context, _ uuid.UUID, _ []uuid.NullUUID) ([]*domain.InjectorValue, error) {
 			return []*domain.InjectorValue{
-				{ID: uuid.New(), InjectorDefinitionID: defID, FieldName: "name", WorkspaceID: nil, Value: `"Inherited DB"`},
+				{ID: uuid.New(), InjectorDefinitionID: defID, FieldName: "name", WorkspaceID: &sysID, Value: `"Inherited DB"`},
 			}, nil
 		},
 	}
@@ -1026,8 +1026,8 @@ func TestResolveWithContext_LockedFieldAlwaysUsesDefault(t *testing.T) {
 	}
 }
 
-func TestResolve_UsesDefinitionsAcrossTheFullChain(t *testing.T) {
-	globalDefID := uuid.New()
+func TestResolve_UsesDefinitionsAcrossWorkspaceAndSystemChain(t *testing.T) {
+	systemDefID := uuid.New()
 	wsDefID := uuid.New()
 	wsID := uuid.Must(uuid.NewV7())
 	sysID := uuid.Must(uuid.NewV7())
@@ -1035,13 +1035,13 @@ func TestResolve_UsesDefinitionsAcrossTheFullChain(t *testing.T) {
 		WorkspaceID:       wsID,
 		SystemWorkspaceID: sysID,
 		TenantID:          uuid.New(),
-		Scopes:            []uuid.NullUUID{{UUID: wsID, Valid: true}, {UUID: sysID, Valid: true}, {Valid: false}},
+		Scopes:            []uuid.NullUUID{{UUID: wsID, Valid: true}, {UUID: sysID, Valid: true}},
 	}
 
 	injStore := &mockInjectorStore{
 		listDefsFn: func(_ context.Context, _ []uuid.NullUUID) ([]*domain.InjectorDefinition, error) {
 			return []*domain.InjectorDefinition{
-				{ID: globalDefID, WorkspaceID: nil, Name: "global_only"},
+				{ID: systemDefID, WorkspaceID: &sysID, Name: "system_only"},
 				{ID: wsDefID, WorkspaceID: &wsID, Name: "workspace_only"},
 			}, nil
 		},
@@ -1057,14 +1057,14 @@ func TestResolve_UsesDefinitionsAcrossTheFullChain(t *testing.T) {
 					DefaultValue:         "Workspace",
 					AllowOverwrite:       true,
 				}}, nil
-			case globalDefID:
+			case systemDefID:
 				return []*domain.InjectorField{{
 					ID:                   uuid.New(),
-					InjectorDefinitionID: globalDefID,
+					InjectorDefinitionID: systemDefID,
 					FieldName:            "name",
 					FieldType:            domain.FieldTypeText,
 					Position:             0,
-					DefaultValue:         "Global",
+					DefaultValue:         "System",
 					AllowOverwrite:       true,
 				}}, nil
 			default:
@@ -1084,8 +1084,8 @@ func TestResolve_UsesDefinitionsAcrossTheFullChain(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got := result["global_only"]["name"]; got != "Global" {
-		t.Fatalf("global_only.name = %v, want Global", got)
+	if got := result["system_only"]["name"]; got != "System" {
+		t.Fatalf("system_only.name = %v, want System", got)
 	}
 	if got := result["workspace_only"]["name"]; got != "Workspace" {
 		t.Fatalf("workspace_only.name = %v, want Workspace", got)

--- a/internal/resolution/template_resolver_test.go
+++ b/internal/resolution/template_resolver_test.go
@@ -28,6 +28,9 @@ func (m *mockTemplateStore) FindTypeBySlugInScope(_ context.Context, _ string, _
 	return nil, nil
 }
 func (m *mockTemplateStore) CreateTemplate(_ context.Context, _ *domain.Template) error { return nil }
+func (m *mockTemplateStore) ForkTemplate(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ *uuid.UUID) (*domain.Template, error) {
+	return nil, domain.ErrNotFound
+}
 func (m *mockTemplateStore) GetByTypeAndScope(_ context.Context, _ uuid.UUID, _ *uuid.UUID) (*domain.Template, error) {
 	return nil, nil
 }

--- a/internal/service/onboarding.go
+++ b/internal/service/onboarding.go
@@ -187,26 +187,39 @@ func (s *OnboardingService) Setup(ctx context.Context, claims *port.OIDCClaims, 
 
 	// 5. Create _system workspace.
 	ws := &domain.Workspace{
-		ID:       uuid.Must(uuid.NewV7()),
-		TenantID: tenant.ID,
-		Code:     "_system",
-		Name:     "System",
-		IsSystem: true,
-		IsActive: true,
+		ID:                                   uuid.Must(uuid.NewV7()),
+		TenantID:                             tenant.ID,
+		Code:                                 "_system",
+		Name:                                 "System",
+		IsSystem:                             true,
+		IsActive:                             true,
+		AllowWorkspaceLocalTemplates:         true,
+		AllowWorkspaceInheritedTemplateForks: true,
+		AllowWorkspaceLocalInjectors:         true,
+		WorkspacePoliciesInitialized:         true,
 	}
 	if err := tx.QueryRow(ctx,
-		`INSERT INTO workspaces (id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale)
-		 VALUES (@id, @tenant_id, @code, @name, @is_system, @is_active, @open_tracking_enabled, @default_locale)
+		`INSERT INTO workspaces (
+		    id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale,
+		    allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors
+		)
+		 VALUES (
+		    @id, @tenant_id, @code, @name, @is_system, @is_active, @open_tracking_enabled, @default_locale,
+		    @allow_workspace_local_templates, @allow_workspace_inherited_template_forks, @allow_workspace_local_injectors
+		)
 		 RETURNING is_active, created_at, updated_at`,
 		pgx.NamedArgs{
-			"id":                    ws.ID,
-			"tenant_id":             ws.TenantID,
-			"code":                  ws.Code,
-			"name":                  ws.Name,
-			"is_system":             ws.IsSystem,
-			"is_active":             ws.IsActive,
-			"open_tracking_enabled": false,
-			"default_locale":        ws.DefaultLocale,
+			"id":                              ws.ID,
+			"tenant_id":                       ws.TenantID,
+			"code":                            ws.Code,
+			"name":                            ws.Name,
+			"is_system":                       ws.IsSystem,
+			"is_active":                       ws.IsActive,
+			"open_tracking_enabled":           false,
+			"default_locale":                  ws.DefaultLocale,
+			"allow_workspace_local_templates": ws.AllowWorkspaceLocalTemplates,
+			"allow_workspace_inherited_template_forks": ws.AllowWorkspaceInheritedTemplateForks,
+			"allow_workspace_local_injectors":          ws.AllowWorkspaceLocalInjectors,
 		},
 	).Scan(&ws.IsActive, &ws.CreatedAt, &ws.UpdatedAt); err != nil {
 		return nil, fmt.Errorf("create system workspace: %w", err)

--- a/internal/service/send_test.go
+++ b/internal/service/send_test.go
@@ -230,6 +230,9 @@ func (m *mockTemplateStoreSend) CreateTemplate(ctx context.Context, tpl *domain.
 	}
 	return nil
 }
+func (m *mockTemplateStoreSend) ForkTemplate(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ *uuid.UUID) (*domain.Template, error) {
+	return nil, domain.ErrNotFound
+}
 func (m *mockTemplateStoreSend) GetByTypeAndScope(ctx context.Context, typeID uuid.UUID, wsID *uuid.UUID) (*domain.Template, error) {
 	if m.getByTypeAndScopeFn != nil {
 		return m.getByTypeAndScopeFn(ctx, typeID, wsID)

--- a/internal/service/template.go
+++ b/internal/service/template.go
@@ -42,6 +42,16 @@ func (s *TemplateService) CreateTemplate(ctx context.Context, templateTypeID uui
 	return tpl, nil
 }
 
+// ForkTemplate clones a visible inherited template into the target workspace while preserving its functional type identity.
+func (s *TemplateService) ForkTemplate(
+	ctx context.Context,
+	sourceTemplateID uuid.UUID,
+	workspaceID uuid.UUID,
+	createdBy *uuid.UUID,
+) (*domain.Template, error) {
+	return s.store.ForkTemplate(ctx, sourceTemplateID, workspaceID, createdBy)
+}
+
 // ListByType returns templates for a given template type and scope.
 func (s *TemplateService) ListByType(ctx context.Context, typeID uuid.UUID, wsID *uuid.UUID, opts port.ListOptions) ([]*domain.Template, string, error) {
 	return s.store.ListByType(ctx, typeID, wsID, opts)

--- a/internal/service/template_test.go
+++ b/internal/service/template_test.go
@@ -20,6 +20,7 @@ type mockTemplateStore struct {
 	findTypeBySlugInScopeFn func(ctx context.Context, slug string, wsID *uuid.UUID) (*domain.TemplateType, error)
 	updateTypeFn            func(ctx context.Context, tt *domain.TemplateType) error
 	createTemplateFn        func(ctx context.Context, tpl *domain.Template) error
+	forkTemplateFn          func(ctx context.Context, sourceTemplateID uuid.UUID, workspaceID uuid.UUID, createdBy *uuid.UUID) (*domain.Template, error)
 	getByTypeAndScopeFn     func(ctx context.Context, typeID uuid.UUID, wsID *uuid.UUID) (*domain.Template, error)
 	resolveTemplateFn       func(ctx context.Context, typeID uuid.UUID, chain []uuid.NullUUID) (*domain.Template, error)
 	getTemplateByIDFn       func(ctx context.Context, id uuid.UUID) (*domain.Template, error)
@@ -59,6 +60,12 @@ func (m *mockTemplateStore) CreateTemplate(ctx context.Context, tpl *domain.Temp
 		return m.createTemplateFn(ctx, tpl)
 	}
 	return nil
+}
+func (m *mockTemplateStore) ForkTemplate(ctx context.Context, sourceTemplateID uuid.UUID, workspaceID uuid.UUID, createdBy *uuid.UUID) (*domain.Template, error) {
+	if m.forkTemplateFn != nil {
+		return m.forkTemplateFn(ctx, sourceTemplateID, workspaceID, createdBy)
+	}
+	return nil, domain.ErrNotFound
 }
 func (m *mockTemplateStore) GetByTypeAndScope(ctx context.Context, typeID uuid.UUID, wsID *uuid.UUID) (*domain.Template, error) {
 	if m.getByTypeAndScopeFn != nil {

--- a/internal/service/test_send_test.go
+++ b/internal/service/test_send_test.go
@@ -158,7 +158,7 @@ func TestTestSendService_ResolvesInjectorsWithRequestCodeAndDefaultPrecedence(t 
 	injectorDefinitionID := uuid.Must(uuid.NewV7())
 	injectorStore := &mockInjectorStoreSend{
 		listDefinitionsInChainFn: func(_ context.Context, chain []uuid.NullUUID) ([]*domain.InjectorDefinition, error) {
-			if len(chain) != 3 || !chain[0].Valid || chain[0].UUID != workspaceID {
+			if len(chain) != 2 || !chain[0].Valid || chain[0].UUID != workspaceID {
 				t.Fatalf("unexpected chain %+v", chain)
 			}
 			return []*domain.InjectorDefinition{

--- a/migrations/000038_workspace_policies_and_template_forks.down.sql
+++ b/migrations/000038_workspace_policies_and_template_forks.down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS idx_templates_origin_template_id;
+
+ALTER TABLE templates
+    DROP COLUMN IF EXISTS origin_template_id,
+    DROP COLUMN IF EXISTS is_fork;
+
+ALTER TABLE workspaces
+    DROP COLUMN IF EXISTS allow_workspace_local_injectors,
+    DROP COLUMN IF EXISTS allow_workspace_inherited_template_forks,
+    DROP COLUMN IF EXISTS allow_workspace_local_templates;

--- a/migrations/000038_workspace_policies_and_template_forks.up.sql
+++ b/migrations/000038_workspace_policies_and_template_forks.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE workspaces
+    ADD COLUMN allow_workspace_local_templates BOOLEAN NOT NULL DEFAULT true,
+    ADD COLUMN allow_workspace_inherited_template_forks BOOLEAN NOT NULL DEFAULT true,
+    ADD COLUMN allow_workspace_local_injectors BOOLEAN NOT NULL DEFAULT true;
+
+ALTER TABLE templates
+    ADD COLUMN is_fork BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN origin_template_id UUID REFERENCES templates(id);
+
+CREATE INDEX idx_templates_origin_template_id
+    ON templates (origin_template_id)
+    WHERE origin_template_id IS NOT NULL AND deleted_at IS NULL;

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -195,5 +195,189 @@
     "noWorkspacesFound": "No workspaces found",
     "noWorkspacesAvailable": "No workspaces available",
     "manageWorkspaces": "Manage workspaces"
+  },
+  "resourceState": {
+    "badges": {
+      "local": "Local",
+      "defaultSystem": "Default/System",
+      "forkedFromDefault": "Forked from Default",
+      "readOnly": "Read-only",
+      "workspace": "Workspace",
+      "global": "Global"
+    }
+  },
+  "scopeIndicator": {
+    "global": "Global",
+    "system": "Default",
+    "tenant": "Tenant",
+    "workspace": "Workspace"
+  },
+  "settingsPage": {
+    "accessDenied": {
+      "title": "Access denied",
+      "description": "Settings are available globally or from the tenant _system workspace."
+    },
+    "saveChanges": "Save Changes",
+    "saving": "Saving...",
+    "global": {
+      "loadErrorTitle": "Failed to load settings",
+      "loadErrorDescription": "Could not retrieve system settings. You may not have superadmin permissions.",
+      "saveSuccess": "Settings saved successfully",
+      "saveError": "Failed to save settings",
+      "oidcTitle": "OIDC Configuration",
+      "discoveryUrl": "Discovery URL",
+      "clientId": "Client ID",
+      "emailDefaultsTitle": "Email Defaults",
+      "maxRetries": "Max Retries",
+      "backoffBaseSeconds": "Backoff Base (sec)",
+      "logRetentionDays": "Log Retention (days)",
+      "alertsTitle": "Alerts",
+      "bounceThreshold": "Bounce Threshold %",
+      "complaintThreshold": "Complaint Threshold %"
+    },
+    "workspace": {
+      "loadErrorTitle": "Failed to load workspace policies",
+      "loadErrorDescription": "Could not retrieve tenant workspace policies from the _system workspace.",
+      "saveSuccess": "Workspace policies saved successfully",
+      "saveError": "Failed to save workspace policies",
+      "workspaceDefaultsPolicy": "Workspace Defaults Policy",
+      "workspaceDefaultsDescription": "These switches control what regular workspaces in this tenant can create locally, and whether they can fork a default template to manage workspace-only versions.",
+      "allowLocalTemplatesTitle": "Allow local template types and templates",
+      "allowLocalTemplatesDescription": "When disabled, workspaces still see tenant defaults but cannot create, edit, or delete local template definitions.",
+      "allowInheritedForksTitle": "Allow forks of inherited default templates",
+      "allowInheritedForksDescription": "When enabled, a workspace can clone a default template into a local fork to manage versions without editing template metadata.",
+      "allowLocalInjectorsTitle": "Allow local injectors",
+      "allowLocalInjectorsDescription": "When disabled, workspaces can still view and use _system injectors, but cannot create or edit local injector schemas."
+    }
+  },
+  "templateTypesPage": {
+    "columns": {
+      "slug": "SLUG",
+      "name": "NAME",
+      "adapter": "ADAPTER",
+      "scope": "SCOPE"
+    },
+    "noAdapter": "No adapter",
+    "viewTemplates": "View templates",
+    "viewTemplatesAria": "View templates for {slug}",
+    "editTemplateTypeAria": "Edit template type {slug}",
+    "deleteTemplateTypeAria": "Delete template type {slug}",
+    "localTemplateTypesDisabled": "Local template types are disabled by the tenant _system workspace policy.",
+    "defaultTemplateTypesReadonly": "Default template types are read-only in workspaces.",
+    "sharedSesRequiresIdentity": "Shared SES adapters require an explicit sender identity",
+    "templateTypeCreated": "Template type created",
+    "templateTypeCreateFailed": "Failed to create template type",
+    "templateTypeDeleted": "Template type deleted",
+    "templateTypeDeleteFailed": "Failed to delete template type",
+    "newTemplateType": "New Template Type",
+    "searchPlaceholder": "Search template types...",
+    "slugLabel": "Slug",
+    "localTemplateCreationDisabled": "Local template creation is disabled by the tenant _system workspace policy.",
+    "empty": {
+      "title": "No template types",
+      "description": "Create your first template type to organize your email templates."
+    },
+    "createDialog": {
+      "title": "Create Template Type",
+      "description": "Define a new template type for this scope.",
+      "namePlaceholder": "Welcome Email",
+      "slugPlaceholder": "welcome-email"
+    },
+    "deleteDialog": {
+      "title": "Delete Template Type",
+      "description": "Are you sure you want to delete \"{name}\"? This action cannot be undone."
+    }
+  },
+  "templatesPage": {
+    "templateTypeNotLoaded": "Template type not loaded",
+    "readOnlyDefaultMustFork": "This default template is read-only. Fork it first to manage workspace-only versions.",
+    "versionManagementDisabledInWorkspace": "Version management is disabled for this template in the current workspace.",
+    "localTemplateCreationDisabled": "Local template creation is disabled by the tenant _system workspace policy.",
+    "draftVersionCreated": "Draft version created",
+    "createVersionFailed": "Failed to create version",
+    "defaultTemplateNotLoaded": "Default template not loaded",
+    "publishSuccess": "Version {version} published",
+    "publishFailed": "Failed to publish version",
+    "forkVersionManagementOnly": "This fork keeps template metadata locked. Only version management is allowed when the tenant _system workspace policy permits it.",
+    "defaultTemplatesReadonly": "Default templates are read-only. Fork this template to manage workspace-only versions.",
+    "localTemplateChangesDisabled": "Local template changes are disabled by the tenant _system workspace policy.",
+    "columns": {
+      "version": "VERSION",
+      "createdBy": "CREATED BY",
+      "date": "DATE"
+    },
+    "openVersionAria": "Open version {version}",
+    "readOnlyBannerTitle": "This template is read-only in this workspace.",
+    "readOnlyBannerDescription": "Fork the default template to create workspace-only versions without changing template metadata.",
+    "versionsTitle": "Versions",
+    "forking": "Forking...",
+    "forkFromDefault": "Fork from Default",
+    "newVersion": "New Version",
+    "createDraftVersion": "Create a new draft version",
+    "forkFirstBeforeVersions": "Fork the default template first to manage workspace-only versions.",
+    "versionManagementDisabledForScope": "Version management is disabled for this scope.",
+    "empty": {
+      "title": "No versions yet",
+      "description": "Create your first template version to start building this email template."
+    },
+    "createVersion": "Create Version",
+    "publishDialog": {
+      "title": "Publish Version",
+      "description": "Are you sure you want to publish version {version}? This will replace the current published version."
+    },
+    "deleteDialog": {
+      "title": "Delete Draft Version",
+      "description": "Are you sure you want to delete version {version}? This action cannot be undone."
+    },
+    "deleteSuccess": "Draft version deleted",
+    "deleteFailed": "Failed to delete version",
+    "cloneSuccess": "Version {version} cloned as draft",
+    "cloneFailed": "Failed to clone version",
+    "actions": {
+      "editVersion": "Edit version",
+      "openVersion": "Open version",
+      "publish": "Publish",
+      "clone": "Clone"
+    }
+  },
+  "injectorsPage": {
+    "unsupportedScopeTitle": "Injectors are managed per writable scope",
+    "unsupportedScopeDescription": "Choose the global catalog or a workspace to define and edit injector schemas.",
+    "backToInjectors": "Back to Injectors",
+    "noDescription": "No description set for this injector yet.",
+    "editInjector": "Edit injector",
+    "localInjectorEditingDisabled": "Local injector editing is disabled by the tenant _system workspace policy.",
+    "defaultInjectorsReadonly": "Default injectors are read-only in workspaces.",
+    "replaceAllNotice": "Schema updates are replace-all: renames or type changes do not migrate existing template references, and all injector values for this definition are cleared when you save.",
+    "noFields": "No fields defined for this injector.",
+    "fieldMeta": {
+      "mode": "Mode",
+      "overwriteEnabled": "overwrite enabled",
+      "lockedToDefault": "locked to default",
+      "position": "Position",
+      "default": "Default",
+      "fieldType": "Field type"
+    },
+    "columns": {
+      "name": "NAME",
+      "scope": "SCOPE",
+      "fields": "FIELDS"
+    },
+    "fieldCount": "{count} fields",
+    "localInjectorManagementDisabled": "Local injector management is disabled by the tenant _system workspace policy.",
+    "viewFields": "View fields",
+    "searchPlaceholder": "Search injectors...",
+    "newInjector": "New Injector",
+    "createInScope": "Create a new injector in this scope",
+    "localInjectorCreationDisabled": "Local injector creation is disabled by the tenant _system workspace policy.",
+    "empty": {
+      "title": "No injectors defined",
+      "description": "Define the tokens your template builders can use and how each field resolves at runtime."
+    },
+    "addInjector": "Add Injector",
+    "deleteDialog": {
+      "title": "Delete Injector",
+      "description": "Are you sure you want to delete \"{name}\"? Templates using this injector will no longer see its fields in the builder."
+    }
   }
 }

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -195,5 +195,189 @@
     "noWorkspacesFound": "No se encontraron workspaces",
     "noWorkspacesAvailable": "No hay workspaces disponibles",
     "manageWorkspaces": "Gestionar workspaces"
+  },
+  "resourceState": {
+    "badges": {
+      "local": "Local",
+      "defaultSystem": "Default/System",
+      "forkedFromDefault": "Fork derivado del default",
+      "readOnly": "Solo lectura",
+      "workspace": "Workspace",
+      "global": "Global"
+    }
+  },
+  "scopeIndicator": {
+    "global": "Global",
+    "system": "Default",
+    "tenant": "Tenant",
+    "workspace": "Workspace"
+  },
+  "settingsPage": {
+    "accessDenied": {
+      "title": "Acceso denegado",
+      "description": "La configuración está disponible globalmente o desde el workspace _system del tenant."
+    },
+    "saveChanges": "Guardar cambios",
+    "saving": "Guardando...",
+    "global": {
+      "loadErrorTitle": "No se pudo cargar la configuración",
+      "loadErrorDescription": "No fue posible recuperar la configuración del sistema. Es posible que no tengas permisos de superadmin.",
+      "saveSuccess": "Configuración guardada correctamente",
+      "saveError": "No se pudo guardar la configuración",
+      "oidcTitle": "Configuración OIDC",
+      "discoveryUrl": "Discovery URL",
+      "clientId": "Client ID",
+      "emailDefaultsTitle": "Valores por defecto de email",
+      "maxRetries": "Máximo de reintentos",
+      "backoffBaseSeconds": "Base de backoff (seg)",
+      "logRetentionDays": "Retención de logs (días)",
+      "alertsTitle": "Alertas",
+      "bounceThreshold": "Umbral de bounce %",
+      "complaintThreshold": "Umbral de complaint %"
+    },
+    "workspace": {
+      "loadErrorTitle": "No se pudieron cargar las políticas del workspace",
+      "loadErrorDescription": "No fue posible recuperar las políticas del tenant desde el workspace _system.",
+      "saveSuccess": "Políticas del workspace guardadas correctamente",
+      "saveError": "No se pudieron guardar las políticas del workspace",
+      "workspaceDefaultsPolicy": "Política de defaults de workspace",
+      "workspaceDefaultsDescription": "Estos switches controlan qué pueden crear localmente los workspaces regulares del tenant y si pueden derivar un template default para gestionar versiones exclusivas del workspace.",
+      "allowLocalTemplatesTitle": "Permitir template types y templates locales",
+      "allowLocalTemplatesDescription": "Cuando está desactivado, los workspaces siguen viendo los defaults del tenant pero no pueden crear, editar ni eliminar definiciones locales.",
+      "allowInheritedForksTitle": "Permitir forks de templates default heredados",
+      "allowInheritedForksDescription": "Cuando está activado, un workspace puede clonar un template default a un fork local para gestionar versiones sin editar el metadata del template.",
+      "allowLocalInjectorsTitle": "Permitir injectors locales",
+      "allowLocalInjectorsDescription": "Cuando está desactivado, los workspaces pueden seguir viendo y usando injectors de _system, pero no crear ni editar esquemas locales."
+    }
+  },
+  "templateTypesPage": {
+    "columns": {
+      "slug": "SLUG",
+      "name": "NOMBRE",
+      "adapter": "ADAPTER",
+      "scope": "SCOPE"
+    },
+    "noAdapter": "Sin adapter",
+    "viewTemplates": "Ver templates",
+    "viewTemplatesAria": "Ver templates de {slug}",
+    "editTemplateTypeAria": "Editar template type {slug}",
+    "deleteTemplateTypeAria": "Eliminar template type {slug}",
+    "localTemplateTypesDisabled": "Los template types locales están deshabilitados por la política del workspace _system del tenant.",
+    "defaultTemplateTypesReadonly": "Los template types default son de solo lectura en workspaces.",
+    "sharedSesRequiresIdentity": "Los adapters SES compartidos requieren una identidad de envío explícita",
+    "templateTypeCreated": "Template type creado",
+    "templateTypeCreateFailed": "No se pudo crear el template type",
+    "templateTypeDeleted": "Template type eliminado",
+    "templateTypeDeleteFailed": "No se pudo eliminar el template type",
+    "newTemplateType": "Nuevo template type",
+    "searchPlaceholder": "Buscar template types...",
+    "slugLabel": "Slug",
+    "localTemplateCreationDisabled": "La creación local de templates está deshabilitada por la política del workspace _system del tenant.",
+    "empty": {
+      "title": "No hay template types",
+      "description": "Crea tu primer template type para organizar tus templates de email."
+    },
+    "createDialog": {
+      "title": "Crear template type",
+      "description": "Define un nuevo template type para este scope.",
+      "namePlaceholder": "Email de bienvenida",
+      "slugPlaceholder": "email-bienvenida"
+    },
+    "deleteDialog": {
+      "title": "Eliminar template type",
+      "description": "¿Seguro que quieres eliminar \"{name}\"? Esta acción no se puede deshacer."
+    }
+  },
+  "templatesPage": {
+    "templateTypeNotLoaded": "Template type no cargado",
+    "readOnlyDefaultMustFork": "Este template default es de solo lectura. Haz fork primero para gestionar versiones exclusivas del workspace.",
+    "versionManagementDisabledInWorkspace": "La gestión de versiones está deshabilitada para este template en el workspace actual.",
+    "localTemplateCreationDisabled": "La creación local de templates está deshabilitada por la política del workspace _system del tenant.",
+    "draftVersionCreated": "Versión draft creada",
+    "createVersionFailed": "No se pudo crear la versión",
+    "defaultTemplateNotLoaded": "Template default no cargado",
+    "publishSuccess": "Versión {version} publicada",
+    "publishFailed": "No se pudo publicar la versión",
+    "forkVersionManagementOnly": "Este fork mantiene bloqueado el metadata del template. Solo se permite gestionar versiones cuando la política del workspace _system del tenant lo permite.",
+    "defaultTemplatesReadonly": "Los templates default son de solo lectura. Haz fork de este template para gestionar versiones exclusivas del workspace.",
+    "localTemplateChangesDisabled": "Los cambios locales de templates están deshabilitados por la política del workspace _system del tenant.",
+    "columns": {
+      "version": "VERSIÓN",
+      "createdBy": "CREADO POR",
+      "date": "FECHA"
+    },
+    "openVersionAria": "Abrir versión {version}",
+    "readOnlyBannerTitle": "Este template es de solo lectura en este workspace.",
+    "readOnlyBannerDescription": "Haz fork del template default para crear versiones exclusivas del workspace sin cambiar el metadata del template.",
+    "versionsTitle": "Versiones",
+    "forking": "Derivando...",
+    "forkFromDefault": "Fork desde default",
+    "newVersion": "Nueva versión",
+    "createDraftVersion": "Crear una nueva versión draft",
+    "forkFirstBeforeVersions": "Haz fork del template default primero para gestionar versiones exclusivas del workspace.",
+    "versionManagementDisabledForScope": "La gestión de versiones está deshabilitada para este scope.",
+    "empty": {
+      "title": "Aún no hay versiones",
+      "description": "Crea tu primera versión para empezar a construir este template de email."
+    },
+    "createVersion": "Crear versión",
+    "publishDialog": {
+      "title": "Publicar versión",
+      "description": "¿Seguro que quieres publicar la versión {version}? Esto reemplazará la versión publicada actual."
+    },
+    "deleteDialog": {
+      "title": "Eliminar versión draft",
+      "description": "¿Seguro que quieres eliminar la versión {version}? Esta acción no se puede deshacer."
+    },
+    "deleteSuccess": "Versión draft eliminada",
+    "deleteFailed": "No se pudo eliminar la versión",
+    "cloneSuccess": "Versión {version} clonada como draft",
+    "cloneFailed": "No se pudo clonar la versión",
+    "actions": {
+      "editVersion": "Editar versión",
+      "openVersion": "Abrir versión",
+      "publish": "Publicar",
+      "clone": "Clonar"
+    }
+  },
+  "injectorsPage": {
+    "unsupportedScopeTitle": "Los injectors se gestionan por scope escribible",
+    "unsupportedScopeDescription": "Elige el catálogo global o un workspace para definir y editar esquemas de injectors.",
+    "backToInjectors": "Volver a injectors",
+    "noDescription": "Este injector todavía no tiene descripción.",
+    "editInjector": "Editar injector",
+    "localInjectorEditingDisabled": "La edición de injectors locales está deshabilitada por la política del workspace _system del tenant.",
+    "defaultInjectorsReadonly": "Los injectors default son de solo lectura en workspaces.",
+    "replaceAllNotice": "Las actualizaciones de esquema reemplazan todo: renombres o cambios de tipo no migran referencias existentes en templates, y todos los valores del injector se limpian al guardar.",
+    "noFields": "Este injector no tiene campos definidos.",
+    "fieldMeta": {
+      "mode": "Modo",
+      "overwriteEnabled": "overwrite habilitado",
+      "lockedToDefault": "bloqueado al default",
+      "position": "Posición",
+      "default": "Default",
+      "fieldType": "Tipo de campo"
+    },
+    "columns": {
+      "name": "NOMBRE",
+      "scope": "SCOPE",
+      "fields": "CAMPOS"
+    },
+    "fieldCount": "{count} campos",
+    "localInjectorManagementDisabled": "La gestión de injectors locales está deshabilitada por la política del workspace _system del tenant.",
+    "viewFields": "Ver campos",
+    "searchPlaceholder": "Buscar injectors...",
+    "newInjector": "Nuevo injector",
+    "createInScope": "Crear un injector nuevo en este scope",
+    "localInjectorCreationDisabled": "La creación local de injectors está deshabilitada por la política del workspace _system del tenant.",
+    "empty": {
+      "title": "No hay injectors definidos",
+      "description": "Define los tokens que tus templates pueden usar y cómo resuelve cada campo en runtime."
+    },
+    "addInjector": "Agregar injector",
+    "deleteDialog": {
+      "title": "Eliminar injector",
+      "description": "¿Seguro que quieres eliminar \"{name}\"? Los templates que usan este injector dejarán de ver sus campos en el builder."
+    }
   }
 }

--- a/web/src/components/injectors/injectors-content.tsx
+++ b/web/src/components/injectors/injectors-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Database,
   ArrowLeft,
@@ -13,15 +14,22 @@ import {
 } from "lucide-react";
 import { useScope, useScopedPath } from "@/hooks/use-scope";
 import {
+  getInjectorManagementState,
+  resolveResourceDisplayScope,
+} from "@/lib/workspace-resource-policies";
+import {
   useInjectorList,
   useInjectorDetail,
   useCreateInjector,
   useDeleteInjector,
   useUpdateInjector,
 } from "@/hooks/use-injectors";
+import { useResolvedWorkspacePolicies } from "@/hooks/use-settings";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
 import { DataTable } from "@/components/shared/data-table";
 import { EmptyState } from "@/components/shared/empty-state";
+import { ResourceStateBadges } from "@/components/shared/resource-state-badges";
+import { ScopeIndicator } from "@/components/shared/scope-indicator";
 import { InjectorFieldCard } from "@/components/injectors/injector-field-card";
 import { InjectorForm } from "./injector-form";
 import {
@@ -31,7 +39,6 @@ import {
 } from "@/components/injectors/injector-form-model";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
@@ -46,14 +53,15 @@ import type {
 } from "@/types/injectors";
 
 export function InjectorsContent() {
+  const t = useTranslations("injectorsPage");
   const scope = useScope();
 
   if (!supportsInjectorManagementScope(scope.level)) {
     return (
       <EmptyState
         icon={Database}
-        title="Injectors are managed per writable scope"
-        description="Choose the global catalog or a workspace to define and edit injector schemas."
+        title={t("unsupportedScopeTitle")}
+        description={t("unsupportedScopeDescription")}
       />
     );
   }
@@ -62,14 +70,19 @@ export function InjectorsContent() {
 }
 
 function InjectorsTable() {
+  const t = useTranslations("injectorsPage");
+  const tCommon = useTranslations("common");
   const scope = useScope();
   const scopedPath = useScopedPath();
+  const workspacePolicies = useResolvedWorkspacePolicies(scope);
   const [selectedInjector, setSelectedInjector] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
   const [editingOpen, setEditingOpen] = useState(false);
 
-  const { data: listData, isLoading: listLoading } = useInjectorList(scopedPath);
+  const { data: listData, isLoading: listLoading } = useInjectorList(scopedPath, {
+    includeInherited: scope.level === "workspace",
+  });
   const createInjector = useCreateInjector(scopedPath);
   const updateInjector = useUpdateInjector(scopedPath);
   const deleteInjector = useDeleteInjector(scopedPath);
@@ -104,131 +117,38 @@ function InjectorsTable() {
     setEditingOpen(false);
   }
 
-  const selectedCanEdit = canEditInjectorSchema(scope.level, detail);
+  const selectedState = getInjectorManagementState(
+    scope,
+    detail,
+    workspacePolicies.data,
+  );
+  const selectedCanEdit = canEditInjectorSchema(scope.level, detail) && selectedState.canEdit;
+  const canCreateInjectors =
+    scope.level !== "workspace" ||
+    workspacePolicies.data?.allow_workspace_local_injectors === true;
 
   if (selectedInjector) {
     return (
-      <div className="flex flex-col gap-6">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => {
-            setEditingOpen(false);
-            setSelectedInjector(null);
-          }}
-          className="w-fit gap-2"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Back to Injectors
-        </Button>
-
-        {detailLoading ? (
-          <InjectorDetailSkeleton />
-        ) : detail ? (
-          <div className="animate-in fade-in duration-300 flex flex-col gap-5">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex flex-col gap-2">
-                <div className="flex items-center gap-2">
-                  <h2 className="text-xl font-semibold" style={{ letterSpacing: "-1px" }}>
-                    {detail.name}
-                  </h2>
-                  <Badge variant="outline">
-                    {detail.workspace_id ? "Workspace" : "Global"}
-                  </Badge>
-                </div>
-                {detail.description ? (
-                  <p className="text-sm text-muted-foreground">{detail.description}</p>
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    No description set for this injector yet.
-                  </p>
-                )}
-              </div>
-
-              {selectedCanEdit ? (
-                <InjectorForm
-                  key={`edit-${detail.name}`}
-                  mode="edit"
-                  injector={detail}
-                  open={editingOpen}
-                  onOpenChange={setEditingOpen}
-                  onSubmit={handleUpdate}
-                  trigger={
-                    <Button className="gap-2">
-                      <Pencil className="h-4 w-4" />
-                      Edit injector
-                    </Button>
-                  }
-                />
-              ) : (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span>
-                      <Button disabled className="gap-2">
-                        <Pencil className="h-4 w-4" />
-                        Edit injector
-                      </Button>
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Only injectors owned by the current writable scope can be edited.
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </div>
-
-            <div className="rounded-lg border bg-muted/20 p-4 text-sm text-muted-foreground">
-              Schema updates are replace-all: renames or type changes do not migrate
-              existing template references, and all injector values for this definition are
-              cleared when you save.
-            </div>
-
-            <div className="flex flex-col gap-4">
-              {(detail.fields ?? []).length === 0 ? (
-                <p className="text-sm text-muted-foreground italic">
-                  No fields defined for this injector.
-                </p>
-              ) : (
-                [...(detail.fields ?? [])]
-                  .sort((a, b) => a.position - b.position)
-                  .map((field) => (
-                    <InjectorFieldCard
-                      key={field.field_name}
-                      title={field.field_name}
-                      typeLabel={field.field_type}
-                      description={field.description}
-                    >
-                      <div className="grid gap-3 text-sm text-muted-foreground md:grid-cols-2">
-                        <FieldMeta
-                          label="Mode"
-                          value={
-                            field.allow_overwrite ? "overwrite enabled" : "locked to default"
-                          }
-                        />
-                        <FieldMeta
-                          label="Position"
-                          value={String(field.position + 1)}
-                        />
-                        <FieldMeta
-                          label="Default"
-                          value={formatDefaultValue(field.default_value)}
-                        />
-                        <FieldMeta label="Field type" value={field.field_type} />
-                      </div>
-                    </InjectorFieldCard>
-                  ))
-              )}
-            </div>
-          </div>
-        ) : null}
-      </div>
+      <InjectorDetailSection
+        detail={detail}
+        detailLoading={detailLoading}
+        editingOpen={editingOpen}
+        onOpenChange={setEditingOpen}
+        onBack={() => {
+          setEditingOpen(false);
+          setSelectedInjector(null);
+        }}
+        onSubmit={handleUpdate}
+        selectedCanEdit={selectedCanEdit}
+        selectedState={selectedState}
+      />
     );
   }
 
   const listColumns: ColumnDef<InjectorDefinition, unknown>[] = [
     {
       accessorKey: "name",
-      header: "NAME",
+      header: t("columns.name"),
       cell: ({ row }) => (
         <button
           onClick={() => setSelectedInjector(row.original.name)}
@@ -240,7 +160,7 @@ function InjectorsTable() {
     },
     {
       accessorKey: "description",
-      header: "DESCRIPTION",
+      header: tCommon("description"),
       cell: ({ row }) => (
         <span className="text-sm text-muted-foreground">
           {row.original.description ?? "\u2014"}
@@ -249,15 +169,24 @@ function InjectorsTable() {
     },
     {
       id: "scope",
-      header: "SCOPE",
+      header: t("columns.scope"),
       enableSorting: false,
       cell: ({ row }) => (
-        <Badge variant="outline">{row.original.workspace_id ? "Workspace" : "Global"}</Badge>
+        <div className="flex flex-wrap items-center gap-2">
+          <ScopeIndicator scope={resolveResourceDisplayScope(row.original)} />
+          <ResourceStateBadges
+            badges={getInjectorManagementState(
+              scope,
+              row.original,
+              workspacePolicies.data,
+            ).badges}
+          />
+        </div>
       ),
     },
     {
       id: "defaults",
-      header: "FIELDS",
+      header: t("columns.fields"),
       enableSorting: false,
       cell: ({ row }) => {
         const fieldCount = row.original.fields?.length ?? 0;
@@ -267,7 +196,7 @@ function InjectorsTable() {
 
         return (
           <div className="flex flex-col gap-1 text-xs text-muted-foreground">
-            <span className="font-mono">{fieldCount} fields</span>
+            <span className="font-mono">{t("fieldCount", { count: fieldCount })}</span>
             <span className="flex items-center gap-3">
               <span className="inline-flex items-center gap-1">
                 <Lock className="h-3 w-3" />
@@ -284,36 +213,53 @@ function InjectorsTable() {
     },
     {
       id: "actions",
-      cell: ({ row }) => (
-        <div className="flex items-center justify-end gap-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                onClick={() => setSelectedInjector(row.original.name)}
-              >
-                <Eye className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>View fields</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-destructive"
-                onClick={() => setDeleteTarget(row.original)}
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Delete</TooltipContent>
-          </Tooltip>
-        </div>
-      ),
+      cell: ({ row }) => {
+        const itemState = getInjectorManagementState(
+          scope,
+          row.original,
+          workspacePolicies.data,
+        );
+        const deleteReason =
+          row.original.owner_scope === "local"
+            ? t("localInjectorManagementDisabled")
+            : t("defaultInjectorsReadonly");
+
+        return (
+          <div className="flex items-center justify-end gap-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => setSelectedInjector(row.original.name)}
+                >
+                  <Eye className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t("viewFields")}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-destructive"
+                    onClick={() => itemState.canDelete && setDeleteTarget(row.original)}
+                    disabled={!itemState.canDelete}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {itemState.canDelete ? tCommon("delete") : deleteReason}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        );
+      },
     },
   ];
 
@@ -321,19 +267,31 @@ function InjectorsTable() {
     <div className="flex flex-col gap-6">
       <div className="flex items-center justify-between gap-4">
         <Input
-          placeholder="Search injectors..."
+          placeholder={t("searchPlaceholder")}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="w-[280px]"
         />
-        <Button
-          className="gap-2"
-          data-testid="injector-create-trigger"
-          onClick={() => setCreateOpen(true)}
-        >
-          <Plus className="h-4 w-4" />
-          New Injector
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <Button
+                className="gap-2"
+                data-testid="injector-create-trigger"
+                onClick={() => canCreateInjectors && setCreateOpen(true)}
+                disabled={!canCreateInjectors}
+              >
+                <Plus className="h-4 w-4" />
+                {t("newInjector")}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {canCreateInjectors
+              ? t("createInScope")
+              : t("localInjectorCreationDisabled")}
+          </TooltipContent>
+        </Tooltip>
       </div>
 
       <DataTable
@@ -343,16 +301,17 @@ function InjectorsTable() {
         emptyState={
           <EmptyState
             icon={Database}
-            title="No injectors defined"
-            description="Define the tokens your template builders can use and how each field resolves at runtime."
+            title={t("empty.title")}
+            description={t("empty.description")}
             action={
               <Button
                 className="gap-2"
                 data-testid="injector-empty-create-trigger"
                 onClick={() => setCreateOpen(true)}
+                disabled={!canCreateInjectors}
               >
                 <Plus className="h-4 w-4" />
-                Add Injector
+                {t("addInjector")}
               </Button>
             }
           />
@@ -368,9 +327,9 @@ function InjectorsTable() {
       <ConfirmDialog
         open={!!deleteTarget}
         onOpenChange={(nextOpen) => !nextOpen && setDeleteTarget(null)}
-        title="Delete Injector"
-        description={`Are you sure you want to delete "${deleteTarget?.name}"? Templates using this injector will no longer see its fields in the builder.`}
-        confirmLabel="Delete"
+        title={t("deleteDialog.title")}
+        description={t("deleteDialog.description", { name: deleteTarget?.name ?? "" })}
+        confirmLabel={tCommon("delete")}
         onConfirm={async () => {
           if (!deleteTarget) {
             return;
@@ -380,6 +339,142 @@ function InjectorsTable() {
           setDeleteTarget(null);
         }}
       />
+    </div>
+  );
+}
+
+function InjectorDetailSection({
+  detail,
+  detailLoading,
+  editingOpen,
+  onOpenChange,
+  onBack,
+  onSubmit,
+  selectedCanEdit,
+  selectedState,
+}: {
+  detail: InjectorDefinition | undefined;
+  detailLoading: boolean;
+  editingOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onBack: () => void;
+  onSubmit: (data: UpdateInjectorRequest) => Promise<void>;
+  selectedCanEdit: boolean;
+  selectedState: ReturnType<typeof getInjectorManagementState>;
+}) {
+  const t = useTranslations("injectorsPage");
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onBack}
+        className="w-fit gap-2"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t("backToInjectors")}
+      </Button>
+
+      {detailLoading ? (
+        <InjectorDetailSkeleton />
+      ) : detail ? (
+        <div className="animate-in fade-in duration-300 flex flex-col gap-5">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <h2 className="text-xl font-semibold" style={{ letterSpacing: "-1px" }}>
+                  {detail.name}
+                </h2>
+                <ScopeIndicator scope={resolveResourceDisplayScope(detail)} />
+                <ResourceStateBadges badges={selectedState.badges} />
+              </div>
+              {detail.description ? (
+                <p className="text-sm text-muted-foreground">{detail.description}</p>
+              ) : (
+                <p className="text-sm text-muted-foreground">{t("noDescription")}</p>
+              )}
+            </div>
+
+            {selectedCanEdit ? (
+              <InjectorForm
+                key={`edit-${detail.name}`}
+                mode="edit"
+                injector={detail}
+                open={editingOpen}
+                onOpenChange={onOpenChange}
+                onSubmit={onSubmit}
+                trigger={
+                  <Button className="gap-2">
+                    <Pencil className="h-4 w-4" />
+                    {t("editInjector")}
+                  </Button>
+                }
+              />
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Button disabled className="gap-2">
+                      <Pencil className="h-4 w-4" />
+                      {t("editInjector")}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {detail.owner_scope === "local"
+                    ? t("localInjectorEditingDisabled")
+                    : t("defaultInjectorsReadonly")}
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+
+          <div className="rounded-lg border bg-muted/20 p-4 text-sm text-muted-foreground">
+            {t("replaceAllNotice")}
+          </div>
+
+          <div className="flex flex-col gap-4">
+            {(detail.fields ?? []).length === 0 ? (
+              <p className="text-sm text-muted-foreground italic">{t("noFields")}</p>
+            ) : (
+              [...(detail.fields ?? [])]
+                .sort((a, b) => a.position - b.position)
+                .map((field) => (
+                  <InjectorFieldCard
+                    key={field.field_name}
+                    title={field.field_name}
+                    typeLabel={field.field_type}
+                    description={field.description}
+                  >
+                    <div className="grid gap-3 text-sm text-muted-foreground md:grid-cols-2">
+                      <FieldMeta
+                        label={t("fieldMeta.mode")}
+                        value={
+                          field.allow_overwrite
+                            ? t("fieldMeta.overwriteEnabled")
+                            : t("fieldMeta.lockedToDefault")
+                        }
+                      />
+                      <FieldMeta
+                        label={t("fieldMeta.position")}
+                        value={String(field.position + 1)}
+                      />
+                      <FieldMeta
+                        label={t("fieldMeta.default")}
+                        value={formatDefaultValue(field.default_value)}
+                      />
+                      <FieldMeta
+                        label={t("fieldMeta.fieldType")}
+                        value={field.field_type}
+                      />
+                    </div>
+                  </InjectorFieldCard>
+                ))
+            )}
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/settings/settings-content.tsx
+++ b/web/src/components/settings/settings-content.tsx
@@ -2,11 +2,20 @@
 
 import { useEffect } from "react";
 import { useMinimumLoading } from "@/hooks/use-minimum-loading";
-import { useForm } from "react-hook-form";
+import { type UseFormRegisterReturn, useForm } from "react-hook-form";
 import { Save, ShieldAlert } from "lucide-react";
 import { toast } from "sonner";
 import { useScope } from "@/hooks/use-scope";
-import { useSettings, useUpdateSettings } from "@/hooks/use-settings";
+import {
+  canManageSystemWorkspacePolicies,
+  canShowGlobalSettings,
+} from "@/lib/workspace-resource-policies";
+import {
+  useResolvedWorkspacePolicies,
+  useSettings,
+  useUpdateSettings,
+  useUpdateWorkspacePolicies,
+} from "@/hooks/use-settings";
 import { SettingsSection } from "@/components/settings/settings-section";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -14,7 +23,10 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/shared/empty-state";
 import { ThemeSelector } from "@/components/shared/theme-selector";
-import type { UpdateSettingsRequest } from "@/types/settings";
+import type {
+  UpdateSettingsRequest,
+  UpdateWorkspacePoliciesRequest,
+} from "@/types/settings";
 import { useTranslations } from "next-intl";
 
 interface SettingsFormValues {
@@ -23,6 +35,12 @@ interface SettingsFormValues {
   log_retention_days: number;
   bounce_threshold_percent: number;
   complaint_threshold_percent: number;
+}
+
+interface WorkspacePolicyFormValues {
+  allow_workspace_local_templates: boolean;
+  allow_workspace_inherited_template_forks: boolean;
+  allow_workspace_local_injectors: boolean;
 }
 
 function SettingsFormSkeleton() {
@@ -48,13 +66,55 @@ function SettingsFormSkeleton() {
 }
 
 export function SettingsContent() {
+  const tSettings = useTranslations("settingsPage");
   const tTheme = useTranslations("theme");
   const tAppearance = useTranslations("appearance");
   const scope = useScope();
+  const showGlobalSettings = canShowGlobalSettings(scope);
+  const showSystemPolicies = canManageSystemWorkspacePolicies(scope);
+
+  if (!showGlobalSettings && !showSystemPolicies) {
+    return (
+      <EmptyState
+        icon={ShieldAlert}
+        title={tSettings("accessDenied.title")}
+        description={tSettings("accessDenied.description")}
+      />
+    );
+  }
+
+  if (showGlobalSettings) {
+    return (
+      <GlobalSettingsContent
+        appearanceTitle={tAppearance("title")}
+        appearanceDescription={tAppearance("description")}
+        themeLabel={tTheme("label")}
+      />
+    );
+  }
+
+  return (
+    <WorkspacePolicySettingsContent
+      appearanceTitle={tAppearance("title")}
+      appearanceDescription={tAppearance("description")}
+      themeLabel={tTheme("label")}
+    />
+  );
+}
+
+function GlobalSettingsContent({
+  appearanceTitle,
+  appearanceDescription,
+  themeLabel,
+}: {
+  appearanceTitle: string;
+  appearanceDescription: string;
+  themeLabel: string;
+}) {
+  const tSettings = useTranslations("settingsPage");
   const { data, isLoading: rawLoading, error } = useSettings();
   const isLoading = useMinimumLoading(rawLoading);
   const updateSettings = useUpdateSettings();
-
   const { register, handleSubmit, reset } = useForm<SettingsFormValues>();
 
   useEffect(() => {
@@ -69,25 +129,14 @@ export function SettingsContent() {
     }
   }, [data, reset]);
 
-  // Guard: settings only at global scope
-  if (scope.level !== "global") {
-    return (
-      <EmptyState
-        icon={ShieldAlert}
-        title="Access denied"
-        description="Settings are only available at the global scope for superadmin users."
-      />
-    );
-  }
-
   if (isLoading) return <SettingsFormSkeleton />;
 
   if (error && !data) {
     return (
       <EmptyState
         icon={ShieldAlert}
-        title="Failed to load settings"
-        description="Could not retrieve system settings. You may not have superadmin permissions."
+        title={tSettings("global.loadErrorTitle")}
+        description={tSettings("global.loadErrorDescription")}
       />
     );
   }
@@ -107,19 +156,19 @@ export function SettingsContent() {
 
     try {
       await updateSettings.mutateAsync(payload);
-      toast.success("Settings saved successfully");
+      toast.success(tSettings("global.saveSuccess"));
     } catch {
-      toast.error("Failed to save settings");
+      toast.error(tSettings("global.saveError"));
     }
   };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-8 animate-in fade-in duration-300">
       {/* OIDC Section — read only */}
-      <SettingsSection title="OIDC Configuration">
+      <SettingsSection title={tSettings("global.oidcTitle")}>
         <div className="flex flex-col gap-3">
           <div className="space-y-1.5">
-            <Label className="text-[13px] font-medium">Discovery URL</Label>
+            <Label className="text-[13px] font-medium">{tSettings("global.discoveryUrl")}</Label>
             <Input
               readOnly
               value={data?.oidc.discovery_url ?? ""}
@@ -127,7 +176,7 @@ export function SettingsContent() {
             />
           </div>
           <div className="space-y-1.5">
-            <Label className="text-[13px] font-medium">Client ID</Label>
+            <Label className="text-[13px] font-medium">{tSettings("global.clientId")}</Label>
             <Input
               readOnly
               value={data?.oidc.client_id ?? ""}
@@ -138,10 +187,10 @@ export function SettingsContent() {
       </SettingsSection>
 
       {/* Email Defaults Section */}
-      <SettingsSection title="Email Defaults">
+      <SettingsSection title={tSettings("global.emailDefaultsTitle")}>
         <div className="flex gap-4">
           <div className="flex-1 space-y-1.5">
-            <Label className="text-[13px] font-medium">Max Retries</Label>
+            <Label className="text-[13px] font-medium">{tSettings("global.maxRetries")}</Label>
             <Input
               type="number"
               {...register("max_retries", { valueAsNumber: true })}
@@ -150,7 +199,7 @@ export function SettingsContent() {
           </div>
           <div className="flex-1 space-y-1.5">
             <Label className="text-[13px] font-medium">
-              Backoff Base (sec)
+              {tSettings("global.backoffBaseSeconds")}
             </Label>
             <Input
               type="number"
@@ -160,7 +209,7 @@ export function SettingsContent() {
           </div>
           <div className="flex-1 space-y-1.5">
             <Label className="text-[13px] font-medium">
-              Log Retention (days)
+              {tSettings("global.logRetentionDays")}
             </Label>
             <Input
               type="number"
@@ -172,11 +221,11 @@ export function SettingsContent() {
       </SettingsSection>
 
       {/* Alerts Section */}
-      <SettingsSection title="Alerts">
+      <SettingsSection title={tSettings("global.alertsTitle")}>
         <div className="flex gap-4">
           <div className="flex-1 space-y-1.5">
             <Label className="text-[13px] font-medium">
-              Bounce Threshold %
+              {tSettings("global.bounceThreshold")}
             </Label>
             <Input
               type="number"
@@ -189,7 +238,7 @@ export function SettingsContent() {
           </div>
           <div className="flex-1 space-y-1.5">
             <Label className="text-[13px] font-medium">
-              Complaint Threshold %
+              {tSettings("global.complaintThreshold")}
             </Label>
             <Input
               type="number"
@@ -203,12 +252,12 @@ export function SettingsContent() {
         </div>
       </SettingsSection>
 
-      <SettingsSection title={tAppearance("title")}>
+      <SettingsSection title={appearanceTitle}>
         <div className="space-y-4">
           <div className="space-y-1.5">
-            <Label className="text-[13px] font-medium">{tTheme("label")}</Label>
+            <Label className="text-[13px] font-medium">{themeLabel}</Label>
             <p className="text-sm text-muted-foreground">
-              {tAppearance("description")}
+              {appearanceDescription}
             </p>
           </div>
           <ThemeSelector variant="inline" />
@@ -223,9 +272,163 @@ export function SettingsContent() {
           disabled={updateSettings.isPending}
         >
           <Save className="h-4 w-4" />
-          {updateSettings.isPending ? "Saving..." : "Save Changes"}
+          {updateSettings.isPending
+            ? tSettings("saving")
+            : tSettings("saveChanges")}
         </Button>
       </div>
     </form>
+  );
+}
+
+function WorkspacePolicySettingsContent({
+  appearanceTitle,
+  appearanceDescription,
+  themeLabel,
+}: {
+  appearanceTitle: string;
+  appearanceDescription: string;
+  themeLabel: string;
+}) {
+  const tSettings = useTranslations("settingsPage");
+  const scope = useScope();
+  const { data, isLoading: rawLoading, error } = useResolvedWorkspacePolicies(scope);
+  const isLoading = useMinimumLoading(rawLoading);
+  const updatePolicies = useUpdateWorkspacePolicies(scope.tenantCode);
+  const { register, getValues, reset } = useForm<WorkspacePolicyFormValues>();
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+    reset({
+      allow_workspace_local_templates: data.allow_workspace_local_templates,
+      allow_workspace_inherited_template_forks:
+        data.allow_workspace_inherited_template_forks,
+      allow_workspace_local_injectors: data.allow_workspace_local_injectors,
+    });
+  }, [data, reset]);
+
+  if (isLoading) return <SettingsFormSkeleton />;
+
+  if (error && !data) {
+    return (
+      <EmptyState
+        icon={ShieldAlert}
+        title={tSettings("workspace.loadErrorTitle")}
+        description={tSettings("workspace.loadErrorDescription")}
+      />
+    );
+  }
+
+  const savePolicies = async (values: WorkspacePolicyFormValues) => {
+    const payload: UpdateWorkspacePoliciesRequest = {
+      allow_workspace_local_templates: Boolean(
+        values.allow_workspace_local_templates,
+      ),
+      allow_workspace_inherited_template_forks: Boolean(
+        values.allow_workspace_inherited_template_forks,
+      ),
+      allow_workspace_local_injectors: Boolean(
+        values.allow_workspace_local_injectors,
+      ),
+    };
+
+    try {
+      await updatePolicies.mutateAsync(payload);
+      toast.success(tSettings("workspace.saveSuccess"));
+    } catch {
+      toast.error(tSettings("workspace.saveError"));
+    }
+  };
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void savePolicies(getValues());
+      }}
+      className="flex flex-col gap-8 animate-in fade-in duration-300"
+    >
+      <SettingsSection title={tSettings("workspace.workspaceDefaultsPolicy")}>
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            {tSettings("workspace.workspaceDefaultsDescription")}
+          </p>
+
+          <PolicyToggleRow
+            title={tSettings("workspace.allowLocalTemplatesTitle")}
+            description={tSettings("workspace.allowLocalTemplatesDescription")}
+            inputProps={register("allow_workspace_local_templates")}
+          />
+
+          <PolicyToggleRow
+            title={tSettings("workspace.allowInheritedForksTitle")}
+            description={tSettings("workspace.allowInheritedForksDescription")}
+            inputProps={register("allow_workspace_inherited_template_forks")}
+          />
+
+          <PolicyToggleRow
+            title={tSettings("workspace.allowLocalInjectorsTitle")}
+            description={tSettings("workspace.allowLocalInjectorsDescription")}
+            inputProps={register("allow_workspace_local_injectors")}
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection title={appearanceTitle}>
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label className="text-[13px] font-medium">{themeLabel}</Label>
+            <p className="text-sm text-muted-foreground">
+              {appearanceDescription}
+            </p>
+          </div>
+          <ThemeSelector variant="inline" />
+        </div>
+      </SettingsSection>
+
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          className="h-9 gap-2"
+          disabled={updatePolicies.isPending}
+          onClick={() => void savePolicies(getValues())}
+        >
+          <Save className="h-4 w-4" />
+          {updatePolicies.isPending
+            ? tSettings("saving")
+            : tSettings("saveChanges")}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function PolicyToggleRow({
+  title,
+  description,
+  inputProps,
+}: {
+  title: string;
+  description: string;
+  inputProps: UseFormRegisterReturn;
+}) {
+  return (
+    <label className="flex items-start gap-3 rounded-lg border bg-muted/20 p-4">
+      <input
+        type="checkbox"
+        className="mt-0.5 h-4 w-4 rounded border-border"
+        {...inputProps}
+      />
+      <span className="space-y-1">
+        <span className="block text-sm font-medium text-foreground">
+          {title}
+        </span>
+        <span className="block text-sm text-muted-foreground">
+          {description}
+        </span>
+      </span>
+    </label>
   );
 }

--- a/web/src/components/shared/resource-state-badges.tsx
+++ b/web/src/components/shared/resource-state-badges.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { ResourceStateBadge } from "@/lib/workspace-resource-policies";
+
+const badgeClassByKey: Record<ResourceStateBadge, string> = {
+  local:
+    "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  defaultSystem:
+    "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+  forkedFromDefault:
+    "border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300",
+  readOnly:
+    "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  workspace:
+    "border-slate-500/30 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+  global:
+    "border-zinc-500/30 bg-zinc-500/10 text-zinc-700 dark:text-zinc-300",
+};
+
+export function ResourceStateBadges({
+  badges,
+  className,
+}: {
+  badges: ResourceStateBadge[];
+  className?: string;
+}) {
+  const t = useTranslations("resourceState");
+
+  if (!badges.length) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      {badges.map((badge) => (
+        <Badge
+          key={badge}
+          variant="outline"
+          className={cn("text-[11px]", badgeClassByKey[badge])}
+        >
+          {t(`badges.${badge}`)}
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/shared/scope-indicator.tsx
+++ b/web/src/components/shared/scope-indicator.tsx
@@ -1,32 +1,40 @@
-import { cn } from "@/lib/utils";
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Globe, Settings, Box } from "lucide-react";
+
+import { cn } from "@/lib/utils";
 import type { ScopeLevel } from "@/types/api";
-import { SYSTEM_WORKSPACE_LABEL } from "@/lib/system-workspace-display";
 
 const scopeConfig: Record<
   ScopeLevel | "system",
-  { label: string; icon: typeof Globe; color: string; bgColor: string }
+  {
+    labelKey: "global" | "system" | "tenant" | "workspace";
+    icon: typeof Globe;
+    color: string;
+    bgColor: string;
+  }
 > = {
   global: {
-    label: "Global",
+    labelKey: "global",
     icon: Globe,
     color: "text-scope-global",
     bgColor: "bg-scope-global-bg",
   },
   system: {
-    label: SYSTEM_WORKSPACE_LABEL,
+    labelKey: "system",
     icon: Settings,
     color: "text-scope-system",
     bgColor: "bg-scope-system-bg",
   },
   tenant: {
-    label: "Tenant",
+    labelKey: "tenant",
     icon: Settings,
     color: "text-scope-system",
     bgColor: "bg-scope-system-bg",
   },
   workspace: {
-    label: "Workspace",
+    labelKey: "workspace",
     icon: Box,
     color: "text-scope-workspace",
     bgColor: "bg-scope-workspace-bg",
@@ -39,7 +47,12 @@ interface ScopeIndicatorProps {
   className?: string;
 }
 
-export function ScopeIndicator({ scope, label, className }: ScopeIndicatorProps) {
+export function ScopeIndicator({
+  scope,
+  label,
+  className,
+}: ScopeIndicatorProps) {
+  const t = useTranslations("scopeIndicator");
   const config = scopeConfig[scope] ?? scopeConfig.global;
   const Icon = config.icon;
 
@@ -49,11 +62,11 @@ export function ScopeIndicator({ scope, label, className }: ScopeIndicatorProps)
         "inline-flex items-center justify-center gap-1.5 rounded-full px-2.5 h-6 font-mono text-[11px] font-medium",
         config.bgColor,
         config.color,
-        className
+        className,
       )}
     >
       <Icon className="h-3 w-3" />
-      {label ?? config.label}
+      {label ?? t(config.labelKey)}
     </span>
   );
 }

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -52,6 +52,7 @@ import {
   renderVideoBlockToMjml,
 } from "./video-block";
 import { useScope, useScopedPath } from "@/hooks/use-scope";
+import { getTemplateManagementState } from "@/lib/workspace-resource-policies";
 import {
   useTemplateVersion,
   useSaveTemplateVersion,
@@ -62,7 +63,9 @@ import {
   useSaveTemplateLocale,
   useDeleteTemplateLocale,
 } from "@/hooks/use-template-version";
+import { useResolvedWorkspacePolicies } from "@/hooks/use-settings";
 import { useTemplateType } from "@/hooks/use-template-types";
+import { useTemplatesByType } from "@/hooks/use-templates";
 import { useInjectorList } from "@/hooks/use-injectors";
 import { useAutoSave } from "@/hooks/use-auto-save";
 import { SaveStatusIndicator } from "@/components/templates/save-status-indicator";
@@ -1653,6 +1656,7 @@ export function MjmlEditor() {
   const router = useRouter();
   const scope = useScope();
   const scopedPath = useScopedPath();
+  const workspacePolicies = useResolvedWorkspacePolicies(scope);
   const searchParams = useSearchParams();
   const params = useParams<{ slug: string }>();
   const templateTypeSlug = params.slug ?? "";
@@ -1679,6 +1683,27 @@ export function MjmlEditor() {
   const previewMutation = usePreviewMjml(scopedPath, templateId);
 
   const templateTypeQuery = useTemplateType(scopedPath, templateTypeSlug);
+  const visibleTemplatesQuery = useTemplatesByType(scopedPath, templateTypeSlug);
+  const visibleTemplate = useMemo(
+    () =>
+      visibleTemplatesQuery.data?.find((candidate) => candidate.id === templateId) ??
+      visibleTemplatesQuery.data?.[0],
+    [templateId, visibleTemplatesQuery.data],
+  );
+  const templateManagementTarget =
+    visibleTemplate ??
+    (scope.level !== "workspace" || scope.workspaceCode === "_system"
+      ? {
+          owner_scope: scope.level === "global" ? "global" : "local",
+          inherited_from_system: false,
+          is_fork: false,
+        }
+      : undefined);
+  const templateState = getTemplateManagementState(
+    scope,
+    templateManagementTarget,
+    workspacePolicies.data,
+  );
   const testSendAvailability = useMemo(
     () =>
       getTestSendAvailability({
@@ -1686,7 +1711,9 @@ export function MjmlEditor() {
       }),
     [templateTypeQuery.data?.adapter_id],
   );
-  const injectorList = useInjectorList(scopedPath);
+  const injectorList = useInjectorList(scopedPath, {
+    includeInherited: scope.level === "workspace",
+  });
   const injectorItems = useMemo<InjectorDefinition[]>(() => {
     return injectorList.data?.items ?? [];
   }, [injectorList.data]);
@@ -1786,6 +1813,7 @@ export function MjmlEditor() {
   });
 
   const isDraft = version?.status === "draft";
+  const canEditDraft = Boolean(isDraft && templateState.canManageVersions);
 
   const autoSave = useAutoSave({
     getPayload: () => {
@@ -1822,7 +1850,7 @@ export function MjmlEditor() {
         ...(data.editor_data ? { editor_data: data.editor_data as Record<string, unknown> } : {}),
       });
     },
-    enabled: isDraft,
+    enabled: canEditDraft,
     debounceMs: 2000,
   });
 
@@ -2502,7 +2530,7 @@ export function MjmlEditor() {
   }
 
   function addBlock(type: BuilderBlockType) {
-    if (!builderDocument || !isDraft) return;
+    if (!builderDocument || !canEditDraft) return;
 
     const id = nowId();
     let newBlock: BuilderBlock;
@@ -2590,7 +2618,7 @@ export function MjmlEditor() {
   }
 
   function removeBlock(blockId: string) {
-    if (!builderDocument || !isDraft) return;
+    if (!builderDocument || !canEditDraft) return;
 
     const remaining = builderDocument.blocks.filter((block) => block.id !== blockId);
     if (!remaining.length) {
@@ -2734,7 +2762,7 @@ export function MjmlEditor() {
     blockId: string,
     variable: TemplateVariable
   ) {
-    if (!builderDocument || !isDraft) return;
+    if (!builderDocument || !canEditDraft) return;
 
     const targetBlock =
       builderDocument.blocks.find((block) => block.id === blockId) ??
@@ -2808,7 +2836,7 @@ export function MjmlEditor() {
     blockId: string,
     event: ReactKeyboardEvent<HTMLDivElement>
   ) {
-    if (!isDraft) return;
+    if (!canEditDraft) return;
     if (event.key === "Enter") {
       event.preventDefault();
       return;
@@ -2892,7 +2920,7 @@ export function MjmlEditor() {
         ),
       })
     );
-    if (mode === "cut" && isDraft) {
+    if (mode === "cut" && canEditDraft) {
       const nextSegments = replaceSegmentsUnitRange(
         liveSegments,
         selectionRange.start,
@@ -2912,7 +2940,7 @@ export function MjmlEditor() {
     blockId: string,
     event: ReactClipboardEvent<HTMLDivElement>
   ) {
-    if (!isDraft) {
+    if (!canEditDraft) {
       return;
     }
     const editor = event.currentTarget;
@@ -2952,7 +2980,7 @@ export function MjmlEditor() {
     blockId: string,
     event: DragEvent<HTMLDivElement>
   ) {
-    if (!isDraft || isBlockDragEvent(event.dataTransfer)) {
+    if (!canEditDraft || isBlockDragEvent(event.dataTransfer)) {
       return;
     }
     if (!isVariableDragEvent(event.dataTransfer)) {
@@ -2971,7 +2999,7 @@ export function MjmlEditor() {
     blockId: string,
     event: DragEvent<HTMLDivElement>
   ) {
-    if (!isDraft || isBlockDragEvent(event.dataTransfer)) {
+    if (!canEditDraft || isBlockDragEvent(event.dataTransfer)) {
       return;
     }
     if (!isVariableDragEvent(event.dataTransfer)) {
@@ -3326,7 +3354,7 @@ export function MjmlEditor() {
   }
 
   function moveListItem(blockId: string, draggedItemId: string, targetItemId: string, position: "before" | "after") {
-    if (!builderDocument || !isDraft || draggedItemId === targetItemId) return;
+    if (!builderDocument || !canEditDraft || draggedItemId === targetItemId) return;
     const block = builderDocument.blocks.find(
       (b) => b.id === blockId && b.type === "list"
     );
@@ -3393,7 +3421,7 @@ export function MjmlEditor() {
     event: DragEvent<HTMLButtonElement>,
     blockId: string
   ) {
-    if (!isDraft) return;
+    if (!canEditDraft) return;
     event.dataTransfer.setData(BLOCK_DND_MIME, blockId);
     event.dataTransfer.setData(MIME_TEXT_PLAIN, `block:${blockId}`);
     event.dataTransfer.effectAllowed = "move";
@@ -3413,7 +3441,7 @@ export function MjmlEditor() {
     event: DragEvent<HTMLDivElement>,
     dropIndex: number
   ) {
-    if (!isDraft || !builderDocument) return;
+    if (!canEditDraft || !builderDocument) return;
     if (!isBlockDragEvent(event.dataTransfer)) return;
 
     event.preventDefault();
@@ -3422,7 +3450,7 @@ export function MjmlEditor() {
   }
 
   function moveBlockToIndex(blockId: string, targetIndex: number) {
-    if (!builderDocument || !isDraft) return;
+    if (!builderDocument || !canEditDraft) return;
     const sourceIndex = builderDocument.blocks.findIndex(
       (block) => block.id === blockId
     );
@@ -3455,7 +3483,7 @@ export function MjmlEditor() {
     event: DragEvent<HTMLDivElement>,
     dropIndex: number
   ) {
-    if (!isDraft) return;
+    if (!canEditDraft) return;
     const blockId = getDraggedBlockId(event.dataTransfer);
     if (!blockId) return;
 
@@ -3537,7 +3565,7 @@ export function MjmlEditor() {
                   >
                     {loc.locale}
                   </button>
-                  {isDraft && (
+                  {canEditDraft && (
                     <button
                       type="button"
                       className="absolute -top-1.5 -right-1.5 hidden group-hover:flex items-center justify-center w-3.5 h-3.5 rounded-full bg-destructive text-destructive-foreground"
@@ -3553,7 +3581,7 @@ export function MjmlEditor() {
                 </div>
               ))}
 
-              {isDraft && (
+              {canEditDraft && (
                 <Popover open={addLocaleOpen} onOpenChange={setAddLocaleOpen}>
                   <PopoverTrigger asChild>
                     <button
@@ -3599,7 +3627,7 @@ export function MjmlEditor() {
               </button>
             </div>
 
-            {isDraft && (
+            {canEditDraft && (
               <>
                 <SaveStatusIndicator
                   status={autoSave.status}
@@ -3668,7 +3696,7 @@ export function MjmlEditor() {
                 </TooltipContent>
               </Tooltip>
             )}
-            {isDraft && (
+            {canEditDraft && (
               <Button size="sm" onClick={() => setShowPublishConfirm(true)}>
                 <Rocket className="h-4 w-4 mr-1.5" />
                 Publish
@@ -3677,6 +3705,14 @@ export function MjmlEditor() {
           </div>
         </div>
       </div>
+
+      {isDraft && !canEditDraft ? (
+        <div className="mx-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
+          This draft is visible in this workspace but locked for editing. Fork
+          the default template or enable workspace version management from the
+          tenant _system workspace policies.
+        </div>
+      ) : null}
 
       <div ref={layoutSplitRef} className="flex flex-1 overflow-hidden">
         {/* Left: editor */}
@@ -3716,7 +3752,7 @@ export function MjmlEditor() {
                       <Button
                         size="sm"
                         variant="outline"
-                        disabled={!isDraft}
+                        disabled={!canEditDraft}
                         onClick={() => addBlock("text")}
                         className="h-8"
                       >
@@ -3725,7 +3761,7 @@ export function MjmlEditor() {
                       <Button
                         size="sm"
                         variant="outline"
-                        disabled={!isDraft}
+                        disabled={!canEditDraft}
                         onClick={() => addBlock("button")}
                         className="h-8"
                       >
@@ -3734,7 +3770,7 @@ export function MjmlEditor() {
                       <Button
                         size="sm"
                         variant="outline"
-                        disabled={!isDraft}
+                        disabled={!canEditDraft}
                         onClick={() => addBlock("image")}
                         className="h-8"
                       >
@@ -3743,7 +3779,7 @@ export function MjmlEditor() {
                       <Button
                         size="sm"
                         variant="outline"
-                        disabled={!isDraft}
+                        disabled={!canEditDraft}
                         onClick={() => addBlock("divider")}
                         className="h-8"
                       >
@@ -3752,7 +3788,7 @@ export function MjmlEditor() {
                       <Button
                         size="sm"
                         variant="outline"
-                        disabled={!isDraft}
+                        disabled={!canEditDraft}
                         onClick={() => addBlock("spacer")}
                         className="h-8"
                       >
@@ -3761,7 +3797,7 @@ export function MjmlEditor() {
                       <Button
                         size="sm"
                         variant="outline"
-                        disabled={!isDraft}
+                        disabled={!canEditDraft}
                         onClick={() => addBlock("banner")}
                         className="h-8"
                       >
@@ -3770,7 +3806,7 @@ export function MjmlEditor() {
                       <Button
                         size="sm"
                         variant="outline"
-                        disabled={!isDraft}
+                        disabled={!canEditDraft}
                         onClick={() => addBlock("video")}
                         className="h-8"
                       >
@@ -3779,7 +3815,7 @@ export function MjmlEditor() {
                       <Button
                         size="sm"
                         variant="outline"
-                        disabled={!isDraft}
+                        disabled={!canEditDraft}
                         onClick={() => addBlock("list")}
                         className="h-8"
                       >
@@ -3817,7 +3853,7 @@ export function MjmlEditor() {
                         draggable={editorMode === "visual"}
                         onDragStart={editorMode === "visual" ? (event) => onVariableCardDragStart(event, item) : undefined}
                         onClick={() => appendTemplateVariableToBlock(selectedBlockId ?? "", item)}
-                        disabled={!isDraft}
+                        disabled={!canEditDraft}
                       >
                         <div className="font-mono text-[11px] truncate">{item.label}</div>
                         <div className="text-muted-foreground text-[10px]">{item.hint}</div>
@@ -3899,7 +3935,7 @@ export function MjmlEditor() {
                                             draggable={editorMode === "visual"}
                                             onDragStart={editorMode === "visual" ? (event) => onVariableCardDragStart(event, item) : undefined}
                                             onClick={() => appendTemplateVariableToBlock(selectedBlockId ?? "", item)}
-                                            disabled={!isDraft}
+                                            disabled={!canEditDraft}
                                           >
                                             <div className="font-mono text-[11px] truncate">{fieldName}</div>
                                           </button>
@@ -3998,7 +4034,7 @@ export function MjmlEditor() {
                               isActive ? "border-primary bg-primary/5" : "bg-background"
                             }`}
                             onDragOver={(ev) => {
-                              if (!isDraft) return;
+                              if (!canEditDraft) return;
                               if (isBlockDragEvent(ev.dataTransfer)) {
                                 ev.preventDefault();
                                 ev.dataTransfer.dropEffect = "move";
@@ -4018,7 +4054,7 @@ export function MjmlEditor() {
                             }}
                             onDrop={(ev) => {
                               ev.preventDefault();
-                              if (!isDraft) return;
+                              if (!canEditDraft) return;
                               if (isBlockDragEvent(ev.dataTransfer)) {
                                 const rect = ev.currentTarget.getBoundingClientRect();
                                 const nextIndex =
@@ -4060,7 +4096,7 @@ export function MjmlEditor() {
                                 <button
                                   type="button"
                                   className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded hover:bg-muted cursor-grab active:cursor-grabbing"
-                                  draggable={isDraft}
+                                  draggable={canEditDraft}
                                   onDragStart={(event) =>
                                     onBlockHandleDragStart(event, block.id)
                                   }
@@ -4084,10 +4120,10 @@ export function MjmlEditor() {
                                     }
                                   }}
                                   onClick={(ev) => ev.stopPropagation()}
-                                  readOnly={!isDraft}
+                                  readOnly={!canEditDraft}
                                 />
                               </div>
-                              {isDraft ? (
+                              {canEditDraft ? (
                                 <Button
                                   size="sm"
                                   variant="ghost"
@@ -4112,7 +4148,7 @@ export function MjmlEditor() {
                                 content={block.content}
                                 onChange={(html, newAlign) => updateTextBlock(block.id, html, newAlign)}
                                 align={block.align}
-                                disabled={!isDraft}
+                                disabled={!canEditDraft}
                                 onFocus={() => setSelectedBlockId(block.id)}
                               />
                             )}
@@ -4129,7 +4165,7 @@ export function MjmlEditor() {
                                         delete blockEditorRefs.current[block.id];
                                       }
                                     }}
-                                    contentEditable={isDraft}
+                                    contentEditable={canEditDraft}
                                     suppressContentEditableWarning
                                     className="min-h-6 w-full whitespace-pre-wrap break-words text-sm font-mono outline-none empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground"
                                     data-placeholder={t("textPlaceholder")}
@@ -4166,7 +4202,7 @@ export function MjmlEditor() {
                                   onChange={(ev) =>
                                     updateButtonHref(block.id, ev.target.value)
                                   }
-                                  readOnly={!isDraft}
+                                  readOnly={!canEditDraft}
                                 />
                               </div>
                             ) : null}
@@ -4180,7 +4216,7 @@ export function MjmlEditor() {
                                   onChange={(ev) =>
                                     updateImageBlock(block.id, "src", ev.target.value)
                                   }
-                                  readOnly={!isDraft}
+                                  readOnly={!canEditDraft}
                                 />
                                 <Label className="text-xs mt-2">Alt</Label>
                                 <Input
@@ -4189,7 +4225,7 @@ export function MjmlEditor() {
                                   onChange={(ev) =>
                                     updateImageBlock(block.id, "alt", ev.target.value)
                                   }
-                                  readOnly={!isDraft}
+                                  readOnly={!canEditDraft}
                                 />
                                 <Label className="text-xs mt-2">Width</Label>
                                 <Input
@@ -4198,7 +4234,7 @@ export function MjmlEditor() {
                                   onChange={(ev) =>
                                     updateImageBlock(block.id, "width", ev.target.value)
                                   }
-                                  readOnly={!isDraft}
+                                  readOnly={!canEditDraft}
                                 />
                               </>
                             ) : null}
@@ -4218,7 +4254,7 @@ export function MjmlEditor() {
                                       Number.parseInt(ev.target.value, 10)
                                     )
                                   }
-                                  readOnly={!isDraft}
+                                  readOnly={!canEditDraft}
                                 />
                               </>
                             ) : null}
@@ -4238,7 +4274,7 @@ export function MjmlEditor() {
                                     className="h-8 mt-1"
                                     placeholder="https://example.com/hero.jpg"
                                     onChange={(ev) => updateBannerBlock(block.id, "backgroundUrl", ev.target.value)}
-                                    readOnly={!isDraft}
+                                    readOnly={!canEditDraft}
                                   />
                                 </div>
                                 <div className="flex gap-2">
@@ -4249,7 +4285,7 @@ export function MjmlEditor() {
                                       value={block.backgroundColor}
                                       className="h-8 mt-1 w-16"
                                       onChange={(ev) => updateBannerBlock(block.id, "backgroundColor", ev.target.value)}
-                                      readOnly={!isDraft}
+                                      readOnly={!canEditDraft}
                                     />
                                   </div>
                                   <div className="flex-1">
@@ -4257,7 +4293,7 @@ export function MjmlEditor() {
                                     <select
                                       value={block.mode}
                                       onChange={(ev) => updateBannerBlock(block.id, "mode", ev.target.value)}
-                                      disabled={!isDraft}
+                                      disabled={!canEditDraft}
                                       className="h-8 mt-1 w-full rounded-md border border-input bg-background px-2 text-sm"
                                     >
                                       <option value="fluid-height">Fluid</option>
@@ -4274,7 +4310,7 @@ export function MjmlEditor() {
                                       value={block.height}
                                       className="h-8 mt-1"
                                       onChange={(ev) => updateBannerBlock(block.id, "height", Number.parseInt(ev.target.value, 10) || 400)}
-                                      readOnly={!isDraft}
+                                      readOnly={!canEditDraft}
                                     />
                                   </div>
                                 )}
@@ -4289,7 +4325,7 @@ export function MjmlEditor() {
                                           delete blockEditorRefs.current[block.id];
                                         }
                                       }}
-                                      contentEditable={isDraft}
+                                      contentEditable={canEditDraft}
                                       suppressContentEditableWarning
                                       className="min-h-6 w-full whitespace-pre-wrap break-words text-sm font-mono outline-none empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground"
                                       data-placeholder="Headline text..."
@@ -4322,7 +4358,7 @@ export function MjmlEditor() {
                                     className="h-8 mt-1"
                                     placeholder="Leave empty for no button"
                                     onChange={(ev) => updateBannerBlock(block.id, "buttonText", ev.target.value)}
-                                    readOnly={!isDraft}
+                                    readOnly={!canEditDraft}
                                   />
                                 </div>
                                 {block.buttonText && (
@@ -4333,7 +4369,7 @@ export function MjmlEditor() {
                                         value={block.buttonHref}
                                         className="h-8 mt-1"
                                         onChange={(ev) => updateBannerBlock(block.id, "buttonHref", ev.target.value)}
-                                        readOnly={!isDraft}
+                                        readOnly={!canEditDraft}
                                       />
                                     </div>
                                     <div>
@@ -4343,7 +4379,7 @@ export function MjmlEditor() {
                                         value={block.buttonColor}
                                         className="h-8 mt-1 w-16"
                                         onChange={(ev) => updateBannerBlock(block.id, "buttonColor", ev.target.value)}
-                                        readOnly={!isDraft}
+                                        readOnly={!canEditDraft}
                                       />
                                     </div>
                                   </div>
@@ -4354,7 +4390,7 @@ export function MjmlEditor() {
                                     <select
                                       value={block.verticalAlign}
                                       onChange={(ev) => updateBannerBlock(block.id, "verticalAlign", ev.target.value)}
-                                      disabled={!isDraft}
+                                      disabled={!canEditDraft}
                                       className="h-8 mt-1 w-full rounded-md border border-input bg-background px-2 text-sm"
                                     >
                                       <option value="top">Top</option>
@@ -4370,7 +4406,7 @@ export function MjmlEditor() {
                                       value={block.padding}
                                       className="h-8 mt-1"
                                       onChange={(ev) => updateBannerBlock(block.id, "padding", Number.parseInt(ev.target.value, 10) || 0)}
-                                      readOnly={!isDraft}
+                                      readOnly={!canEditDraft}
                                     />
                                   </div>
                                 </div>
@@ -4401,7 +4437,7 @@ export function MjmlEditor() {
                                         }),
                                       });
                                     }}
-                                    readOnly={!isDraft}
+                                    readOnly={!canEditDraft}
                                   />
                                 </div>
                                 <div>
@@ -4411,7 +4447,7 @@ export function MjmlEditor() {
                                     className="h-8 mt-1"
                                     placeholder="https://img.youtube.com/vi/ID/maxresdefault.jpg"
                                     onChange={(ev) => updateVideoBlock(block.id, "thumbnailUrl", ev.target.value)}
-                                    readOnly={!isDraft}
+                                    readOnly={!canEditDraft}
                                   />
                                 </div>
                                 {block.thumbnailUrl && (
@@ -4435,7 +4471,7 @@ export function MjmlEditor() {
                                     value={block.alt}
                                     className="h-8 mt-1"
                                     onChange={(ev) => updateVideoBlock(block.id, "alt", ev.target.value)}
-                                    readOnly={!isDraft}
+                                    readOnly={!canEditDraft}
                                   />
                                 </div>
                                 <div>
@@ -4445,7 +4481,7 @@ export function MjmlEditor() {
                                     className="h-8 mt-1"
                                     placeholder="100%"
                                     onChange={(ev) => updateVideoBlock(block.id, "width", ev.target.value)}
-                                    readOnly={!isDraft}
+                                    readOnly={!canEditDraft}
                                   />
                                 </div>
                               </div>
@@ -4458,7 +4494,7 @@ export function MjmlEditor() {
                                   <select
                                     value={block.listType}
                                     onChange={(ev) => updateListBlock(block.id, "listType", ev.target.value)}
-                                    disabled={!isDraft}
+                                    disabled={!canEditDraft}
                                     className="h-8 mt-1 w-full rounded-md border border-input bg-background px-2 text-sm"
                                   >
                                     <option value="bullet">Bullets</option>
@@ -4516,7 +4552,7 @@ export function MjmlEditor() {
                                             {isDropAfter && (
                                               <div className="absolute -bottom-px left-0 right-0 h-0.5 bg-primary rounded pointer-events-none" />
                                             )}
-                                            {isDraft && (
+                                            {canEditDraft && (
                                               <button
                                                 type="button"
                                                 className="h-5 w-4 inline-flex items-center justify-center shrink-0 cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground"
@@ -4544,9 +4580,9 @@ export function MjmlEditor() {
                                               onChange={(ev) =>
                                                 updateListItemSegments(block.id, item.id, ev.target.value)
                                               }
-                                              readOnly={!isDraft}
+                                              readOnly={!canEditDraft}
                                             />
-                                            {isDraft && (
+                                            {canEditDraft && (
                                               <div className="flex items-center gap-0.5 shrink-0">
                                                 {idx > 0 && depth < 2 && (
                                                   <button
@@ -4593,7 +4629,7 @@ export function MjmlEditor() {
                                       });
                                     })(block.items, 0)}
                                   </div>
-                                  {isDraft && (
+                                  {canEditDraft && (
                                     <Button
                                       size="sm"
                                       variant="outline"
@@ -4643,7 +4679,7 @@ export function MjmlEditor() {
                   <MonacoEditorWrapper
                     value={codeMjml}
                     onChange={handleCodeChange}
-                    readOnly={!isDraft}
+                    readOnly={!canEditDraft}
                   />
                 </div>
               </div>
@@ -4674,7 +4710,7 @@ export function MjmlEditor() {
                 <Input
                   {...register("subject")}
                   className="h-8 text-sm"
-                  readOnly={!isDraft}
+                  readOnly={!canEditDraft}
                 />
                 {errors.subject && (
                   <span className="text-xs text-destructive">
@@ -4687,7 +4723,7 @@ export function MjmlEditor() {
                 <Input
                   {...register("preview_text")}
                   className="h-8 text-sm"
-                  readOnly={!isDraft}
+                  readOnly={!canEditDraft}
                 />
               </div>
               <div className="flex flex-col gap-1.5">
@@ -4695,7 +4731,7 @@ export function MjmlEditor() {
                 <Input
                   {...register("from_name")}
                   className="h-8 text-sm"
-                  readOnly={!isDraft}
+                  readOnly={!canEditDraft}
                 />
                 {errors.from_name && (
                   <span className="text-xs text-destructive">
@@ -4709,7 +4745,7 @@ export function MjmlEditor() {
                   <Input
                     {...register("reply_to")}
                     className="h-8 text-sm"
-                    readOnly={!isDraft}
+                    readOnly={!canEditDraft}
                   />
                 </div>
               )}

--- a/web/src/components/templates/template-types-content.tsx
+++ b/web/src/components/templates/template-types-content.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useRef, useState } from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
   Plus,
   Search,
@@ -15,13 +16,20 @@ import {
 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useScope, useScopedPath } from "@/hooks/use-scope";
+import {
+  getTemplateCatalogState,
+  getTemplateTypeManagementState,
+  resolveResourceDisplayScope,
+} from "@/lib/workspace-resource-policies";
 import { cn } from "@/lib/utils";
 import { generateSlug, nameSchema, slugSchema } from "@/lib/validations/slug";
 import { useTemplateTypes, useCreateTemplateType, useUpdateTemplateType, useDeleteTemplateType } from "@/hooks/use-template-types";
 import { useAdapterList } from "@/hooks/use-adapters";
 import { useIdentityList } from "@/hooks/use-identities";
+import { useResolvedWorkspacePolicies } from "@/hooks/use-settings";
 import { DataTable } from "@/components/shared/data-table";
 import { EmptyState } from "@/components/shared/empty-state";
+import { ResourceStateBadges } from "@/components/shared/resource-state-badges";
 import { ScopeIndicator } from "@/components/shared/scope-indicator";
 import { FormDialog } from "@/components/shared/form-dialog";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
@@ -57,9 +65,13 @@ export function TemplateTypesContent() {
 }
 
 function TemplateTypesTable() {
+  const t = useTranslations("templateTypesPage");
+  const tCommon = useTranslations("common");
   const router = useRouter();
   const scope = useScope();
   const scopedPath = useScopedPath();
+  const workspacePolicies = useResolvedWorkspacePolicies(scope);
+  const templateCatalogState = getTemplateCatalogState(scope, workspacePolicies.data);
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
     useTemplateTypes(scopedPath);
   const createMutation = useCreateTemplateType(scopedPath);
@@ -107,7 +119,7 @@ function TemplateTypesTable() {
   const columns: ColumnDef<TemplateType>[] = [
     {
       accessorKey: "slug",
-      header: "SLUG",
+      header: t("columns.slug"),
       cell: ({ row }) => (
         <button
           className="font-mono text-sm font-medium text-primary hover:underline"
@@ -119,21 +131,30 @@ function TemplateTypesTable() {
     },
     {
       accessorKey: "name",
-      header: "NAME",
+      header: t("columns.name"),
       cell: ({ row }) => (
-        <span className="text-sm text-foreground">{row.original.name}</span>
+        <div className="space-y-1">
+          <span className="text-sm text-foreground">{row.original.name}</span>
+          <ResourceStateBadges
+            badges={getTemplateTypeManagementState(
+              scope,
+              row.original,
+              workspacePolicies.data,
+            ).badges}
+          />
+        </div>
       ),
     },
     {
       accessorKey: "adapter_id",
-      header: "ADAPTER",
+      header: t("columns.adapter"),
       cell: ({ row }) => {
         const aid = row.original.adapter_id;
         if (!aid) {
           return (
             <span className="inline-flex items-center gap-1 text-status-complained text-xs">
               <TriangleAlert className="h-3.5 w-3.5" />
-              No adapter
+              {t("noAdapter")}
             </span>
           );
         }
@@ -147,59 +168,79 @@ function TemplateTypesTable() {
     },
     {
       accessorKey: "scope_level",
-      header: "SCOPE",
+      header: t("columns.scope"),
       cell: ({ row }) => (
-        <ScopeIndicator scope={row.original.scope_level} />
+        <div className="flex items-center gap-2">
+          <ScopeIndicator scope={resolveResourceDisplayScope(row.original)} />
+        </div>
       ),
     },
     {
       id: "actions",
-      cell: ({ row }) => (
-        <div className="flex items-center justify-end gap-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                aria-label={`View templates for ${row.original.slug}`}
-                onClick={() => router.push(buildTypePath(row.original.slug))}
-              >
-                <Eye className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>View templates</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                aria-label={`Edit template type ${row.original.slug}`}
-                onClick={() => setEditTarget(row.original)}
-              >
-                <Pencil className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Edit</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-destructive"
-                aria-label={`Delete template type ${row.original.slug}`}
-                onClick={() => setDeleteTarget(row.original)}
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Delete</TooltipContent>
-          </Tooltip>
-        </div>
-      ),
+      cell: ({ row }) => {
+        const itemState = getTemplateTypeManagementState(
+          scope,
+          row.original,
+          workspacePolicies.data,
+        );
+        const readOnlyReason =
+          row.original.owner_scope === "local"
+            ? t("localTemplateTypesDisabled")
+            : t("defaultTemplateTypesReadonly");
+
+        return (
+          <div className="flex items-center justify-end gap-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label={t("viewTemplatesAria", { slug: row.original.slug })}
+                  onClick={() => router.push(buildTypePath(row.original.slug))}
+                >
+                  <Eye className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t("viewTemplates")}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label={t("editTemplateTypeAria", { slug: row.original.slug })}
+                  onClick={() => itemState.canEdit && setEditTarget(row.original)}
+                  disabled={!itemState.canEdit}
+                >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>{itemState.canEdit ? tCommon("edit") : readOnlyReason}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-destructive"
+                  aria-label={t("deleteTemplateTypeAria", { slug: row.original.slug })}
+                  onClick={() => itemState.canDelete && setDeleteTarget(row.original)}
+                  disabled={!itemState.canDelete}
+                >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>{itemState.canDelete ? tCommon("delete") : readOnlyReason}</TooltipContent>
+            </Tooltip>
+          </div>
+        );
+      },
     },
   ];
 
@@ -208,7 +249,7 @@ function TemplateTypesTable() {
     try {
       const selectedAdapter = adapters.find((adapter) => adapter.id === newAdapterId);
       if (selectedAdapter?.adapter_type === "ses" && selectedAdapter.is_shared && !newSenderIdentityId) {
-        toast.error("Shared SES adapters require an explicit sender identity");
+        toast.error(t("sharedSesRequiresIdentity"));
         return;
       }
       const senderIdValue = newSenderIdentityId && newSenderIdentityId !== SENDER_DEFAULT ? newSenderIdentityId : undefined;
@@ -218,16 +259,23 @@ function TemplateTypesTable() {
         adapter_id: newAdapterId || undefined,
         sender_identity_id: senderIdValue,
       });
-      toast.success("Template type created");
+      toast.success(t("templateTypeCreated"));
       setNewSlug("");
       setNewName("");
       setNewAdapterId("");
       setNewSenderIdentityId("");
       setSlugTouched(false);
     } catch {
-      toast.error("Failed to create template type");
+      toast.error(t("templateTypeCreateFailed"));
     }
   }
+
+  const createTemplateTypeTrigger = (
+    <Button disabled={!templateCatalogState.canCreateTemplateTypes}>
+      <Plus className="h-4 w-4 mr-2" />
+      {t("newTemplateType")}
+    </Button>
+  );
 
   return (
     <div className="flex flex-col gap-6">
@@ -235,64 +283,70 @@ function TemplateTypesTable() {
         <div className="relative w-72">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
           <Input
-            placeholder="Search template types..."
+            placeholder={t("searchPlaceholder")}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9 h-9"
           />
         </div>
-        <FormDialog
-          trigger={
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              New Template Type
-            </Button>
-          }
-          open={createOpen}
-          onOpenChange={setCreateOpen}
-          title="Create Template Type"
-          description="Define a new template type for this scope."
-          submitLabel="Create"
-          onSubmit={handleCreateType}
-        >
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="tt-name">Name</Label>
-              <Input
-                id="tt-name"
-                placeholder="Welcome Email"
-                value={newName}
-                onChange={(e) => {
-                  const name = e.target.value;
-                  setNewName(name);
-                  if (!slugTouched) {
-                    setNewSlug(generateSlug(name));
-                  }
-                }}
+        {templateCatalogState.canCreateTemplateTypes ? (
+          <FormDialog
+            trigger={createTemplateTypeTrigger}
+            open={createOpen}
+            onOpenChange={setCreateOpen}
+            title={t("createDialog.title")}
+            description={t("createDialog.description")}
+            submitLabel={tCommon("create")}
+            onSubmit={handleCreateType}
+          >
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="tt-name">{tCommon("name")}</Label>
+                <Input
+                  id="tt-name"
+                  placeholder={t("createDialog.namePlaceholder")}
+                  value={newName}
+                  onChange={(e) => {
+                    const name = e.target.value;
+                    setNewName(name);
+                    if (!slugTouched) {
+                      setNewSlug(generateSlug(name));
+                    }
+                  }}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="tt-slug">{t("slugLabel")}</Label>
+                <Input
+                  id="tt-slug"
+                  placeholder={t("createDialog.slugPlaceholder")}
+                  value={newSlug}
+                  onChange={(e) => {
+                    setNewSlug(e.target.value);
+                    setSlugTouched(true);
+                  }}
+                  className="font-mono"
+                />
+              </div>
+              <AdapterSelect
+                adapters={adapters}
+                value={newAdapterId}
+                onChange={setNewAdapterId}
+                senderIdentityId={newSenderIdentityId}
+                onSenderIdentityChange={setNewSenderIdentityId}
               />
             </div>
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="tt-slug">Slug</Label>
-              <Input
-                id="tt-slug"
-                placeholder="welcome-email"
-                value={newSlug}
-                onChange={(e) => {
-                  setNewSlug(e.target.value);
-                  setSlugTouched(true);
-                }}
-                className="font-mono"
-              />
-            </div>
-            <AdapterSelect
-              adapters={adapters}
-              value={newAdapterId}
-              onChange={setNewAdapterId}
-              senderIdentityId={newSenderIdentityId}
-              onSenderIdentityChange={setNewSenderIdentityId}
-            />
-          </div>
-        </FormDialog>
+          </FormDialog>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span>{createTemplateTypeTrigger}</span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {t("localTemplateCreationDisabled")}
+            </TooltipContent>
+          </Tooltip>
+        )}
       </div>
 
       <DataTable
@@ -305,12 +359,17 @@ function TemplateTypesTable() {
         emptyState={
           <EmptyState
             icon={FileType}
-            title="No template types"
-            description="Create your first template type to organize your email templates."
+            title={t("empty.title")}
+            description={t("empty.description")}
             action={
-              <Button variant="outline" size="sm" onClick={() => setCreateOpen(true)}>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setCreateOpen(true)}
+                disabled={!templateCatalogState.canCreateTemplateTypes}
+              >
                 <Plus className="h-4 w-4 mr-2" />
-                Create Template Type
+                {t("createDialog.title")}
               </Button>
             }
           />
@@ -329,14 +388,14 @@ function TemplateTypesTable() {
       <ConfirmDialog
         open={!!deleteTarget}
         onOpenChange={(open) => !open && setDeleteTarget(null)}
-        title="Delete Template Type"
-        description={`Are you sure you want to delete "${deleteTarget?.name}"? This action cannot be undone.`}
-        confirmLabel="Delete"
+        title={t("deleteDialog.title")}
+        description={t("deleteDialog.description", { name: deleteTarget?.name ?? "" })}
+        confirmLabel={tCommon("delete")}
         onConfirm={() => {
           if (deleteTarget) {
             deleteMutation.mutate(deleteTarget.slug, {
-              onSuccess: () => toast.success("Template type deleted"),
-              onError: () => toast.error("Failed to delete template type"),
+              onSuccess: () => toast.success(t("templateTypeDeleted")),
+              onError: () => toast.error(t("templateTypeDeleteFailed")),
             });
             setDeleteTarget(null);
           }

--- a/web/src/components/templates/templates-list-actions.test.ts
+++ b/web/src/components/templates/templates-list-actions.test.ts
@@ -8,14 +8,20 @@ const { getVersionPrimaryAction } = await import(
 test("published versions expose an explicit open action instead of view semantics", () => {
   assert.deepEqual(getVersionPrimaryAction("published"), {
     icon: "file-text",
-    label: "Open version",
+    labelKey: "openVersion",
   });
 });
 
 test("draft versions keep edit semantics", () => {
   assert.deepEqual(getVersionPrimaryAction("draft"), {
     icon: "pencil",
-    label: "Edit version",
+    labelKey: "editVersion",
   });
 });
 
+test("draft versions can switch to open semantics when the template is read-only", () => {
+  assert.deepEqual(getVersionPrimaryAction("draft", "open"), {
+    icon: "file-text",
+    labelKey: "openVersion",
+  });
+});

--- a/web/src/components/templates/templates-list-actions.ts
+++ b/web/src/components/templates/templates-list-actions.ts
@@ -2,21 +2,22 @@ import type { TemplateVersionStatus } from "@/types/api";
 
 export interface VersionPrimaryAction {
   icon: "pencil" | "file-text";
-  label: "Edit version" | "Open version";
+  labelKey: "editVersion" | "openVersion";
 }
 
 export function getVersionPrimaryAction(
   status: TemplateVersionStatus,
+  draftAction: "edit" | "open" = "edit",
 ): VersionPrimaryAction {
   if (status === "draft") {
     return {
-      icon: "pencil",
-      label: "Edit version",
+      icon: draftAction === "edit" ? "pencil" : "file-text",
+      labelKey: draftAction === "edit" ? "editVersion" : "openVersion",
     };
   }
 
   return {
     icon: "file-text",
-    label: "Open version",
+    labelKey: "openVersion",
   };
 }

--- a/web/src/components/templates/templates-list-content.tsx
+++ b/web/src/components/templates/templates-list-content.tsx
@@ -3,8 +3,14 @@
 import { useMemo } from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { useRouter, useParams } from "next/navigation";
-import { Plus, FileText, Pencil, Send, Trash2, Copy } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { Plus, FileText, Pencil, Send, Trash2, Copy, GitFork, Lock } from "lucide-react";
 import { useScope, useScopedPath } from "@/hooks/use-scope";
+import {
+  getTemplateCatalogState,
+  getTemplateManagementState,
+  resolveResourceDisplayScope,
+} from "@/lib/workspace-resource-policies";
 import { useTemplateType } from "@/hooks/use-template-types";
 import {
   useTemplateVersions,
@@ -13,10 +19,16 @@ import {
   usePublishVersion,
   useDeleteVersion,
 } from "@/hooks/use-template-version";
-import { useTemplatesByType, useCreateTemplate } from "@/hooks/use-templates";
+import {
+  useTemplatesByType,
+  useCreateTemplate,
+  useForkTemplate,
+} from "@/hooks/use-templates";
 import { useApi } from "@/hooks/use-api";
+import { useResolvedWorkspacePolicies } from "@/hooks/use-settings";
 import { DataTable } from "@/components/shared/data-table";
 import { EmptyState } from "@/components/shared/empty-state";
+import { ResourceStateBadges } from "@/components/shared/resource-state-badges";
 import { StatusBadge } from "@/components/shared/status-badge";
 import { ScopeIndicator } from "@/components/shared/scope-indicator";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
@@ -43,9 +55,14 @@ function createEditorId() {
 }
 
 export function TemplatesListContent() {
+  const t = useTranslations("templatesPage");
+  const tCommon = useTranslations("common");
+  const locale = useLocale();
   const router = useRouter();
   const scope = useScope();
   const scopedPath = useScopedPath();
+  const workspacePolicies = useResolvedWorkspacePolicies(scope);
+  const templateCatalogState = getTemplateCatalogState(scope, workspacePolicies.data);
   const params = useParams<{ slug: string }>();
   const slug = params.slug;
 
@@ -58,6 +75,11 @@ export function TemplatesListContent() {
   // Use first template for this type (own scope)
   const template = templates?.[0];
   const templateId = template?.id ?? "";
+  const templateState = getTemplateManagementState(
+    scope,
+    template,
+    workspacePolicies.data,
+  );
 
   const { data: versions, isLoading: versionsLoading } = useTemplateVersions(
     scopedPath,
@@ -65,6 +87,7 @@ export function TemplatesListContent() {
   );
   const api = useApi();
   const createTemplate = useCreateTemplate(scopedPath);
+  const forkTemplate = useForkTemplate(scopedPath, slug);
   const createVersion = useCreateTemplateVersion(scopedPath, templateId);
   const cloneVersion = useCloneVersion(scopedPath, templateId);
   const deleteVersion = useDeleteVersion(scopedPath, templateId);
@@ -85,7 +108,19 @@ export function TemplatesListContent() {
 
   async function handleCreateVersion() {
     if (!templateType) {
-      toast.error("Template type not loaded");
+      toast.error(t("templateTypeNotLoaded"));
+      return;
+    }
+    if (template && !templateState.canManageVersions) {
+      toast.error(
+        templateState.canFork
+          ? t("readOnlyDefaultMustFork")
+          : t("versionManagementDisabledInWorkspace"),
+      );
+      return;
+    }
+    if (!template && !templateCatalogState.canCreateTemplates) {
+      toast.error(t("localTemplateCreationDisabled"));
       return;
     }
     try {
@@ -112,11 +147,20 @@ export function TemplatesListContent() {
             .post(`${scopedPath}/templates/${tplId}/versions`, { json: versionData })
             .json<TemplateVersion>();
 
-      toast.success("Draft version created");
+      toast.success(t("draftVersionCreated"));
       router.push(buildEditPath(tplId, version.id));
     } catch {
-      toast.error("Failed to create version");
+      toast.error(t("createVersionFailed"));
     }
+  }
+
+  async function handleForkTemplate() {
+    if (!templateId) {
+      toast.error(t("defaultTemplateNotLoaded"));
+      return;
+    }
+
+    await forkTemplate.mutateAsync(templateId);
   }
 
   const publishMutation = usePublishVersion(
@@ -129,10 +173,10 @@ export function TemplatesListContent() {
     if (!publishTarget) return;
     try {
       await publishMutation.mutateAsync();
-      toast.success(`Version ${publishTarget.version_number} published`);
+      toast.success(t("publishSuccess", { version: publishTarget.version_number }));
       setPublishTarget(null);
     } catch {
-      toast.error("Failed to publish version");
+      toast.error(t("publishFailed"));
     }
   }
 
@@ -143,11 +187,19 @@ export function TemplatesListContent() {
       ),
     [versions]
   );
+  const versionWriteDisabledReason = template?.is_fork
+    ? t("forkVersionManagementOnly")
+    : templateState.canFork
+      ? t("defaultTemplatesReadonly")
+      : t("localTemplateChangesDisabled");
+  const canCreateDraftVersion = template
+    ? templateState.canManageVersions
+    : templateCatalogState.canCreateTemplates;
 
   const columns: ColumnDef<TemplateVersion>[] = [
     {
       accessorKey: "version_number",
-      header: "VERSION",
+      header: t("columns.version"),
       cell: ({ row }) => (
         <button
           type="button"
@@ -155,7 +207,7 @@ export function TemplatesListContent() {
           className={`font-mono text-sm transition-colors hover:text-primary ${
             row.original.status === "published" ? "font-semibold" : ""
           }`}
-          aria-label={`Open version ${row.original.version_number}`}
+          aria-label={t("openVersionAria", { version: row.original.version_number })}
         >
           v{row.original.version_number}
         </button>
@@ -163,35 +215,38 @@ export function TemplatesListContent() {
     },
     {
       accessorKey: "status",
-      header: "STATUS",
+      header: tCommon("status"),
       cell: ({ row }) => <StatusBadge status={row.original.status} />,
     },
     {
       accessorKey: "created_by",
-      header: "CREATED BY",
+      header: t("columns.createdBy"),
       cell: ({ row }) => (
         <span className="text-sm">{row.original.created_by ?? "—"}</span>
       ),
     },
     {
       accessorKey: "created_at",
-      header: "DATE",
+      header: t("columns.date"),
       cell: ({ row }) => (
         <span className="font-mono text-xs text-muted-foreground">
-          {new Date(row.original.created_at).toLocaleString("en-US", {
+          {new Intl.DateTimeFormat(locale, {
             year: "numeric",
             month: "2-digit",
             day: "2-digit",
             hour: "2-digit",
             minute: "2-digit",
-          })}
+          }).format(new Date(row.original.created_at))}
         </span>
       ),
     },
     {
       id: "actions",
       cell: ({ row }) => {
-        const primaryAction = getVersionPrimaryAction(row.original.status);
+        const primaryAction = getVersionPrimaryAction(
+          row.original.status,
+          templateState.versionPrimaryAction,
+        );
 
         return (
         <div className="flex items-center justify-end gap-1">
@@ -199,52 +254,85 @@ export function TemplatesListContent() {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => router.push(buildEditPath(templateId, row.original.id))}>
-                  <Pencil className="h-4 w-4" />
+                  {primaryAction.icon === "pencil" ? (
+                    <Pencil className="h-4 w-4" />
+                  ) : (
+                    <FileText className="h-4 w-4" />
+                  )}
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>{primaryAction.label}</TooltipContent>
+              <TooltipContent>{t(`actions.${primaryAction.labelKey}`)}</TooltipContent>
             </Tooltip>
           )}
           {row.original.status === "draft" && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => setPublishTarget(row.original)}>
+                <span>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    disabled={!templateState.canManageVersions}
+                    onClick={() =>
+                      templateState.canManageVersions && setPublishTarget(row.original)
+                    }
+                  >
                   <Send className="h-4 w-4" />
-                </Button>
+                  </Button>
+                </span>
               </TooltipTrigger>
-              <TooltipContent>Publish</TooltipContent>
+              <TooltipContent>
+                {templateState.canManageVersions ? t("actions.publish") : versionWriteDisabledReason}
+              </TooltipContent>
             </Tooltip>
           )}
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                disabled={cloneVersion.isPending}
-                onClick={() =>
-                  cloneVersion.mutate(row.original.id, {
-                    onSuccess: () =>
-                      toast.success(
-                        `Version ${row.original.version_number} cloned as draft`
-                      ),
-                    onError: () => toast.error("Failed to clone version"),
-                  })
-                }
-              >
-                <Copy className="h-4 w-4" />
-              </Button>
+              <span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  disabled={cloneVersion.isPending || !templateState.canManageVersions}
+                  onClick={() =>
+                    templateState.canManageVersions &&
+                    cloneVersion.mutate(row.original.id, {
+                      onSuccess: () =>
+                        toast.success(
+                          t("cloneSuccess", { version: row.original.version_number })
+                        ),
+                      onError: () => toast.error(t("cloneFailed")),
+                    })
+                  }
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </span>
             </TooltipTrigger>
-            <TooltipContent>Clone</TooltipContent>
+            <TooltipContent>
+              {templateState.canManageVersions ? t("actions.clone") : versionWriteDisabledReason}
+            </TooltipContent>
           </Tooltip>
           {row.original.status === "draft" && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-8 w-8 text-destructive" onClick={() => setDeleteVersionTarget(row.original)}>
-                  <Trash2 className="h-4 w-4" />
-                </Button>
+                <span>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-destructive"
+                    disabled={!templateState.canManageVersions}
+                    onClick={() =>
+                      templateState.canManageVersions && setDeleteVersionTarget(row.original)
+                    }
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </span>
               </TooltipTrigger>
-              <TooltipContent>Delete</TooltipContent>
+              <TooltipContent>
+                {templateState.canManageVersions ? tCommon("delete") : versionWriteDisabledReason}
+              </TooltipContent>
             </Tooltip>
           )}
           {row.original.status === "published" && (
@@ -254,7 +342,7 @@ export function TemplatesListContent() {
                   <FileText className="h-4 w-4" />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>{primaryAction.label}</TooltipContent>
+              <TooltipContent>{t(`actions.${primaryAction.labelKey}`)}</TooltipContent>
             </Tooltip>
           )}
         </div>
@@ -268,27 +356,67 @@ export function TemplatesListContent() {
     <div className="flex flex-col gap-6">
       {/* Type info header */}
       {templateType && (
-        <div className="flex items-center gap-4">
-          <h2
-            className="text-xl font-semibold"
-            style={{ letterSpacing: "-1px" }}
-          >
+        <div className="flex flex-wrap items-center gap-4">
+          <h2 className="text-xl font-semibold" style={{ letterSpacing: "-1px" }}>
             {templateType.name}
           </h2>
           <span className="font-mono text-sm text-muted-foreground">
             {templateType.slug}
           </span>
-          <ScopeIndicator scope={templateType.scope_level} />
+          <ScopeIndicator scope={resolveResourceDisplayScope(templateType)} />
+          <ResourceStateBadges badges={templateState.badges} />
         </div>
       )}
 
+      {template && templateState.readOnly ? (
+        <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
+          <Lock className="mt-0.5 h-4 w-4 shrink-0" />
+          <div className="space-y-1">
+            <p className="font-medium">
+              {t("readOnlyBannerTitle")}
+            </p>
+            <p>
+              {templateState.canFork
+                ? t("readOnlyBannerDescription")
+                : versionWriteDisabledReason}
+            </p>
+          </div>
+        </div>
+      ) : null}
+
       {/* Versions section */}
       <div className="flex items-center justify-between">
-        <h3 className="text-base font-semibold">Versions</h3>
-        <Button onClick={handleCreateVersion} disabled={!templateId}>
-          <Plus className="h-4 w-4 mr-2" />
-          New Version
-        </Button>
+        <h3 className="text-base font-semibold">{t("versionsTitle")}</h3>
+        <div className="flex items-center gap-2">
+          {templateState.canFork ? (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleForkTemplate}
+              disabled={forkTemplate.isPending}
+            >
+              <GitFork className="mr-2 h-4 w-4" />
+              {forkTemplate.isPending ? t("forking") : t("forkFromDefault")}
+            </Button>
+          ) : null}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span>
+                <Button onClick={handleCreateVersion} disabled={!canCreateDraftVersion}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  {t("newVersion")}
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {canCreateDraftVersion
+                ? t("createDraftVersion")
+                : templateState.canFork
+                  ? t("forkFirstBeforeVersions")
+                  : t("versionManagementDisabledForScope")}
+            </TooltipContent>
+          </Tooltip>
+        </div>
       </div>
 
       <DataTable
@@ -298,17 +426,31 @@ export function TemplatesListContent() {
         emptyState={
           <EmptyState
             icon={FileText}
-            title="No versions yet"
-            description="Create your first template version to start building this email template."
+            title={t("empty.title")}
+            description={t("empty.description")}
             action={
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleCreateVersion}
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                Create Version
-              </Button>
+              <div className="flex items-center gap-2">
+                {templateState.canFork ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleForkTemplate}
+                    disabled={forkTemplate.isPending}
+                  >
+                    <GitFork className="mr-2 h-4 w-4" />
+                    {t("forkFromDefault")}
+                  </Button>
+                ) : null}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleCreateVersion}
+                  disabled={!canCreateDraftVersion}
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  {t("createVersion")}
+                </Button>
+              </div>
             }
           />
         }
@@ -317,9 +459,9 @@ export function TemplatesListContent() {
       <ConfirmDialog
         open={!!publishTarget}
         onOpenChange={(open) => !open && setPublishTarget(null)}
-        title="Publish Version"
-        description={`Are you sure you want to publish version ${publishTarget?.version_number}? This will replace the current published version.`}
-        confirmLabel="Publish"
+        title={t("publishDialog.title")}
+        description={t("publishDialog.description", { version: publishTarget?.version_number ?? "" })}
+        confirmLabel={t("actions.publish")}
         variant="default"
         onConfirm={handlePublish}
         loading={publishMutation.isPending}
@@ -328,14 +470,14 @@ export function TemplatesListContent() {
       <ConfirmDialog
         open={!!deleteVersionTarget}
         onOpenChange={(open) => !open && setDeleteVersionTarget(null)}
-        title="Delete Draft Version"
-        description={`Are you sure you want to delete version ${deleteVersionTarget?.version_number}? This action cannot be undone.`}
-        confirmLabel="Delete"
+        title={t("deleteDialog.title")}
+        description={t("deleteDialog.description", { version: deleteVersionTarget?.version_number ?? "" })}
+        confirmLabel={tCommon("delete")}
         onConfirm={() => {
           if (deleteVersionTarget) {
             deleteVersion.mutate(deleteVersionTarget.id, {
-              onSuccess: () => toast.success("Draft version deleted"),
-              onError: () => toast.error("Failed to delete version"),
+              onSuccess: () => toast.success(t("deleteSuccess")),
+              onError: () => toast.error(t("deleteFailed")),
             });
             setDeleteVersionTarget(null);
           }

--- a/web/src/hooks/use-settings.ts
+++ b/web/src/hooks/use-settings.ts
@@ -2,7 +2,21 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useApi, useApiReady } from "@/hooks/use-api";
-import type { SystemSettings, UpdateSettingsRequest } from "@/types/settings";
+import {
+  canManageSystemWorkspacePolicies,
+  isWorkspaceScope,
+} from "@/lib/workspace-resource-policies";
+import { type ScopeContext } from "@/types/api";
+import type {
+  SystemSettings,
+  UpdateSettingsRequest,
+  UpdateWorkspacePoliciesRequest,
+  WorkspacePolicies,
+} from "@/types/settings";
+
+function buildWorkspacePoliciesPath(tenantCode: string, workspaceCode: string) {
+  return `manage/tenants/${tenantCode}/workspaces/${workspaceCode}/policies`;
+}
 
 export function useSettings() {
   const api = useApi();
@@ -26,4 +40,59 @@ export function useUpdateSettings() {
       queryClient.invalidateQueries({ queryKey: ["settings"] });
     },
   });
+}
+
+export function useWorkspacePolicies(
+  tenantCode?: string,
+  workspaceCode?: string,
+  enabled = true,
+) {
+  const api = useApi();
+  const ready = useApiReady();
+
+  return useQuery({
+    queryKey: ["workspace-policies", tenantCode, workspaceCode],
+    queryFn: () =>
+      api
+        .get(buildWorkspacePoliciesPath(tenantCode!, workspaceCode!))
+        .json<WorkspacePolicies>(),
+    enabled: ready && enabled && !!tenantCode && !!workspaceCode,
+    retry: false,
+  });
+}
+
+export function useUpdateWorkspacePolicies(
+  tenantCode?: string,
+  workspaceCode = "_system",
+) {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: UpdateWorkspacePoliciesRequest) =>
+      api
+        .put(buildWorkspacePoliciesPath(tenantCode!, workspaceCode), {
+          json: data,
+        })
+        .json<WorkspacePolicies>(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["workspace-policies", tenantCode, workspaceCode],
+      });
+    },
+  });
+}
+
+export function useResolvedWorkspacePolicies(scope: ScopeContext) {
+  const query = useWorkspacePolicies(
+    scope.tenantCode,
+    scope.workspaceCode,
+    isWorkspaceScope(scope),
+  );
+
+  return {
+    ...query,
+    data: query.data,
+    canManage: canManageSystemWorkspacePolicies(scope),
+  };
 }

--- a/web/src/hooks/use-templates.ts
+++ b/web/src/hooks/use-templates.ts
@@ -51,3 +51,21 @@ export function useDeleteTemplate(scopedPath: string) {
     },
   });
 }
+
+export function useForkTemplate(scopedPath: string, typeSlug: string) {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (templateId: string) =>
+      api.post(`${scopedPath}/templates/${templateId}/fork`).json<Template>(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["templates", scopedPath, typeSlug] });
+      queryClient.invalidateQueries({ queryKey: ["template-type", scopedPath, typeSlug] });
+      toast.success("Default template forked into this workspace");
+    },
+    onError: () => {
+      toast.error("Failed to fork default template");
+    },
+  });
+}

--- a/web/src/lib/workspace-resource-policies.test.ts
+++ b/web/src/lib/workspace-resource-policies.test.ts
@@ -1,0 +1,230 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  DEFAULT_WORKSPACE_POLICIES,
+  canManageSystemWorkspacePolicies,
+  canShowGlobalSettings,
+  getInjectorManagementState,
+  getTemplateCatalogState,
+  getTemplateManagementState,
+  getTemplateTypeManagementState,
+  resolveResourceDisplayScope,
+  resolveWorkspacePolicies,
+} = await import(new URL("./workspace-resource-policies.ts", import.meta.url).href);
+
+test("resolveWorkspacePolicies falls back to compatible defaults", () => {
+  assert.deepEqual(resolveWorkspacePolicies(), DEFAULT_WORKSPACE_POLICIES);
+  assert.deepEqual(resolveWorkspacePolicies({ allow_workspace_local_templates: false }), {
+    allow_workspace_local_templates: false,
+    allow_workspace_inherited_template_forks: true,
+    allow_workspace_local_injectors: true,
+  });
+});
+
+test("settings visibility distinguishes global settings from _system workspace policies", () => {
+  assert.equal(canShowGlobalSettings({ level: "global" }), true);
+  assert.equal(
+    canManageSystemWorkspacePolicies({
+      level: "workspace",
+      tenantCode: "acme",
+      workspaceCode: "_system",
+    }),
+    true,
+  );
+  assert.equal(
+    canManageSystemWorkspacePolicies({
+      level: "workspace",
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+    }),
+    false,
+  );
+});
+
+test("workspace inherited templates stay read-only but can be forked", () => {
+  const state = getTemplateManagementState(
+    {
+      level: "workspace",
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+    },
+    {
+      owner_scope: "system",
+      inherited_from_system: true,
+      is_fork: false,
+    },
+    DEFAULT_WORKSPACE_POLICIES,
+  );
+
+  assert.equal(state.canFork, true);
+  assert.equal(state.canManageVersions, false);
+  assert.equal(state.canEditMetadata, false);
+  assert.equal(state.versionPrimaryAction, "open");
+  assert.deepEqual(state.badges, ["defaultSystem", "readOnly"]);
+});
+
+test("forked workspace templates unlock version management without unlocking metadata", () => {
+  const state = getTemplateManagementState(
+    {
+      level: "workspace",
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+    },
+    {
+      owner_scope: "local",
+      inherited_from_system: false,
+      is_fork: true,
+    },
+    {
+      allow_workspace_local_templates: false,
+      allow_workspace_inherited_template_forks: true,
+      allow_workspace_local_injectors: true,
+    },
+  );
+
+  assert.equal(state.canFork, false);
+  assert.equal(state.canManageVersions, true);
+  assert.equal(state.canEditMetadata, false);
+  assert.equal(state.versionPrimaryAction, "edit");
+  assert.deepEqual(state.badges, ["forkedFromDefault"]);
+});
+
+test("workspace template type creation and local edits obey the local template policy", () => {
+  const catalogState = getTemplateCatalogState(
+    {
+      level: "workspace",
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+    },
+    {
+      allow_workspace_local_templates: false,
+      allow_workspace_inherited_template_forks: true,
+      allow_workspace_local_injectors: true,
+    },
+  );
+
+  assert.equal(catalogState.canCreateTemplateTypes, false);
+
+  const typeState = getTemplateTypeManagementState(
+    {
+      level: "workspace",
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+    },
+    {
+      owner_scope: "local",
+      inherited_from_system: false,
+    },
+    {
+      allow_workspace_local_templates: false,
+      allow_workspace_inherited_template_forks: true,
+      allow_workspace_local_injectors: true,
+    },
+  );
+
+  assert.equal(typeState.canEdit, false);
+  assert.equal(typeState.canDelete, false);
+  assert.deepEqual(typeState.badges, ["local", "readOnly"]);
+});
+
+test("workspace actions stay conservative when policies are unavailable", () => {
+  const scope = {
+    level: "workspace" as const,
+    tenantCode: "acme",
+    workspaceCode: "marketing",
+  };
+
+  const catalogState = getTemplateCatalogState(scope, undefined);
+  assert.equal(catalogState.canCreateTemplateTypes, false);
+  assert.equal(catalogState.canCreateTemplates, false);
+
+  const inheritedTemplateState = getTemplateManagementState(
+    scope,
+    {
+      owner_scope: "system",
+      inherited_from_system: true,
+      is_fork: false,
+    },
+    undefined,
+  );
+  assert.equal(inheritedTemplateState.canFork, false);
+
+  const localInjectorState = getInjectorManagementState(
+    scope,
+    {
+      owner_scope: "local",
+      inherited_from_system: false,
+    },
+    undefined,
+  );
+  assert.equal(localInjectorState.canEdit, false);
+  assert.equal(localInjectorState.canDelete, false);
+});
+
+test("injectors expose inherited read-only state and local policy restrictions", () => {
+  const inherited = getInjectorManagementState(
+    {
+      level: "workspace",
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+    },
+    {
+      owner_scope: "system",
+      inherited_from_system: true,
+    },
+    DEFAULT_WORKSPACE_POLICIES,
+  );
+
+  assert.equal(inherited.canEdit, false);
+  assert.equal(inherited.canDelete, false);
+  assert.deepEqual(inherited.badges, ["defaultSystem", "readOnly"]);
+
+  const localBlocked = getInjectorManagementState(
+    {
+      level: "workspace",
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+    },
+    {
+      owner_scope: "local",
+      inherited_from_system: false,
+    },
+    {
+      allow_workspace_local_templates: true,
+      allow_workspace_inherited_template_forks: true,
+      allow_workspace_local_injectors: false,
+    },
+  );
+
+  assert.equal(localBlocked.canEdit, false);
+  assert.equal(localBlocked.canDelete, false);
+  assert.deepEqual(localBlocked.badges, ["local", "readOnly"]);
+});
+
+test("display scope resolves system-owned resources without relying on scope_level", () => {
+  assert.equal(
+    resolveResourceDisplayScope({
+      owner_scope: "system",
+      inherited_from_system: true,
+      scope_level: undefined,
+    }),
+    "system",
+  );
+
+  assert.equal(
+    resolveResourceDisplayScope({
+      owner_scope: "local",
+      workspace_id: "ws-123",
+    }),
+    "workspace",
+  );
+
+  assert.equal(
+    resolveResourceDisplayScope({
+      owner_scope: "global",
+      scope_level: "global",
+    }),
+    "global",
+  );
+});

--- a/web/src/lib/workspace-resource-policies.ts
+++ b/web/src/lib/workspace-resource-policies.ts
@@ -1,0 +1,409 @@
+import {
+  SYSTEM_WORKSPACE_CODE,
+  type OwnerScope,
+  type ScopeContext,
+  type ScopeLevel,
+} from "../types/api.ts";
+import type { WorkspacePolicies } from "../types/settings.ts";
+
+type TemplateResourceLike = {
+  owner_scope?: OwnerScope;
+  inherited_from_system?: boolean;
+  is_fork?: boolean;
+  workspace_id?: string;
+  scope_level?: ScopeLevel;
+};
+
+type TemplateTypeResourceLike = {
+  owner_scope?: OwnerScope;
+  inherited_from_system?: boolean;
+  workspace_id?: string;
+  scope_level?: ScopeLevel;
+};
+
+type InjectorResourceLike = {
+  owner_scope?: OwnerScope;
+  inherited_from_system?: boolean;
+  workspace_id?: string;
+  scope_level?: ScopeLevel;
+};
+
+export type ResourceStateBadge =
+  | "local"
+  | "defaultSystem"
+  | "forkedFromDefault"
+  | "readOnly"
+  | "workspace"
+  | "global";
+
+export type ResourceDisplayScope = ScopeLevel | "system";
+
+type ResourceState = {
+  badges: ResourceStateBadge[];
+  readOnly: boolean;
+};
+
+type TemplateCatalogState = {
+  canCreateTemplateTypes: boolean;
+  canCreateTemplates: boolean;
+};
+
+type TemplateTypeManagementState = ResourceState & {
+  canEdit: boolean;
+  canDelete: boolean;
+};
+
+type TemplateManagementState = ResourceState & {
+  canFork: boolean;
+  canManageVersions: boolean;
+  canEditMetadata: boolean;
+  versionPrimaryAction: "open" | "edit";
+};
+
+type InjectorManagementState = ResourceState & {
+  canEdit: boolean;
+  canDelete: boolean;
+};
+
+export const DEFAULT_WORKSPACE_POLICIES: WorkspacePolicies = {
+  allow_workspace_local_templates: true,
+  allow_workspace_inherited_template_forks: true,
+  allow_workspace_local_injectors: true,
+};
+
+export function resolveWorkspacePolicies(
+  policies?: Partial<WorkspacePolicies> | null,
+): WorkspacePolicies {
+  return {
+    allow_workspace_local_templates:
+      policies?.allow_workspace_local_templates ??
+      DEFAULT_WORKSPACE_POLICIES.allow_workspace_local_templates,
+    allow_workspace_inherited_template_forks:
+      policies?.allow_workspace_inherited_template_forks ??
+      DEFAULT_WORKSPACE_POLICIES.allow_workspace_inherited_template_forks,
+    allow_workspace_local_injectors:
+      policies?.allow_workspace_local_injectors ??
+      DEFAULT_WORKSPACE_POLICIES.allow_workspace_local_injectors,
+  };
+}
+
+export function canShowGlobalSettings(scope: ScopeContext): boolean {
+  return scope.level === "global";
+}
+
+export function canManageSystemWorkspacePolicies(scope: ScopeContext): boolean {
+  return (
+    scope.level === "workspace" && scope.workspaceCode === SYSTEM_WORKSPACE_CODE
+  );
+}
+
+export function isWorkspaceScope(scope: ScopeContext): boolean {
+  return scope.level === "workspace";
+}
+
+export function isSystemWorkspaceScope(scope: ScopeContext): boolean {
+  return canManageSystemWorkspacePolicies(scope);
+}
+
+export function getTemplateCatalogState(
+  scope: ScopeContext,
+  policies?: Partial<WorkspacePolicies> | null,
+): TemplateCatalogState {
+  const workspaceScope = isWorkspaceScope(scope);
+  const systemScope = isSystemWorkspaceScope(scope);
+
+  if (!workspaceScope || systemScope) {
+    return {
+      canCreateTemplateTypes: true,
+      canCreateTemplates: true,
+    };
+  }
+
+  if (!policies) {
+    return {
+      canCreateTemplateTypes: false,
+      canCreateTemplates: false,
+    };
+  }
+
+  const resolved = resolveWorkspacePolicies(policies);
+  return {
+    canCreateTemplateTypes: resolved.allow_workspace_local_templates,
+    canCreateTemplates: resolved.allow_workspace_local_templates,
+  };
+}
+
+export function getTemplateTypeManagementState(
+  scope: ScopeContext,
+  resource?: TemplateTypeResourceLike | null,
+  policies?: Partial<WorkspacePolicies> | null,
+): TemplateTypeManagementState {
+  const base = getBaseResourceState(resource);
+
+  if (!resource) {
+    return {
+      ...base,
+      canEdit: false,
+      canDelete: false,
+    };
+  }
+
+  const resolved = resolveWorkspacePolicies(policies);
+  if (!isWorkspaceScope(scope) || isSystemWorkspaceScope(scope)) {
+    return {
+      ...base,
+      canEdit: true,
+      canDelete: true,
+    };
+  }
+
+  if (resource.owner_scope !== "local") {
+    return {
+      ...appendReadOnlyBadge(base),
+      canEdit: false,
+      canDelete: false,
+    };
+  }
+
+  if (!policies) {
+    return {
+      ...appendReadOnlyBadge(base),
+      canEdit: false,
+      canDelete: false,
+    };
+  }
+
+  const allowed = resolved.allow_workspace_local_templates;
+  return {
+    ...withConditionalReadOnly(base, !allowed),
+    canEdit: allowed,
+    canDelete: allowed,
+  };
+}
+
+export function getTemplateManagementState(
+  scope: ScopeContext,
+  resource?: TemplateResourceLike | null,
+  policies?: Partial<WorkspacePolicies> | null,
+): TemplateManagementState {
+  const base = getBaseResourceState(resource);
+
+  if (!resource) {
+    return {
+      ...base,
+      canFork: false,
+      canManageVersions: false,
+      canEditMetadata: false,
+      versionPrimaryAction: "open" as const,
+    };
+  }
+
+  const resolved = resolveWorkspacePolicies(policies);
+  if (!isWorkspaceScope(scope) || isSystemWorkspaceScope(scope)) {
+    return {
+      ...base,
+      canFork: false,
+      canManageVersions: true,
+      canEditMetadata: true,
+      versionPrimaryAction: "edit" as const,
+    };
+  }
+
+  if (resource.is_fork) {
+    if (!policies) {
+      return {
+        badges: ["forkedFromDefault", "readOnly"],
+        readOnly: true,
+        canFork: false,
+        canManageVersions: false,
+        canEditMetadata: false,
+        versionPrimaryAction: "open" as const,
+      };
+    }
+    const allowed = resolved.allow_workspace_inherited_template_forks;
+    return {
+      badges: ["forkedFromDefault"],
+      readOnly: false,
+      canFork: false,
+      canManageVersions: allowed,
+      canEditMetadata: false,
+      versionPrimaryAction: allowed ? ("edit" as const) : ("open" as const),
+    };
+  }
+
+  if (resource.owner_scope === "system" || resource.inherited_from_system) {
+    return {
+      ...appendReadOnlyBadge(base),
+      canFork: Boolean(policies && resolved.allow_workspace_inherited_template_forks),
+      canManageVersions: false,
+      canEditMetadata: false,
+      versionPrimaryAction: "open" as const,
+    };
+  }
+
+  if (!policies) {
+    return {
+      ...appendReadOnlyBadge(base),
+      canFork: false,
+      canManageVersions: false,
+      canEditMetadata: false,
+      versionPrimaryAction: "open" as const,
+    };
+  }
+
+  const allowed = resolved.allow_workspace_local_templates;
+  return {
+    ...withConditionalReadOnly(base, !allowed),
+    canFork: false,
+    canManageVersions: allowed,
+    canEditMetadata: allowed,
+    versionPrimaryAction: allowed ? ("edit" as const) : ("open" as const),
+  };
+}
+
+export function getInjectorManagementState(
+  scope: ScopeContext,
+  resource?: InjectorResourceLike | null,
+  policies?: Partial<WorkspacePolicies> | null,
+): InjectorManagementState {
+  const base = getBaseResourceState(resource);
+
+  if (!resource) {
+    return {
+      ...base,
+      canEdit: false,
+      canDelete: false,
+    };
+  }
+
+  const resolved = resolveWorkspacePolicies(policies);
+  if (!isWorkspaceScope(scope) || isSystemWorkspaceScope(scope)) {
+    return {
+      ...base,
+      canEdit: true,
+      canDelete: true,
+    };
+  }
+
+  if (resource.owner_scope !== "local") {
+    return {
+      ...appendReadOnlyBadge(base),
+      canEdit: false,
+      canDelete: false,
+    };
+  }
+
+  if (!policies) {
+    return {
+      ...appendReadOnlyBadge(base),
+      canEdit: false,
+      canDelete: false,
+    };
+  }
+
+  const allowed = resolved.allow_workspace_local_injectors;
+  return {
+    ...withConditionalReadOnly(base, !allowed),
+    canEdit: allowed,
+    canDelete: allowed,
+  };
+}
+
+function getBaseResourceState(
+  resource?: {
+    owner_scope?: OwnerScope;
+    inherited_from_system?: boolean;
+    is_fork?: boolean;
+  } | null,
+): ResourceState {
+  if (resource?.is_fork) {
+    return {
+      badges: ["forkedFromDefault"],
+      readOnly: false,
+    };
+  }
+
+  if (resource?.owner_scope === "local") {
+    return {
+      badges: ["local"],
+      readOnly: false,
+    };
+  }
+
+  if (resource?.owner_scope === "system" || resource?.inherited_from_system) {
+    return {
+      badges: ["defaultSystem"],
+      readOnly: true,
+    };
+  }
+
+  if (resource?.owner_scope === "workspace") {
+    return {
+      badges: ["workspace"],
+      readOnly: false,
+    };
+  }
+
+  if (resource?.owner_scope === "global") {
+    return {
+      badges: ["global"],
+      readOnly: false,
+    };
+  }
+
+  return {
+    badges: [],
+    readOnly: false,
+  };
+}
+
+export function resolveResourceDisplayScope(
+  resource?: {
+    owner_scope?: OwnerScope;
+    inherited_from_system?: boolean;
+    workspace_id?: string;
+    scope_level?: ScopeLevel;
+  } | null,
+  fallbackScope: ScopeLevel = "global",
+): ResourceDisplayScope {
+  if (resource?.owner_scope === "system" || resource?.inherited_from_system) {
+    return "system";
+  }
+
+  if (resource?.owner_scope === "local" || resource?.owner_scope === "workspace") {
+    return "workspace";
+  }
+
+  if (resource?.owner_scope === "global") {
+    return "global";
+  }
+
+  if (resource?.scope_level) {
+    return resource.scope_level;
+  }
+
+  if (resource?.workspace_id) {
+    return "workspace";
+  }
+
+  return fallbackScope;
+}
+
+function appendReadOnlyBadge(state: ResourceState): ResourceState {
+  if (state.badges.includes("readOnly")) {
+    return state;
+  }
+
+  return {
+    ...state,
+    readOnly: true,
+    badges: [...state.badges, "readOnly"],
+  };
+}
+
+function withConditionalReadOnly(
+  state: ResourceState,
+  readOnly: boolean,
+): ResourceState {
+  return readOnly ? appendReadOnlyBadge(state) : state;
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -28,6 +28,7 @@ export interface FieldError {
 
 /** Scope levels for the hierarchy */
 export type ScopeLevel = "global" | "tenant" | "workspace";
+export type OwnerScope = "global" | "system" | "local" | "workspace";
 
 export const SYSTEM_WORKSPACE_CODE = "_system";
 

--- a/web/src/types/injectors.ts
+++ b/web/src/types/injectors.ts
@@ -1,3 +1,5 @@
+import type { OwnerScope } from "@/types/api";
+
 /** Injector field type */
 export type InjectorFieldType = "text" | "number" | "bool" | "img" | "url" | "html";
 
@@ -19,6 +21,8 @@ export interface InjectorDefinition {
   name: string;
   description?: string;
   fields: InjectorField[];
+  owner_scope?: OwnerScope;
+  inherited_from_system?: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/web/src/types/settings.ts
+++ b/web/src/types/settings.ts
@@ -5,6 +5,13 @@ export interface SystemSettings {
   alerts: AlertSettings;
 }
 
+/** Tenant-local workspace policies configured from the _system workspace */
+export interface WorkspacePolicies {
+  allow_workspace_local_templates: boolean;
+  allow_workspace_inherited_template_forks: boolean;
+  allow_workspace_local_injectors: boolean;
+}
+
 export interface OidcSettings {
   discovery_url: string;
   client_id: string;
@@ -27,3 +34,5 @@ export interface UpdateSettingsRequest {
   email_defaults?: Partial<EmailDefaultSettings>;
   alerts?: Partial<AlertSettings>;
 }
+
+export type UpdateWorkspacePoliciesRequest = Partial<WorkspacePolicies>;

--- a/web/src/types/templates.ts
+++ b/web/src/types/templates.ts
@@ -1,4 +1,4 @@
-import type { TemplateVersionStatus, ScopeLevel } from "./api";
+import type { OwnerScope, ScopeLevel, TemplateVersionStatus } from "./api";
 
 /** Template type (e.g., "welcome", "invoice") */
 export interface TemplateType {
@@ -8,7 +8,9 @@ export interface TemplateType {
   adapter_id?: string;
   sender_identity_id?: string;
   variable_schema?: Record<string, unknown>;
-  scope_level: ScopeLevel;
+  scope_level?: ScopeLevel;
+  owner_scope?: OwnerScope;
+  inherited_from_system?: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -18,7 +20,11 @@ export interface Template {
   id: string;
   template_type_id: string;
   is_disabled: boolean;
-  scope_level: ScopeLevel;
+  scope_level?: ScopeLevel;
+  owner_scope?: OwnerScope;
+  inherited_from_system?: boolean;
+  is_fork?: boolean;
+  origin_template_id?: string;
   created_at: string;
   updated_at: string;
 }

--- a/web/tests/workspace-defaults-ui.test.mjs
+++ b/web/tests/workspace-defaults-ui.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const cwd = process.cwd();
+const root = cwd.endsWith("/web") ? cwd : path.join(cwd, "web");
+
+async function read(relativePath) {
+  const normalized =
+    relativePath.startsWith("web/") && root.endsWith("/web")
+      ? relativePath.slice(4)
+      : relativePath;
+
+  return readFile(path.join(root, normalized), "utf8");
+}
+
+test("settings page exposes _system workspace policy controls", async () => {
+  const source = await read("web/src/components/settings/settings-content.tsx");
+  const en = await read("web/messages/en.json");
+  const hooks = await read("web/src/hooks/use-settings.ts");
+
+  assert.match(source, /useTranslations\("settingsPage"\)/);
+  assert.match(source, /onClick=\{\(\) => void savePolicies\(getValues\(\)\)\}/);
+  assert.match(hooks, /scope\.workspaceCode/);
+  assert.doesNotMatch(hooks, /query\.data \?\? DEFAULT_WORKSPACE_POLICIES/);
+  assert.match(en, /"workspaceDefaultsPolicy"/);
+});
+
+test("template screens surface fork and read-only workspace copy", async () => {
+  const list = await read("web/src/components/templates/templates-list-content.tsx");
+  const types = await read("web/src/components/templates/template-types-content.tsx");
+  const badges = await read("web/src/components/shared/resource-state-badges.tsx");
+
+  assert.match(list, /useTranslations\("templatesPage"\)/);
+  assert.match(types, /resolveResourceDisplayScope/);
+  assert.match(badges, /useTranslations\("resourceState"\)/);
+});
+
+test("injector screens request inherited injectors and surface read-only copy", async () => {
+  const source = await read("web/src/components/injectors/injectors-content.tsx");
+  const scope = await read("web/src/components/shared/scope-indicator.tsx");
+
+  assert.match(source, /includeInherited: scope\.level === "workspace"/);
+  assert.match(source, /useTranslations\("injectorsPage"\)/);
+  assert.match(scope, /useTranslations\("scopeIndicator"\)/);
+});

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
Closes #65

## Summary

- Expose tenant `_system` templates, template types, and injectors inside workspaces as read-only `Default/System` resources.
- Add tenant-scoped workspace policies managed from `/_system/settings` and enforce them in both backend and frontend.
- Add workspace template forks that shadow inherited defaults locally while freezing template metadata and allowing version-only workspace divergence.

## Context

- Related issue: #65
- Related story (if any): none
- Risk / tradeoffs:
  - This intentionally removes workspace fallback to global resources for templates and injectors, so tenants now inherit only from their own `_system` workspace.
  - Policy reads are now exposed as effective read-only values for workspace viewers so the UI can disable actions conservatively.

## Validation

Mark everything you actually ran.

- [ ] `make ci-backend-pr` (if backend, infra, migrations, or tests changed)
- [ ] `make ci-frontend` (if `web/` changed)
- [x] `make ci-pr` (if both backend and frontend changed)
- [ ] `make ci-main` (required for pushes to `main` and systemic/cross-layer changes; fast gate, no Docker)

Optional deeper checks when you intentionally want Docker-backed coverage:

- [ ] `make test-integration`
- [ ] `make test-e2e`

Additional commands actually run:

- [x] `go test ./internal/http/handler ./internal/resolution`
- [x] `go test ./internal/service -run 'TestTestSendService|TestSend'`
- [x] `go test -tags=integration ./internal/adapter/postgres -run 'TestTemplateRepo_(GetTypeBySlug_PrefersEarlierScopeInChainOverUUIDOrdering|ResolveTemplate_PrefersEarlierScopeInChainOverUUIDOrdering|ForkTemplate_CopiesTemplateVersionsAndLocales)|TestInjectorRepo_ListDefinitionsInChain'`
- [x] `node --test web/src/lib/workspace-resource-policies.test.ts web/tests/workspace-defaults-ui.test.mjs`
- [x] `pnpm --dir web typecheck`
- [x] `pnpm --dir web lint`
- [x] Browser validation of `_system/settings`, workspace templates, template fork flow, and inherited injectors

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test-only
- [ ] Security-sensitive

## Contributor checklist

- [x] I kept the change focused and reviewable.
- [x] I added or updated tests where behavior changed.
- [ ] I updated docs when behavior, setup, API, or workflows changed.
- [x] I did not add build-only validation as a substitute for the required local gates.
- [x] I did not add AI attribution or `Co-Authored-By` trailers.

## Compatibility / ops impact

- [ ] No migration
- [x] Migration included
- [x] No config changes
- [ ] Config changes included
- [x] No security impact
- [ ] Security impact described above

## Changes table

| File | Change |
|------|--------|
| `internal/http/handler/scope_inheritance.go` | Centralized workspace-only `_system` inheritance rules and visibility helpers |
| `internal/http/handler/template.go` | Added fork flow, mutable workspace guards, and cache invalidation after fork |
| `internal/http/handler/injector.go` | Limited inherited injector lookup to workspace + `_system` and enforced read-only inherited behavior |
| `internal/http/handler/workspace_policy.go` | Added effective workspace policy read/update behavior for tenant `_system` settings |
| `internal/resolution/chain.go` | Removed global fallback from workspace runtime resolution chain |
| `internal/adapter/postgres/template_repo.go` | Added persistence support for workspace policies and template forks |
| `migrations/000038_workspace_policies_and_template_forks.*.sql` | Added schema for workspace policies and template fork metadata |
| `web/src/components/settings/settings-content.tsx` | Added `_system` policy controls |
| `web/src/components/templates/*` | Surfaced inherited/forked template states and fork/version actions in UI |
| `web/src/components/injectors/injectors-content.tsx` | Surfaced inherited injector state and workspace policy gating |
