### PR TITLE
feat: add external integration embed surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ test/system/baselines/pencil/
 # Project internal files (stories, design files)
 stories/
 *.pen
+.worktrees/

--- a/cmd/senda-e2e/main.go
+++ b/cmd/senda-e2e/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
+	httpmw "github.com/rendis/senda/internal/http/middleware"
 	"github.com/rendis/senda/sdk"
 )
 
@@ -21,6 +24,15 @@ func main() {
 		engine.RegisterInjector(e2eStudentInjector{})
 	} else {
 		slog.Warn("e2e code injectors disabled")
+	}
+	if os.Getenv("SENDA_E2E_ENABLE_EXTERNAL_INTEGRATION") == "true" {
+		slog.Info("registering e2e external integration methods")
+		engine.RegisterExternalAuthMethod(e2eExternalAuthMethod{
+			token: externalToken(),
+		})
+		engine.RegisterExternalWorkspaceResolver(e2eExternalWorkspaceResolver{})
+	} else {
+		slog.Warn("e2e external integration disabled")
 	}
 
 	if err := engine.Run(); err != nil {
@@ -47,3 +59,103 @@ func (e2eStudentInjector) Resolve() (sdk.ResolveFunc, []string) {
 func (e2eStudentInjector) IsCritical() bool { return true }
 
 func (e2eStudentInjector) Timeout() time.Duration { return 0 }
+
+type e2eExternalAuthMethod struct {
+	token string
+}
+
+func (e e2eExternalAuthMethod) Name() string { return "e2e-signed-token" }
+
+func (e e2eExternalAuthMethod) Description() string {
+	return "E2E token auth for external integration tests"
+}
+
+func (e e2eExternalAuthMethod) Authenticate(_ context.Context, req *sdk.ExternalIntegrationRequest) (*sdk.ExternalAuthResult, error) {
+	if req == nil {
+		return nil, errors.New("missing external integration request")
+	}
+
+	token := strings.TrimSpace(req.Token)
+	if token == "" {
+		token = strings.TrimSpace(req.QueryParams["token"])
+	}
+	if token == "" {
+		token = strings.TrimSpace(req.Headers["x-senda-external-token"])
+	}
+	if tenantHeader := strings.TrimSpace(req.Headers["x-tenant-code"]); tenantHeader != "" && !strings.EqualFold(tenantHeader, req.TenantCode) {
+		return nil, httpmw.ExternalAuthDenied()
+	}
+
+	permissions := sdk.ExternalPermissions{
+		ListTemplates:   true,
+		ViewVersions:    true,
+		EditVersions:    true,
+		PublishVersions: true,
+		TestSend:        true,
+		BuilderAccess:   true,
+		MetadataAccess:  true,
+		LocaleAccess:    true,
+	}
+
+	switch token {
+	case "external-e2e-viewer":
+		permissions = sdk.ExternalPermissions{
+			ListTemplates:   true,
+			ViewVersions:    true,
+			EditVersions:    false,
+			PublishVersions: false,
+			TestSend:        false,
+			BuilderAccess:   true,
+			MetadataAccess:  true,
+			LocaleAccess:    true,
+		}
+	case e.token:
+	default:
+		return nil, httpmw.ExternalAuthDenied()
+	}
+
+	return &sdk.ExternalAuthResult{
+		Permissions: permissions,
+		Context: map[string]any{
+			"tenant_code": req.TenantCode,
+			"token":       token,
+		},
+	}, nil
+}
+
+type e2eExternalWorkspaceResolver struct{}
+
+func (e2eExternalWorkspaceResolver) Name() string { return "e2e-workspace-resolver" }
+
+func (e2eExternalWorkspaceResolver) Description() string {
+	return "E2E resolver that can force workspace fallback via query params"
+}
+
+func (e2eExternalWorkspaceResolver) ResolveWorkspace(_ context.Context, req *sdk.ExternalIntegrationRequest, _ *sdk.ExternalAuthResult) (*sdk.ExternalWorkspaceResolution, error) {
+	if req == nil {
+		return nil, errors.New("missing external integration request")
+	}
+
+	if req.QueryParams["fallback"] == "system" {
+		return &sdk.ExternalWorkspaceResolution{
+			WorkspaceCode: "_system",
+			ReadOnly:      true,
+		}, nil
+	}
+
+	if len(req.WorkspaceCodes) == 0 || strings.TrimSpace(req.WorkspaceCodes[0]) == "" {
+		return nil, errors.New("missing workspace code")
+	}
+
+	return &sdk.ExternalWorkspaceResolution{
+		WorkspaceCode: strings.TrimSpace(req.WorkspaceCodes[0]),
+		ReadOnly:      false,
+	}, nil
+}
+
+func externalToken() string {
+	if token := strings.TrimSpace(os.Getenv("SENDA_E2E_EXTERNAL_TOKEN")); token != "" {
+		return token
+	}
+	return "external-e2e-token"
+}

--- a/cmd/senda/docs/docs.go
+++ b/cmd/senda/docs/docs.go
@@ -14132,6 +14132,90 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_rendis_senda_internal_http_request.ExternalIntegrationCapabilitiesUpdate": {
+            "type": "object",
+            "properties": {
+                "builder_access": {
+                    "type": "boolean"
+                },
+                "edit_versions": {
+                    "type": "boolean"
+                },
+                "list_templates": {
+                    "type": "boolean"
+                },
+                "locale_access": {
+                    "type": "boolean"
+                },
+                "metadata_access": {
+                    "type": "boolean"
+                },
+                "publish_versions": {
+                    "type": "boolean"
+                },
+                "test_send": {
+                    "type": "boolean"
+                },
+                "view_versions": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_rendis_senda_internal_http_request.ExternalIntegrationProfileUpdate": {
+            "type": "object",
+            "properties": {
+                "allowed_headers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "allowed_origins": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "auth_method_name": {
+                    "type": "string"
+                },
+                "capabilities": {
+                    "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.ExternalIntegrationCapabilitiesUpdate"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "required_headers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "resolver_name": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_rendis_senda_internal_http_request.ExternalIntegrationsUpdate": {
+            "type": "object",
+            "properties": {
+                "profiles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.ExternalIntegrationProfileUpdate"
+                    }
+                }
+            }
+        },
         "github_com_rendis_senda_internal_http_request.InjectorFieldValue": {
             "type": "object",
             "properties": {
@@ -14335,6 +14419,9 @@ const docTemplate = `{
                 },
                 "email_defaults": {
                     "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.EmailDefaultsUpdate"
+                },
+                "external_integrations": {
+                    "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.ExternalIntegrationsUpdate"
                 }
             }
         },
@@ -14648,6 +14735,9 @@ const docTemplate = `{
                 },
                 "email_defaults": {
                     "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.EmailDefaultsConfigResponse"
+                },
+                "external_integrations": {
+                    "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationsConfigResponse"
                 },
                 "oidc": {
                     "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.OIDCConfigResponse"
@@ -15047,6 +15137,90 @@ const docTemplate = `{
                 },
                 "workspace_id": {
                     "type": "string"
+                }
+            }
+        },
+        "github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse": {
+            "type": "object",
+            "properties": {
+                "builder_access": {
+                    "type": "boolean"
+                },
+                "edit_versions": {
+                    "type": "boolean"
+                },
+                "list_templates": {
+                    "type": "boolean"
+                },
+                "locale_access": {
+                    "type": "boolean"
+                },
+                "metadata_access": {
+                    "type": "boolean"
+                },
+                "publish_versions": {
+                    "type": "boolean"
+                },
+                "test_send": {
+                    "type": "boolean"
+                },
+                "view_versions": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_rendis_senda_internal_http_response.ExternalIntegrationProfileResponse": {
+            "type": "object",
+            "properties": {
+                "allowed_headers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "allowed_origins": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "auth_method_name": {
+                    "type": "string"
+                },
+                "capabilities": {
+                    "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "required_headers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "resolver_name": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_rendis_senda_internal_http_response.ExternalIntegrationsConfigResponse": {
+            "type": "object",
+            "properties": {
+                "profiles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationProfileResponse"
+                    }
                 }
             }
         },

--- a/cmd/senda/docs/openapi.yaml
+++ b/cmd/senda/docs/openapi.yaml
@@ -199,6 +199,61 @@ components:
                 max_retries:
                     type: integer
             type: object
+        github_com_rendis_senda_internal_http_request.ExternalIntegrationCapabilitiesUpdate:
+            properties:
+                builder_access:
+                    type: boolean
+                edit_versions:
+                    type: boolean
+                list_templates:
+                    type: boolean
+                locale_access:
+                    type: boolean
+                metadata_access:
+                    type: boolean
+                publish_versions:
+                    type: boolean
+                test_send:
+                    type: boolean
+                view_versions:
+                    type: boolean
+            type: object
+        github_com_rendis_senda_internal_http_request.ExternalIntegrationProfileUpdate:
+            properties:
+                allowed_headers:
+                    items:
+                        type: string
+                    type: array
+                allowed_origins:
+                    items:
+                        type: string
+                    type: array
+                auth_method_name:
+                    type: string
+                capabilities:
+                    $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.ExternalIntegrationCapabilitiesUpdate'
+                description:
+                    type: string
+                enabled:
+                    type: boolean
+                name:
+                    type: string
+                required_headers:
+                    items:
+                        type: string
+                    type: array
+                resolver_name:
+                    type: string
+                slug:
+                    type: string
+            type: object
+        github_com_rendis_senda_internal_http_request.ExternalIntegrationsUpdate:
+            properties:
+                profiles:
+                    items:
+                        $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.ExternalIntegrationProfileUpdate'
+                    type: array
+            type: object
         github_com_rendis_senda_internal_http_request.InjectorFieldValue:
             properties:
                 field_name:
@@ -333,6 +388,8 @@ components:
                     $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.DomainUpdate'
                 email_defaults:
                     $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.EmailDefaultsUpdate'
+                external_integrations:
+                    $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.ExternalIntegrationsUpdate'
             type: object
         github_com_rendis_senda_internal_http_request.UpdateInjectorFieldRequest:
             properties:
@@ -538,6 +595,8 @@ components:
                     $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.DomainConfigResponse'
                 email_defaults:
                     $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.EmailDefaultsConfigResponse'
+                external_integrations:
+                    $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.ExternalIntegrationsConfigResponse'
                 oidc:
                     $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.OIDCConfigResponse'
             type: object
@@ -800,6 +859,61 @@ components:
                     type: string
                 workspace_id:
                     type: string
+            type: object
+        github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse:
+            properties:
+                builder_access:
+                    type: boolean
+                edit_versions:
+                    type: boolean
+                list_templates:
+                    type: boolean
+                locale_access:
+                    type: boolean
+                metadata_access:
+                    type: boolean
+                publish_versions:
+                    type: boolean
+                test_send:
+                    type: boolean
+                view_versions:
+                    type: boolean
+            type: object
+        github_com_rendis_senda_internal_http_response.ExternalIntegrationProfileResponse:
+            properties:
+                allowed_headers:
+                    items:
+                        type: string
+                    type: array
+                allowed_origins:
+                    items:
+                        type: string
+                    type: array
+                auth_method_name:
+                    type: string
+                capabilities:
+                    $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse'
+                description:
+                    type: string
+                enabled:
+                    type: boolean
+                name:
+                    type: string
+                required_headers:
+                    items:
+                        type: string
+                    type: array
+                resolver_name:
+                    type: string
+                slug:
+                    type: string
+            type: object
+        github_com_rendis_senda_internal_http_response.ExternalIntegrationsConfigResponse:
+            properties:
+                profiles:
+                    items:
+                        $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.ExternalIntegrationProfileResponse'
+                    type: array
             type: object
         github_com_rendis_senda_internal_http_response.InjectorDetailResponse:
             properties:

--- a/cmd/senda/docs/swagger.yaml
+++ b/cmd/senda/docs/swagger.yaml
@@ -199,6 +199,61 @@ definitions:
       max_retries:
         type: integer
     type: object
+  github_com_rendis_senda_internal_http_request.ExternalIntegrationCapabilitiesUpdate:
+    properties:
+      builder_access:
+        type: boolean
+      edit_versions:
+        type: boolean
+      list_templates:
+        type: boolean
+      locale_access:
+        type: boolean
+      metadata_access:
+        type: boolean
+      publish_versions:
+        type: boolean
+      test_send:
+        type: boolean
+      view_versions:
+        type: boolean
+    type: object
+  github_com_rendis_senda_internal_http_request.ExternalIntegrationProfileUpdate:
+    properties:
+      allowed_headers:
+        items:
+          type: string
+        type: array
+      allowed_origins:
+        items:
+          type: string
+        type: array
+      auth_method_name:
+        type: string
+      capabilities:
+        $ref: '#/definitions/github_com_rendis_senda_internal_http_request.ExternalIntegrationCapabilitiesUpdate'
+      description:
+        type: string
+      enabled:
+        type: boolean
+      name:
+        type: string
+      required_headers:
+        items:
+          type: string
+        type: array
+      resolver_name:
+        type: string
+      slug:
+        type: string
+    type: object
+  github_com_rendis_senda_internal_http_request.ExternalIntegrationsUpdate:
+    properties:
+      profiles:
+        items:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.ExternalIntegrationProfileUpdate'
+        type: array
+    type: object
   github_com_rendis_senda_internal_http_request.InjectorFieldValue:
     properties:
       field_name:
@@ -333,6 +388,8 @@ definitions:
         $ref: '#/definitions/github_com_rendis_senda_internal_http_request.DomainUpdate'
       email_defaults:
         $ref: '#/definitions/github_com_rendis_senda_internal_http_request.EmailDefaultsUpdate'
+      external_integrations:
+        $ref: '#/definitions/github_com_rendis_senda_internal_http_request.ExternalIntegrationsUpdate'
     type: object
   github_com_rendis_senda_internal_http_request.UpdateInjectorFieldRequest:
     properties:
@@ -538,6 +595,8 @@ definitions:
         $ref: '#/definitions/github_com_rendis_senda_internal_http_response.DomainConfigResponse'
       email_defaults:
         $ref: '#/definitions/github_com_rendis_senda_internal_http_response.EmailDefaultsConfigResponse'
+      external_integrations:
+        $ref: '#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationsConfigResponse'
       oidc:
         $ref: '#/definitions/github_com_rendis_senda_internal_http_response.OIDCConfigResponse'
     type: object
@@ -800,6 +859,61 @@ definitions:
         type: string
       workspace_id:
         type: string
+    type: object
+  github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse:
+    properties:
+      builder_access:
+        type: boolean
+      edit_versions:
+        type: boolean
+      list_templates:
+        type: boolean
+      locale_access:
+        type: boolean
+      metadata_access:
+        type: boolean
+      publish_versions:
+        type: boolean
+      test_send:
+        type: boolean
+      view_versions:
+        type: boolean
+    type: object
+  github_com_rendis_senda_internal_http_response.ExternalIntegrationProfileResponse:
+    properties:
+      allowed_headers:
+        items:
+          type: string
+        type: array
+      allowed_origins:
+        items:
+          type: string
+        type: array
+      auth_method_name:
+        type: string
+      capabilities:
+        $ref: '#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse'
+      description:
+        type: string
+      enabled:
+        type: boolean
+      name:
+        type: string
+      required_headers:
+        items:
+          type: string
+        type: array
+      resolver_name:
+        type: string
+      slug:
+        type: string
+    type: object
+  github_com_rendis_senda_internal_http_response.ExternalIntegrationsConfigResponse:
+    properties:
+      profiles:
+        items:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationProfileResponse'
+        type: array
     type: object
   github_com_rendis_senda_internal_http_response.InjectorDetailResponse:
     properties:

--- a/internal/adapter/postgres/global_config_repo.go
+++ b/internal/adapter/postgres/global_config_repo.go
@@ -71,6 +71,7 @@ func (r *GlobalConfigRepo) Upsert(ctx context.Context, cfg *domain.GlobalConfig)
 		{"complaint.alert_threshold_percent", cfg.ComplaintAlertThresholdPercent},
 		{"domain.recheck_interval_hours", cfg.DomainRecheckIntervalHours},
 		{"onboarding.completed", cfg.OnboardingCompleted},
+		{"external.integrations", cfg.ExternalIntegrations},
 	}
 
 	for _, e := range entries {
@@ -112,6 +113,8 @@ func mapConfigValue(cfg *domain.GlobalConfig, key string, value json.RawMessage)
 		return json.Unmarshal(value, &cfg.DomainRecheckIntervalHours)
 	case "onboarding.completed":
 		return json.Unmarshal(value, &cfg.OnboardingCompleted)
+	case "external.integrations":
+		return json.Unmarshal(value, &cfg.ExternalIntegrations)
 	default:
 		// Unknown keys (e.g. oidc.*) are intentionally ignored.
 		return nil

--- a/internal/adapter/postgres/global_config_repo_test.go
+++ b/internal/adapter/postgres/global_config_repo_test.go
@@ -61,13 +61,13 @@ func TestGlobalConfigRepo_Upsert(t *testing.T) {
 
 	// Modify values
 	updated := &domain.GlobalConfig{
-		DefaultRetryCount:             5,
-		RetryBackoffBaseSeconds:       120,
-		LogRetentionDays:              180,
-		BounceAlertThresholdPercent:   10.0,
+		DefaultRetryCount:              5,
+		RetryBackoffBaseSeconds:        120,
+		LogRetentionDays:               180,
+		BounceAlertThresholdPercent:    10.0,
 		ComplaintAlertThresholdPercent: 0.5,
-		DomainRecheckIntervalHours:    48,
-		OnboardingCompleted:           true,
+		DomainRecheckIntervalHours:     48,
+		OnboardingCompleted:            true,
 	}
 
 	if err := repo.Upsert(ctx, updated); err != nil {
@@ -113,13 +113,13 @@ func TestGlobalConfigRepo_Upsert_PartialUpdate(t *testing.T) {
 
 	// Only change one field, rest should be overwritten with the values we pass
 	cfg := &domain.GlobalConfig{
-		DefaultRetryCount:             10,
-		RetryBackoffBaseSeconds:       60,
-		LogRetentionDays:              365,
-		BounceAlertThresholdPercent:   5.0,
+		DefaultRetryCount:              10,
+		RetryBackoffBaseSeconds:        60,
+		LogRetentionDays:               365,
+		BounceAlertThresholdPercent:    5.0,
 		ComplaintAlertThresholdPercent: 0.1,
-		DomainRecheckIntervalHours:    24,
-		OnboardingCompleted:           false,
+		DomainRecheckIntervalHours:     24,
+		OnboardingCompleted:            false,
 	}
 
 	if err := repo.Upsert(ctx, cfg); err != nil {
@@ -137,5 +137,54 @@ func TestGlobalConfigRepo_Upsert_PartialUpdate(t *testing.T) {
 	// Other fields should match what we passed
 	if got.RetryBackoffBaseSeconds != 60 {
 		t.Errorf("RetryBackoffBaseSeconds: want 60, got %d", got.RetryBackoffBaseSeconds)
+	}
+}
+
+func TestGlobalConfigRepo_ExternalIntegrationsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	repo := pgadapter.NewGlobalConfigRepo(pool)
+
+	cfg := &domain.GlobalConfig{
+		DefaultRetryCount:              3,
+		RetryBackoffBaseSeconds:        60,
+		LogRetentionDays:               365,
+		BounceAlertThresholdPercent:    5.0,
+		ComplaintAlertThresholdPercent: 0.1,
+		DomainRecheckIntervalHours:     24,
+		OnboardingCompleted:            false,
+		ExternalIntegrations: []domain.ExternalIntegrationProfile{
+			{
+				Slug:            "partner-portal",
+				Name:            "Partner Portal",
+				Description:     "Integration for partner-facing UI",
+				Enabled:         true,
+				AuthMethodName:  "signed-headers",
+				ResolverName:    "tenant-workspace-resolver",
+				AllowedOrigins:  []string{"https://app.example.com"},
+				AllowedHeaders:  []string{"x-tenant-code"},
+				RequiredHeaders: []string{"x-tenant-code"},
+			},
+		},
+	}
+
+	if err := repo.Upsert(ctx, cfg); err != nil {
+		t.Fatalf("Upsert() error: %v", err)
+	}
+
+	got, err := repo.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+
+	if len(got.ExternalIntegrations) != 1 {
+		t.Fatalf("expected 1 external integration profile, got %d", len(got.ExternalIntegrations))
+	}
+	profile := got.ExternalIntegrations[0]
+	if profile.Slug != "partner-portal" {
+		t.Fatalf("expected slug partner-portal, got %q", profile.Slug)
+	}
+	if len(profile.AllowedHeaders) != 1 || profile.AllowedHeaders[0] != "x-tenant-code" {
+		t.Fatalf("expected normalized allowed headers, got %#v", profile.AllowedHeaders)
 	}
 }

--- a/internal/adapter/postgres/workspace_repo.go
+++ b/internal/adapter/postgres/workspace_repo.go
@@ -197,6 +197,53 @@ func (r *WorkspaceRepo) SoftDelete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+func (r *WorkspaceRepo) ExistsActiveByTenantCode(ctx context.Context, tenantCode string, workspaceCodes []string) (map[string]bool, error) {
+	result := make(map[string]bool, len(workspaceCodes))
+	if len(workspaceCodes) == 0 {
+		return result, nil
+	}
+
+	requested := uniqueWorkspaceCodes(workspaceCodes)
+	for _, code := range requested {
+		result[code] = false
+	}
+
+	rows, err := r.pool.Query(ctx, `
+		WITH requested(code) AS (
+			SELECT DISTINCT unnest($2::text[])
+		)
+		SELECT requested.code,
+		       (w.id IS NOT NULL) AS exists_active
+		FROM requested
+		LEFT JOIN tenants t
+		  ON t.code = $1
+		 AND t.deleted_at IS NULL
+		LEFT JOIN workspaces w
+		  ON w.tenant_id = t.id
+		 AND w.code = requested.code
+		 AND w.deleted_at IS NULL
+		 AND w.is_active = true
+		ORDER BY requested.code`, tenantCode, requested)
+	if err != nil {
+		return nil, fmt.Errorf("querying workspace existence by tenant code: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var code string
+		var exists bool
+		if err := rows.Scan(&code, &exists); err != nil {
+			return nil, fmt.Errorf("scanning workspace existence row: %w", err)
+		}
+		result[code] = exists
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating workspace existence rows: %w", err)
+	}
+
+	return result, nil
+}
+
 func scanWorkspace(row pgx.Row) (*domain.Workspace, error) {
 	var ws domain.Workspace
 	err := row.Scan(
@@ -220,4 +267,17 @@ func effectiveWorkspacePolicyValue(value bool, initialized bool) bool {
 		return value
 	}
 	return true
+}
+
+func uniqueWorkspaceCodes(workspaceCodes []string) []string {
+	seen := make(map[string]struct{}, len(workspaceCodes))
+	result := make([]string, 0, len(workspaceCodes))
+	for _, code := range workspaceCodes {
+		if _, ok := seen[code]; ok {
+			continue
+		}
+		seen[code] = struct{}{}
+		result = append(result, code)
+	}
+	return result
 }

--- a/internal/adapter/postgres/workspace_repo_test.go
+++ b/internal/adapter/postgres/workspace_repo_test.go
@@ -475,3 +475,87 @@ func TestWorkspaceRepo_ListByTenant_IsolatesTenants(t *testing.T) {
 		t.Errorf("expected 0 workspaces for tenant2, got %d", len(results))
 	}
 }
+
+func TestWorkspaceRepo_ExistsActiveByTenantCode(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	tenantRepo := pgadapter.NewTenantRepo(pool)
+	repo := pgadapter.NewWorkspaceRepo(pool)
+
+	tenant := createTestTenant(ctx, t, tenantRepo)
+	otherTenant := createTestTenant(ctx, t, tenantRepo)
+
+	active := &domain.Workspace{ID: uuid.New(), TenantID: tenant.ID, Code: "main", Name: "Main"}
+	inactive := &domain.Workspace{ID: uuid.New(), TenantID: tenant.ID, Code: "paused", Name: "Paused"}
+	deleted := &domain.Workspace{ID: uuid.New(), TenantID: tenant.ID, Code: "deleted", Name: "Deleted"}
+	otherTenantWS := &domain.Workspace{ID: uuid.New(), TenantID: otherTenant.ID, Code: "foreign", Name: "Foreign"}
+
+	for _, ws := range []*domain.Workspace{active, inactive, deleted, otherTenantWS} {
+		if err := repo.Create(ctx, ws); err != nil {
+			t.Fatalf("Create(%s) error: %v", ws.Code, err)
+		}
+	}
+
+	if _, err := pool.Exec(ctx, `UPDATE workspaces SET is_active = false WHERE id = $1`, inactive.ID); err != nil {
+		t.Fatalf("deactivating workspace: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE workspaces SET deleted_at = now() WHERE id = $1`, deleted.ID); err != nil {
+		t.Fatalf("soft-deleting workspace: %v", err)
+	}
+
+	got, err := repo.ExistsActiveByTenantCode(ctx, tenant.Code, []string{"main", "paused", "deleted", "missing", "main", "foreign"})
+	if err != nil {
+		t.Fatalf("ExistsActiveByTenantCode() error: %v", err)
+	}
+
+	want := map[string]bool{
+		"main":    true,
+		"paused":  false,
+		"deleted": false,
+		"missing": false,
+		"foreign": false,
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d entries, got %d: %#v", len(want), len(got), got)
+	}
+	for code, wantExists := range want {
+		if got[code] != wantExists {
+			t.Errorf("code %q => %v, want %v", code, got[code], wantExists)
+		}
+	}
+}
+
+func TestWorkspaceRepo_ExistsActiveByTenantCode_EmptyInput(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	repo := pgadapter.NewWorkspaceRepo(pool)
+
+	got, err := repo.ExistsActiveByTenantCode(ctx, "tenant-does-not-matter", nil)
+	if err != nil {
+		t.Fatalf("ExistsActiveByTenantCode() error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result, got %#v", got)
+	}
+}
+
+func TestWorkspaceRepo_HasActiveExistenceLookupIndex(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+
+	var indexDef string
+	err := pool.QueryRow(ctx, `
+		SELECT indexdef
+		FROM pg_indexes
+		WHERE schemaname = 'public'
+		  AND tablename = 'workspaces'
+		  AND indexname = 'idx_workspaces_active_code_lookup'`).Scan(&indexDef)
+	if err != nil {
+		t.Fatalf("querying index metadata: %v", err)
+	}
+
+	if indexDef == "" {
+		t.Fatal("expected idx_workspaces_active_code_lookup index definition")
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -207,6 +207,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *slog.Logger, ext
 		ClientID:        cfg.OIDC.ClientID,
 		ClientSecretSet: cfg.OIDC.ClientSecret != "",
 	})
+	externalIntegrationH := handler.NewExternalIntegrationHandler(configRepo, extExternalAuthMethods(ext), extExternalResolvers(ext))
 	injectorH := handler.NewInjectorHandler(injectorRepo, tenantRepo, wsRepo)
 	// Tracking auto-provisioner (nil if no tracking base URL) — used for deprovision on adapter delete.
 	provisioningStepRepo := postgres.NewProvisioningStepRepo(pool)
@@ -291,6 +292,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *slog.Logger, ext
 		sendahttp.WithWorkspacePolicyHandler(workspacePolicyH),
 		sendahttp.WithMemberHandler(memberH),
 		sendahttp.WithConfigHandler(configH),
+		sendahttp.WithExternalIntegrationHandler(externalIntegrationH),
 		sendahttp.WithInjectorHandler(injectorH),
 		sendahttp.WithAdapterHandler(adapterH),
 		sendahttp.WithIdentityHandler(identityH),
@@ -319,6 +321,20 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *slog.Logger, ext
 		Pool:        pool,
 		cache:       cache,
 	}, nil
+}
+
+func extExternalAuthMethods(ext *Extensions) []port.ExternalAuthMethod {
+	if ext == nil {
+		return nil
+	}
+	return ext.ExternalAuthMethods
+}
+
+func extExternalResolvers(ext *Extensions) []port.ExternalWorkspaceResolver {
+	if ext == nil {
+		return nil
+	}
+	return ext.ExternalWorkspaceResolvers
 }
 
 // Close gracefully shuts down app resources.

--- a/internal/app/extensions.go
+++ b/internal/app/extensions.go
@@ -5,6 +5,8 @@ import "github.com/rendis/senda/internal/port"
 // Extensions holds user-provided extensions registered via the SDK Engine.
 // When nil or empty, Senda runs with built-in behavior only.
 type Extensions struct {
-	Injectors []port.CodeInjector
-	InitFunc  port.CodeInitFunc
+	Injectors                  []port.CodeInjector
+	InitFunc                   port.CodeInitFunc
+	ExternalAuthMethods        []port.ExternalAuthMethod
+	ExternalWorkspaceResolvers []port.ExternalWorkspaceResolver
 }

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -1,14 +1,207 @@
 package domain
 
-import "time"
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/rendis/senda/pkg/slug"
+)
+
+var headerNamePattern = regexp.MustCompile(`^[!#$%&'*+.^_` + "`" + `{|}~0-9A-Za-z-]+$`)
+
+type ExternalIntegrationCapabilities struct {
+	ListTemplates   bool
+	ViewVersions    bool
+	EditVersions    bool
+	PublishVersions bool
+	TestSend        bool
+	BuilderAccess   bool
+	MetadataAccess  bool
+	LocaleAccess    bool
+}
+
+type ExternalIntegrationProfile struct {
+	Slug            string
+	Name            string
+	Description     string
+	Enabled         bool
+	AuthMethodName  string
+	ResolverName    string
+	AllowedOrigins  []string
+	AllowedHeaders  []string
+	RequiredHeaders []string
+	Capabilities    ExternalIntegrationCapabilities
+}
+
+func (p ExternalIntegrationProfile) Normalize() ExternalIntegrationProfile {
+	p.Slug = strings.TrimSpace(strings.ToLower(p.Slug))
+	p.Name = strings.TrimSpace(p.Name)
+	p.Description = strings.TrimSpace(p.Description)
+	p.AuthMethodName = strings.TrimSpace(p.AuthMethodName)
+	p.ResolverName = strings.TrimSpace(p.ResolverName)
+	p.AllowedOrigins = normalizeAndDedupeStrings(p.AllowedOrigins, false)
+	p.AllowedHeaders = normalizeAndDedupeStrings(p.AllowedHeaders, true)
+	p.RequiredHeaders = normalizeAndDedupeStrings(p.RequiredHeaders, true)
+	return p
+}
+
+func (p ExternalIntegrationProfile) Validate() error {
+	normalized := p.Normalize()
+
+	if err := slug.Validate(normalized.Slug); err != nil {
+		return fmt.Errorf("slug: %w", err)
+	}
+	if normalized.Name == "" {
+		return errors.New("name is required")
+	}
+	if normalized.AuthMethodName == "" {
+		return errors.New("auth_method_name is required")
+	}
+	if err := validateExternalMethodName(normalized.AuthMethodName); err != nil {
+		return fmt.Errorf("auth_method_name: %w", err)
+	}
+	if normalized.ResolverName == "" {
+		return errors.New("resolver_name is required")
+	}
+	if err := validateExternalMethodName(normalized.ResolverName); err != nil {
+		return fmt.Errorf("resolver_name: %w", err)
+	}
+	for _, origin := range normalized.AllowedOrigins {
+		if err := validateAllowedOrigin(origin); err != nil {
+			return fmt.Errorf("allowed_origin %q: %w", origin, err)
+		}
+	}
+
+	allowed := make(map[string]struct{}, len(normalized.AllowedHeaders))
+	for _, header := range normalized.AllowedHeaders {
+		if err := validateAllowedHeaderName(header); err != nil {
+			return fmt.Errorf("allowed_header %q: %w", header, err)
+		}
+		allowed[header] = struct{}{}
+	}
+	for _, header := range normalized.RequiredHeaders {
+		if err := validateAllowedHeaderName(header); err != nil {
+			return fmt.Errorf("required_header %q: %w", header, err)
+		}
+		if _, ok := allowed[header]; !ok {
+			return fmt.Errorf("required header %q must be present in allowed_headers", header)
+		}
+	}
+
+	return nil
+}
 
 type GlobalConfig struct {
-	DefaultRetryCount             int
-	RetryBackoffBaseSeconds       int
-	LogRetentionDays              int
-	BounceAlertThresholdPercent   float64
+	DefaultRetryCount              int
+	RetryBackoffBaseSeconds        int
+	LogRetentionDays               int
+	BounceAlertThresholdPercent    float64
 	ComplaintAlertThresholdPercent float64
-	DomainRecheckIntervalHours    int
-	OnboardingCompleted           bool
-	UpdatedAt                     time.Time
+	DomainRecheckIntervalHours     int
+	OnboardingCompleted            bool
+	ExternalIntegrations           []ExternalIntegrationProfile
+	UpdatedAt                      time.Time
+}
+
+func (cfg *GlobalConfig) Validate() error {
+	if cfg == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(cfg.ExternalIntegrations))
+	for i, profile := range cfg.ExternalIntegrations {
+		normalized := profile.Normalize()
+		if err := normalized.Validate(); err != nil {
+			return fmt.Errorf("external_integrations[%d]: %w", i, err)
+		}
+		if _, ok := seen[normalized.Slug]; ok {
+			return fmt.Errorf("external_integrations[%d]: duplicate slug %q", i, normalized.Slug)
+		}
+		seen[normalized.Slug] = struct{}{}
+	}
+
+	return nil
+}
+
+func NormalizeExternalIntegrationProfiles(profiles []ExternalIntegrationProfile) []ExternalIntegrationProfile {
+	out := make([]ExternalIntegrationProfile, len(profiles))
+	for i, profile := range profiles {
+		out[i] = profile.Normalize()
+	}
+	return out
+}
+
+func normalizeAndDedupeStrings(values []string, lower bool) []string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if lower {
+			value = strings.ToLower(value)
+		}
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func validateExternalMethodName(value string) error {
+	if err := slug.Validate(strings.ToLower(value)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateAllowedOrigin(origin string) error {
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return fmt.Errorf("invalid origin: %w", err)
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return fmt.Errorf("scheme must be http or https")
+	}
+	if parsed.Host == "" {
+		return errors.New("host is required")
+	}
+	if parsed.User != nil {
+		return errors.New("userinfo is not allowed")
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return errors.New("origin must not include a path")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("origin must not include query or fragment")
+	}
+	if origin != parsed.Scheme+"://"+parsed.Host && origin != parsed.Scheme+"://"+parsed.Host+"/" {
+		return errors.New("origin must be a bare origin")
+	}
+	return nil
+}
+
+func validateAllowedHeaderName(value string) error {
+	if !headerNamePattern.MatchString(value) {
+		return errors.New("invalid header name")
+	}
+	lower := strings.ToLower(value)
+	if lower == "host" || lower == "origin" || lower == "cookie" || lower == "authorization" {
+		return errors.New("header is not allowed for external integration auth")
+	}
+	if strings.HasPrefix(lower, "x-forwarded-") || strings.HasPrefix(lower, "sec-") {
+		return errors.New("header is not allowed for external integration auth")
+	}
+	return nil
 }

--- a/internal/domain/config_external_test.go
+++ b/internal/domain/config_external_test.go
@@ -1,0 +1,131 @@
+package domain
+
+import "testing"
+
+func TestExternalIntegrationProfile_Validate(t *testing.T) {
+	profile := ExternalIntegrationProfile{
+		Slug:            "partner-portal",
+		Name:            "Partner Portal",
+		Description:     "Integration for partner-facing UI",
+		Enabled:         true,
+		AuthMethodName:  "signed-headers",
+		ResolverName:    "tenant-workspace-resolver",
+		AllowedOrigins:  []string{"https://app.example.com"},
+		AllowedHeaders:  []string{"X-Tenant-Code", "X-Trace-ID"},
+		RequiredHeaders: []string{"x-tenant-code"},
+	}
+
+	if err := profile.Validate(); err != nil {
+		t.Fatalf("expected profile to validate, got error: %v", err)
+	}
+}
+
+func TestExternalIntegrationProfile_Validate_RequiredHeadersSubset(t *testing.T) {
+	profile := ExternalIntegrationProfile{
+		Slug:            "partner-portal",
+		Name:            "Partner Portal",
+		Description:     "Integration for partner-facing UI",
+		Enabled:         true,
+		AuthMethodName:  "signed-headers",
+		ResolverName:    "tenant-workspace-resolver",
+		AllowedHeaders:  []string{"x-trace-id"},
+		RequiredHeaders: []string{"x-tenant-code"},
+	}
+
+	if err := profile.Validate(); err == nil {
+		t.Fatal("expected validation to fail when required headers are not included in allowed headers")
+	}
+}
+
+func TestExternalIntegrationProfile_Validate_RejectsInvalidAllowedOrigin(t *testing.T) {
+	profile := ExternalIntegrationProfile{
+		Slug:           "partner-portal",
+		Name:           "Partner Portal",
+		Description:    "Integration for partner-facing UI",
+		Enabled:        true,
+		AuthMethodName: "signed-headers",
+		ResolverName:   "tenant-workspace-resolver",
+		AllowedOrigins: []string{"https://app.example.com/path"},
+	}
+
+	if err := profile.Validate(); err == nil {
+		t.Fatal("expected validation to fail when allowed origin is not a bare origin")
+	}
+}
+
+func TestExternalIntegrationProfile_Validate_RejectsInvalidHeaderName(t *testing.T) {
+	profile := ExternalIntegrationProfile{
+		Slug:           "partner-portal",
+		Name:           "Partner Portal",
+		Description:    "Integration for partner-facing UI",
+		Enabled:        true,
+		AuthMethodName: "signed-headers",
+		ResolverName:   "tenant-workspace-resolver",
+		AllowedHeaders: []string{"x bad header"},
+	}
+
+	if err := profile.Validate(); err == nil {
+		t.Fatal("expected validation to fail for invalid header name")
+	}
+}
+
+func TestExternalIntegrationProfile_Validate_RejectsInvalidMethodNames(t *testing.T) {
+	profile := ExternalIntegrationProfile{
+		Slug:           "partner-portal",
+		Name:           "Partner Portal",
+		Description:    "Integration for partner-facing UI",
+		Enabled:        true,
+		AuthMethodName: "signed headers",
+		ResolverName:   "tenant-workspace-resolver",
+	}
+
+	if err := profile.Validate(); err == nil {
+		t.Fatal("expected validation to fail for invalid auth method name")
+	}
+}
+
+func TestGlobalConfig_Validate_ExternalProfiles(t *testing.T) {
+	cfg := &GlobalConfig{
+		ExternalIntegrations: []ExternalIntegrationProfile{
+			{
+				Slug:           "partner-portal",
+				Name:           "Partner Portal",
+				Description:    "Integration for partner-facing UI",
+				Enabled:        true,
+				AuthMethodName: "signed-headers",
+				ResolverName:   "tenant-workspace-resolver",
+			},
+		},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected config to validate, got error: %v", err)
+	}
+}
+
+func TestGlobalConfig_Validate_RejectsDuplicateExternalProfileSlugs(t *testing.T) {
+	cfg := &GlobalConfig{
+		ExternalIntegrations: []ExternalIntegrationProfile{
+			{
+				Slug:           "partner-portal",
+				Name:           "Partner Portal",
+				Description:    "Integration for partner-facing UI",
+				Enabled:        true,
+				AuthMethodName: "signed-headers",
+				ResolverName:   "tenant-workspace-resolver",
+			},
+			{
+				Slug:           "partner-portal",
+				Name:           "Partner Portal v2",
+				Description:    "Duplicate slug",
+				Enabled:        true,
+				AuthMethodName: "signed-headers",
+				ResolverName:   "tenant-workspace-resolver",
+			},
+		},
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected duplicate profile slugs to be rejected")
+	}
+}

--- a/internal/http/handler/config.go
+++ b/internal/http/handler/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v5"
+	"github.com/rendis/senda/internal/domain"
 	"github.com/rendis/senda/internal/http/request"
 	"github.com/rendis/senda/internal/http/response"
 	"github.com/rendis/senda/internal/port"
@@ -76,6 +77,14 @@ func (h *ConfigHandler) Update(c *echo.Context) error {
 		if req.Domain.RecheckIntervalHours != nil {
 			cfg.DomainRecheckIntervalHours = *req.Domain.RecheckIntervalHours
 		}
+	}
+
+	if req.ExternalIntegrations != nil {
+		cfg.ExternalIntegrations = domain.NormalizeExternalIntegrationProfiles(req.ExternalIntegrations.ToDomain())
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", err.Error())
 	}
 
 	cfg.UpdatedAt = time.Now().UTC()

--- a/internal/http/handler/config_test.go
+++ b/internal/http/handler/config_test.go
@@ -58,14 +58,24 @@ func setupConfigTest(cs port.GlobalConfigStore) *echo.Echo {
 func TestConfigHandler_Get_Success(t *testing.T) {
 	now := time.Now().UTC()
 	cfg := &domain.GlobalConfig{
-		DefaultRetryCount:             3,
-		RetryBackoffBaseSeconds:       60,
-		LogRetentionDays:              90,
-		BounceAlertThresholdPercent:   5.0,
+		DefaultRetryCount:              3,
+		RetryBackoffBaseSeconds:        60,
+		LogRetentionDays:               90,
+		BounceAlertThresholdPercent:    5.0,
 		ComplaintAlertThresholdPercent: 0.1,
-		DomainRecheckIntervalHours:    24,
-		OnboardingCompleted:           true,
-		UpdatedAt:                     now,
+		DomainRecheckIntervalHours:     24,
+		OnboardingCompleted:            true,
+		ExternalIntegrations: []domain.ExternalIntegrationProfile{
+			{
+				Slug:           "partner-portal",
+				Name:           "Partner Portal",
+				Description:    "Integration for partner-facing UI",
+				Enabled:        true,
+				AuthMethodName: "signed-headers",
+				ResolverName:   "tenant-workspace-resolver",
+			},
+		},
+		UpdatedAt: now,
 	}
 
 	cs := &mockGlobalConfigStore{
@@ -124,19 +134,25 @@ func TestConfigHandler_Get_Success(t *testing.T) {
 	if resp.Domain.RecheckIntervalHours != 24 {
 		t.Fatalf("expected domain.recheck_interval_hours 24, got %d", resp.Domain.RecheckIntervalHours)
 	}
+	if len(resp.ExternalIntegrations.Profiles) != 1 {
+		t.Fatalf("expected 1 external integration profile, got %d", len(resp.ExternalIntegrations.Profiles))
+	}
+	if resp.ExternalIntegrations.Profiles[0].Slug != "partner-portal" {
+		t.Fatalf("expected external integration slug partner-portal, got %q", resp.ExternalIntegrations.Profiles[0].Slug)
+	}
 }
 
 func TestConfigHandler_Update_Success(t *testing.T) {
 	now := time.Now().UTC()
 	cfg := &domain.GlobalConfig{
-		DefaultRetryCount:             3,
-		RetryBackoffBaseSeconds:       60,
-		LogRetentionDays:              90,
-		BounceAlertThresholdPercent:   5.0,
+		DefaultRetryCount:              3,
+		RetryBackoffBaseSeconds:        60,
+		LogRetentionDays:               90,
+		BounceAlertThresholdPercent:    5.0,
 		ComplaintAlertThresholdPercent: 0.1,
-		DomainRecheckIntervalHours:    24,
-		OnboardingCompleted:           false,
-		UpdatedAt:                     now,
+		DomainRecheckIntervalHours:     24,
+		OnboardingCompleted:            false,
+		UpdatedAt:                      now,
 	}
 
 	var upserted *domain.GlobalConfig
@@ -183,14 +199,14 @@ func TestConfigHandler_Update_Success(t *testing.T) {
 func TestConfigHandler_Update_PartialFields(t *testing.T) {
 	now := time.Now().UTC()
 	cfg := &domain.GlobalConfig{
-		DefaultRetryCount:             3,
-		RetryBackoffBaseSeconds:       60,
-		LogRetentionDays:              90,
-		BounceAlertThresholdPercent:   5.0,
+		DefaultRetryCount:              3,
+		RetryBackoffBaseSeconds:        60,
+		LogRetentionDays:               90,
+		BounceAlertThresholdPercent:    5.0,
 		ComplaintAlertThresholdPercent: 0.1,
-		DomainRecheckIntervalHours:    24,
-		OnboardingCompleted:           false,
-		UpdatedAt:                     now,
+		DomainRecheckIntervalHours:     24,
+		OnboardingCompleted:            false,
+		UpdatedAt:                      now,
 	}
 
 	var upserted *domain.GlobalConfig
@@ -228,5 +244,110 @@ func TestConfigHandler_Update_PartialFields(t *testing.T) {
 	}
 	if upserted.LogRetentionDays != 90 {
 		t.Fatalf("expected log_retention_days 90, got %d", upserted.LogRetentionDays)
+	}
+}
+
+func TestConfigHandler_Update_ExternalIntegrations(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := &domain.GlobalConfig{
+		DefaultRetryCount:              3,
+		RetryBackoffBaseSeconds:        60,
+		LogRetentionDays:               90,
+		BounceAlertThresholdPercent:    5.0,
+		ComplaintAlertThresholdPercent: 0.1,
+		DomainRecheckIntervalHours:     24,
+		OnboardingCompleted:            false,
+		UpdatedAt:                      now,
+	}
+
+	var upserted *domain.GlobalConfig
+	cs := &mockGlobalConfigStore{
+		getFn: func(_ context.Context) (*domain.GlobalConfig, error) {
+			return cfg, nil
+		},
+		upsertFn: func(_ context.Context, c *domain.GlobalConfig) error {
+			upserted = c
+			return nil
+		},
+	}
+
+	e := setupConfigTest(cs)
+
+	body := `{
+		"external_integrations":{
+			"profiles":[
+				{
+					"slug":"partner-portal",
+					"name":"Partner Portal",
+					"description":"Integration for partner-facing UI",
+					"enabled":true,
+					"auth_method_name":"signed-headers",
+					"resolver_name":"tenant-workspace-resolver",
+					"allowed_headers":["X-Tenant-Code","X-Trace-ID"],
+					"required_headers":["x-tenant-code"]
+				}
+			]
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if upserted == nil {
+		t.Fatal("expected config to be upserted")
+	}
+	if len(upserted.ExternalIntegrations) != 1 {
+		t.Fatalf("expected 1 external integration profile, got %d", len(upserted.ExternalIntegrations))
+	}
+	profile := upserted.ExternalIntegrations[0]
+	if profile.Slug != "partner-portal" {
+		t.Fatalf("expected normalized slug partner-portal, got %q", profile.Slug)
+	}
+	if len(profile.RequiredHeaders) != 1 || profile.RequiredHeaders[0] != "x-tenant-code" {
+		t.Fatalf("expected normalized required header x-tenant-code, got %#v", profile.RequiredHeaders)
+	}
+}
+
+func TestConfigHandler_Update_ExternalIntegrationsValidation(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := &domain.GlobalConfig{
+		DefaultRetryCount:              3,
+		RetryBackoffBaseSeconds:        60,
+		LogRetentionDays:               90,
+		BounceAlertThresholdPercent:    5.0,
+		ComplaintAlertThresholdPercent: 0.1,
+		DomainRecheckIntervalHours:     24,
+		OnboardingCompleted:            false,
+		UpdatedAt:                      now,
+	}
+
+	upsertCalled := false
+	cs := &mockGlobalConfigStore{
+		getFn: func(_ context.Context) (*domain.GlobalConfig, error) {
+			return cfg, nil
+		},
+		upsertFn: func(_ context.Context, c *domain.GlobalConfig) error {
+			upsertCalled = true
+			return nil
+		},
+	}
+
+	e := setupConfigTest(cs)
+
+	body := `{"external_integrations":{"profiles":[{"slug":"partner-portal","name":"Partner Portal","description":"Integration for partner-facing UI","enabled":true,"auth_method_name":"signed-headers","resolver_name":"tenant-workspace-resolver","allowed_headers":["x-trace-id"],"required_headers":["x-tenant-code"]}]}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 validation error, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if upsertCalled {
+		t.Fatal("expected invalid config to be rejected before upsert")
 	}
 }

--- a/internal/http/handler/external_integration.go
+++ b/internal/http/handler/external_integration.go
@@ -1,0 +1,169 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v5"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/http/middleware"
+	"github.com/rendis/senda/internal/http/response"
+	"github.com/rendis/senda/internal/port"
+)
+
+// ExternalIntegrationHandler exposes the bootstrap surface for
+// embeddable external integrations.
+type ExternalIntegrationHandler struct {
+	store               port.GlobalConfigStore
+	externalAuthMethods []port.ExternalAuthMethod
+	externalResolvers   []port.ExternalWorkspaceResolver
+}
+
+// NewExternalIntegrationHandler creates a new handler for the external surface.
+func NewExternalIntegrationHandler(
+	store port.GlobalConfigStore,
+	authMethods []port.ExternalAuthMethod,
+	resolvers []port.ExternalWorkspaceResolver,
+) *ExternalIntegrationHandler {
+	return &ExternalIntegrationHandler{
+		store:               store,
+		externalAuthMethods: authMethods,
+		externalResolvers:   resolvers,
+	}
+}
+
+// Bootstrap handles GET /api/v1/external/:profile_slug/bootstrap.
+func (h *ExternalIntegrationHandler) Bootstrap(c *echo.Context) error {
+	profile, _, err := h.loadProfile(c)
+	if err != nil {
+		return err
+	}
+
+	frameAncestors := frameAncestorsFromProfile(profile.AllowedOrigins)
+	applyExternalFrameHeaders(c, frameAncestors)
+
+	return c.JSON(http.StatusOK, response.NewExternalIntegrationBootstrapResponse(frameAncestors))
+}
+
+// Session exposes the authenticated external embed runtime state so the UI can
+// render the effective permissions and fallback mode without relying on
+// management-only endpoints.
+func (h *ExternalIntegrationHandler) Session(c *echo.Context) error {
+	perms, _ := c.Get(middleware.ContextKeyExternalIntegrationPermissions).(port.ExternalPermissions)
+	readOnly, _ := c.Get(middleware.ContextKeyExternalIntegrationReadOnly).(bool)
+	effectiveWorkspaceCode, _ := c.Get(middleware.ContextKeyExternalIntegrationEffectiveWorkspaceCode).(string)
+
+	return c.JSON(http.StatusOK, response.ExternalIntegrationSessionResponse{
+		ReadOnly:               readOnly,
+		EffectiveWorkspaceCode: effectiveWorkspaceCode,
+		Permissions: response.ExternalIntegrationCapabilitiesResponse{
+			ListTemplates:   perms.ListTemplates,
+			ViewVersions:    perms.ViewVersions,
+			EditVersions:    perms.EditVersions,
+			PublishVersions: perms.PublishVersions,
+			TestSend:        perms.TestSend,
+			BuilderAccess:   perms.BuilderAccess,
+			MetadataAccess:  perms.MetadataAccess,
+			LocaleAccess:    perms.LocaleAccess,
+		},
+	})
+}
+
+// LoadProfileBySlug returns an enabled external integration profile by slug.
+func (h *ExternalIntegrationHandler) LoadProfileBySlug(ctx context.Context, slug string) (domain.ExternalIntegrationProfile, error) {
+	cfg, err := h.store.Get(ctx)
+	if err != nil {
+		return domain.ExternalIntegrationProfile{}, err
+	}
+
+	slug = strings.TrimSpace(strings.ToLower(slug))
+	for _, profile := range cfg.ExternalIntegrations {
+		if profile.Slug == slug {
+			if !profile.Enabled {
+				return domain.ExternalIntegrationProfile{}, domain.ErrForbidden
+			}
+			return profile, nil
+		}
+	}
+
+	return domain.ExternalIntegrationProfile{}, domain.ErrNotFound
+}
+
+// AuthMethodByName returns a registered auth method by name.
+func (h *ExternalIntegrationHandler) AuthMethodByName(name string) (port.ExternalAuthMethod, bool) {
+	for _, method := range h.externalAuthMethods {
+		if method != nil && method.Name() == name {
+			return method, true
+		}
+	}
+	return nil, false
+}
+
+// ResolverByName returns a registered workspace resolver by name.
+func (h *ExternalIntegrationHandler) ResolverByName(name string) (port.ExternalWorkspaceResolver, bool) {
+	for _, resolver := range h.externalResolvers {
+		if resolver != nil && resolver.Name() == name {
+			return resolver, true
+		}
+	}
+	return nil, false
+}
+
+func (h *ExternalIntegrationHandler) loadProfile(c *echo.Context) (domain.ExternalIntegrationProfile, response.ExternalIntegrationProfileResponse, error) {
+	profile, err := h.LoadProfileBySlug(c.Request().Context(), c.Param("profile_slug"))
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrForbidden):
+			return domain.ExternalIntegrationProfile{}, response.ExternalIntegrationProfileResponse{}, response.WriteError(c, http.StatusForbidden, "FORBIDDEN", "external integration profile is disabled")
+		case errors.Is(err, domain.ErrNotFound):
+			return domain.ExternalIntegrationProfile{}, response.ExternalIntegrationProfileResponse{}, response.WriteError(c, http.StatusNotFound, "NOT_FOUND", "external integration profile not found")
+		default:
+			return domain.ExternalIntegrationProfile{}, response.ExternalIntegrationProfileResponse{}, mapStoreError(c, err)
+		}
+	}
+
+	return profile, toExternalIntegrationProfileResponse(profile), nil
+}
+
+func toExternalIntegrationProfileResponse(profile domain.ExternalIntegrationProfile) response.ExternalIntegrationProfileResponse {
+	return response.ExternalIntegrationProfileResponse{
+		Slug:            profile.Slug,
+		Name:            profile.Name,
+		Description:     profile.Description,
+		Enabled:         profile.Enabled,
+		AuthMethodName:  profile.AuthMethodName,
+		ResolverName:    profile.ResolverName,
+		AllowedOrigins:  append([]string(nil), profile.AllowedOrigins...),
+		AllowedHeaders:  append([]string(nil), profile.AllowedHeaders...),
+		RequiredHeaders: append([]string(nil), profile.RequiredHeaders...),
+		Capabilities: response.ExternalIntegrationCapabilitiesResponse{
+			ListTemplates:   profile.Capabilities.ListTemplates,
+			ViewVersions:    profile.Capabilities.ViewVersions,
+			EditVersions:    profile.Capabilities.EditVersions,
+			PublishVersions: profile.Capabilities.PublishVersions,
+			TestSend:        profile.Capabilities.TestSend,
+			BuilderAccess:   profile.Capabilities.BuilderAccess,
+			MetadataAccess:  profile.Capabilities.MetadataAccess,
+			LocaleAccess:    profile.Capabilities.LocaleAccess,
+		},
+	}
+}
+
+func frameAncestorsFromProfile(origins []string) []string {
+	if len(origins) == 0 {
+		return []string{"'none'"}
+	}
+
+	out := make([]string, 0, len(origins)+1)
+	out = append(out, "'self'")
+	out = append(out, origins...)
+	return out
+}
+
+func applyExternalFrameHeaders(c *echo.Context, frameAncestors []string) {
+	header := c.Response().Header()
+	header.Del("X-Frame-Options")
+	header.Set("Content-Security-Policy", "frame-ancestors "+strings.Join(frameAncestors, " "))
+}

--- a/internal/http/handler/external_integration_test.go
+++ b/internal/http/handler/external_integration_test.go
@@ -1,0 +1,223 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/http/handler"
+	"github.com/rendis/senda/internal/http/middleware"
+	"github.com/rendis/senda/internal/http/response"
+	"github.com/rendis/senda/internal/port"
+)
+
+type testExternalAuthMethod struct {
+	name        string
+	description string
+}
+
+func (t *testExternalAuthMethod) Name() string        { return t.name }
+func (t *testExternalAuthMethod) Description() string { return t.description }
+func (t *testExternalAuthMethod) Authenticate(context.Context, *port.ExternalIntegrationRequest) (*port.ExternalAuthResult, error) {
+	return &port.ExternalAuthResult{}, nil
+}
+
+type testExternalResolver struct {
+	name        string
+	description string
+}
+
+func (t *testExternalResolver) Name() string        { return t.name }
+func (t *testExternalResolver) Description() string { return t.description }
+func (t *testExternalResolver) ResolveWorkspace(context.Context, *port.ExternalIntegrationRequest, *port.ExternalAuthResult) (*port.ExternalWorkspaceResolution, error) {
+	return &port.ExternalWorkspaceResolution{WorkspaceCode: "_system", ReadOnly: true}, nil
+}
+
+func setupExternalIntegrationTest(cs *mockGlobalConfigStore, auths []port.ExternalAuthMethod, resolvers []port.ExternalWorkspaceResolver) *echo.Echo {
+	e := echo.New()
+	e.HTTPErrorHandler = response.HTTPErrorHandler
+	e.Use(middleware.RequestID())
+	h := handler.NewExternalIntegrationHandler(cs, auths, resolvers)
+	e.GET("/api/v1/external/:profile_slug/bootstrap", h.Bootstrap)
+	return e
+}
+
+func TestExternalIntegrationHandler_Bootstrap_MinimizesResponseMetadata(t *testing.T) {
+	cfg := &domain.GlobalConfig{
+		ExternalIntegrations: []domain.ExternalIntegrationProfile{
+			{
+				Slug:            "partner-portal",
+				Name:            "Partner Portal",
+				Description:     "External integration",
+				Enabled:         true,
+				AuthMethodName:  "signed-headers",
+				ResolverName:    "tenant-workspace-resolver",
+				AllowedOrigins:  []string{"https://app.example.com"},
+				AllowedHeaders:  []string{"x-tenant-code"},
+				RequiredHeaders: []string{"x-tenant-code"},
+			},
+		},
+	}
+
+	e := setupExternalIntegrationTest(&mockGlobalConfigStore{
+		getFn: func(_ context.Context) (*domain.GlobalConfig, error) { return cfg, nil },
+	}, []port.ExternalAuthMethod{&testExternalAuthMethod{name: "signed-headers"}}, []port.ExternalWorkspaceResolver{&testExternalResolver{name: "tenant-workspace-resolver"}})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/bootstrap", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if _, ok := resp["frame_ancestors"]; !ok {
+		t.Fatalf("expected frame_ancestors in bootstrap response, got %+v", resp)
+	}
+	if _, ok := resp["auth_methods"]; ok {
+		t.Fatalf("bootstrap must not expose auth methods metadata, got %+v", resp)
+	}
+	if _, ok := resp["workspace_resolvers"]; ok {
+		t.Fatalf("bootstrap must not expose resolver metadata, got %+v", resp)
+	}
+	if _, ok := resp["profile"]; ok {
+		t.Fatalf("bootstrap must not expose profile metadata, got %+v", resp)
+	}
+}
+
+func TestExternalIntegrationHandler_Bootstrap_SetsFrameAncestors(t *testing.T) {
+	cfg := &domain.GlobalConfig{
+		ExternalIntegrations: []domain.ExternalIntegrationProfile{
+			{
+				Slug:           "partner-portal",
+				Name:           "Partner Portal",
+				Description:    "External integration",
+				Enabled:        true,
+				AuthMethodName: "signed-headers",
+				ResolverName:   "tenant-workspace-resolver",
+				AllowedOrigins: []string{"https://app.example.com", "https://admin.example.com"},
+			},
+		},
+	}
+
+	auth := &testExternalAuthMethod{name: "signed-headers", description: "Signed headers auth"}
+	resolver := &testExternalResolver{name: "tenant-workspace-resolver", description: "Tenant workspace resolver"}
+
+	e := setupExternalIntegrationTest(&mockGlobalConfigStore{
+		getFn: func(_ context.Context) (*domain.GlobalConfig, error) { return cfg, nil },
+	}, []port.ExternalAuthMethod{auth}, []port.ExternalWorkspaceResolver{resolver})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/bootstrap", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("X-Frame-Options"); got != "" {
+		t.Fatalf("expected X-Frame-Options to be removed for bootstrap, got %q", got)
+	}
+	if got := rec.Header().Get("Content-Security-Policy"); got == "" {
+		t.Fatal("expected bootstrap to set a frame-ancestors CSP")
+	}
+
+	var resp response.ExternalIntegrationBootstrapResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(resp.FrameAncestors) != 3 {
+		t.Fatalf("expected only frame ancestors in bootstrap response, got %+v", resp)
+	}
+}
+
+func TestExternalIntegrationHandler_DisabledProfileRejected(t *testing.T) {
+	cfg := &domain.GlobalConfig{
+		ExternalIntegrations: []domain.ExternalIntegrationProfile{
+			{
+				Slug:           "partner-portal",
+				Name:           "Partner Portal",
+				Description:    "External integration",
+				Enabled:        false,
+				AuthMethodName: "signed-headers",
+				ResolverName:   "tenant-workspace-resolver",
+			},
+		},
+	}
+
+	e := setupExternalIntegrationTest(&mockGlobalConfigStore{
+		getFn: func(_ context.Context) (*domain.GlobalConfig, error) { return cfg, nil },
+	}, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/bootstrap", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for disabled profile, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestExternalIntegrationHandler_SessionReturnsEffectivePermissions(t *testing.T) {
+	cfg := &domain.GlobalConfig{
+		ExternalIntegrations: []domain.ExternalIntegrationProfile{
+			{
+				Slug:           "partner-portal",
+				Name:           "Partner Portal",
+				Description:    "External integration",
+				Enabled:        true,
+				AuthMethodName: "signed-headers",
+				ResolverName:   "tenant-workspace-resolver",
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/marketing/session", nil)
+	rec := httptest.NewRecorder()
+	e := echo.New()
+	e.HTTPErrorHandler = response.HTTPErrorHandler
+	c := e.NewContext(req, rec)
+	c.Set(middleware.ContextKeyExternalIntegrationReadOnly, false)
+	c.Set(middleware.ContextKeyExternalIntegrationEffectiveWorkspaceCode, "marketing")
+	c.Set(middleware.ContextKeyExternalIntegrationPermissions, port.ExternalPermissions{
+		ListTemplates:   true,
+		ViewVersions:    true,
+		EditVersions:    false,
+		PublishVersions: false,
+		TestSend:        false,
+		BuilderAccess:   true,
+		MetadataAccess:  true,
+		LocaleAccess:    true,
+	})
+
+	if err := handler.NewExternalIntegrationHandler(&mockGlobalConfigStore{
+		getFn: func(_ context.Context) (*domain.GlobalConfig, error) { return cfg, nil },
+	}, nil, nil).Session(c); err != nil {
+		t.Fatalf("session handler returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp response.ExternalIntegrationSessionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.EffectiveWorkspaceCode != "marketing" {
+		t.Fatalf("expected effective workspace marketing, got %+v", resp)
+	}
+	if resp.Permissions.EditVersions {
+		t.Fatalf("expected edit_versions=false, got %+v", resp.Permissions)
+	}
+	if !resp.Permissions.BuilderAccess {
+		t.Fatalf("expected builder_access=true, got %+v", resp.Permissions)
+	}
+}

--- a/internal/http/handler/template.go
+++ b/internal/http/handler/template.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rendis/senda/internal/domain"
 	"github.com/rendis/senda/internal/http/pagination"
 	"github.com/rendis/senda/internal/http/request"
+	"github.com/rendis/senda/internal/http/middleware"
 	"github.com/rendis/senda/internal/http/response"
 	"github.com/rendis/senda/internal/port"
 	"github.com/rendis/senda/internal/service"
@@ -397,7 +398,7 @@ func (h *TemplateHandler) TestSend(c *echo.Context) error {
 		Variables:      req.Variables,
 		Injectors:      req.Injectors,
 		Locale:         req.Locale,
-		Headers:        firstHeaderValues(c.Request().Header),
+		Headers:        headersForTemplateTestSend(c),
 	})
 	if err != nil {
 		return mapTestSendError(c, err)
@@ -532,6 +533,17 @@ func firstHeaderValues(header http.Header) map[string]string {
 		}
 	}
 	return headers
+}
+
+func headersForTemplateTestSend(c *echo.Context) map[string]string {
+	if _, ok := c.Get(middleware.ContextKeyExternalIntegrationProfile).(domain.ExternalIntegrationProfile); ok {
+		return middleware.ExternalAllowedHeaders(c)
+	}
+
+	if headers := middleware.ExternalAllowedHeaders(c); len(headers) > 0 {
+		return headers
+	}
+	return firstHeaderValues(c.Request().Header)
 }
 
 func (h *TemplateHandler) effectiveBatchMaxItems() int {

--- a/internal/http/handler/template_internal_test.go
+++ b/internal/http/handler/template_internal_test.go
@@ -1,0 +1,68 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/http/middleware"
+)
+
+func TestHeadersForTemplateTestSend_UsesExternalFilteredHeadersWhenPresent(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest("POST", "/templates/test-send", nil)
+	req.Header.Set("X-Tenant-Code", "acme")
+	req.Header.Set("X-Signature", "sig")
+	req.Header.Set("Authorization", "Bearer should-not-pass")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(middleware.ContextKeyExternalIntegrationAllowedHeaders, map[string]string{
+		"x-tenant-code": "acme",
+		"x-signature":   "sig",
+	})
+
+	headers := headersForTemplateTestSend(c)
+	if len(headers) != 2 {
+		t.Fatalf("expected exactly 2 filtered headers, got %#v", headers)
+	}
+	if headers["x-tenant-code"] != "acme" || headers["x-signature"] != "sig" {
+		t.Fatalf("unexpected filtered headers: %#v", headers)
+	}
+	if _, ok := headers["Authorization"]; ok {
+		t.Fatalf("authorization header must not be forwarded: %#v", headers)
+	}
+}
+
+func TestHeadersForTemplateTestSend_FallsBackToFirstHeaderValues(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest("POST", "/templates/test-send", nil)
+	req.Header.Set("X-Tenant-Code", "acme")
+	req.Header.Add("X-Tenant-Code", "ignored")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	headers := headersForTemplateTestSend(c)
+	if headers["X-Tenant-Code"] != "acme" {
+		t.Fatalf("expected fallback to first request header value, got %#v", headers)
+	}
+}
+
+func TestHeadersForTemplateTestSend_DoesNotFallbackWhenExternalContextPresent(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest("POST", "/templates/test-send", nil)
+	req.Header.Set("X-Tenant-Code", "acme")
+	req.Header.Set("Authorization", "Bearer should-not-pass")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(middleware.ContextKeyExternalIntegrationProfile, domain.ExternalIntegrationProfile{Slug: "partner-portal"})
+	c.Set(middleware.ContextKeyExternalIntegrationAllowedHeaders, map[string]string{})
+
+	headers := headersForTemplateTestSend(c)
+	if len(headers) != 0 {
+		t.Fatalf("expected no fallback to raw request headers, got %#v", headers)
+	}
+	if _, ok := headers["Authorization"]; ok {
+		t.Fatalf("authorization header must not be forwarded: %#v", headers)
+	}
+}

--- a/internal/http/middleware/external_integration.go
+++ b/internal/http/middleware/external_integration.go
@@ -1,0 +1,480 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v5"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/http/response"
+	"github.com/rendis/senda/internal/port"
+)
+
+const (
+	// ContextKeyExternalIntegrationProfile stores the loaded external profile.
+	ContextKeyExternalIntegrationProfile = "external_integration_profile"
+
+	// ContextKeyExternalIntegrationAuthResult stores the auth result returned by the selected method.
+	ContextKeyExternalIntegrationAuthResult = "external_integration_auth_result"
+
+	// ContextKeyExternalIntegrationResolution stores the workspace resolution returned by the selected resolver.
+	ContextKeyExternalIntegrationResolution = "external_integration_resolution"
+
+	// ContextKeyExternalIntegrationPermissions stores the effective permissions after combining profile + auth.
+	ContextKeyExternalIntegrationPermissions = "external_integration_permissions"
+
+	// ContextKeyExternalIntegrationReadOnly stores whether the request is running in read-only fallback mode.
+	ContextKeyExternalIntegrationReadOnly = "external_integration_read_only"
+
+	// ContextKeyExternalIntegrationEffectiveWorkspaceCode stores the workspace code handlers should use.
+	ContextKeyExternalIntegrationEffectiveWorkspaceCode = "external_integration_effective_workspace_code"
+
+	// ContextKeyExternalIntegrationAllowedHeaders stores the explicit profile-allowed
+	// headers captured from the incoming request for downstream use.
+	ContextKeyExternalIntegrationAllowedHeaders = "external_integration_allowed_headers"
+)
+
+// ExternalAction identifies the capability required by a given external route.
+type ExternalAction string
+
+const (
+	ExternalActionListTemplates   ExternalAction = "list_templates"
+	ExternalActionViewVersions    ExternalAction = "view_versions"
+	ExternalActionEditVersions    ExternalAction = "edit_versions"
+	ExternalActionPublishVersions ExternalAction = "publish_versions"
+	ExternalActionTestSend        ExternalAction = "test_send"
+	ExternalActionBuilderAccess   ExternalAction = "builder_access"
+	ExternalActionMetadataAccess  ExternalAction = "metadata_access"
+	ExternalActionLocaleAccess    ExternalAction = "locale_access"
+)
+
+var errExternalAuthDenied = errors.New("external integration auth denied")
+
+const ExternalIntegrationTokenHeader = "x-senda-external-token"
+
+// ExternalIntegrationResolverStore is the minimal contract required by the
+// external integration middleware. It is implemented by the handler layer.
+type ExternalIntegrationResolverStore interface {
+	LoadProfileBySlug(ctx context.Context, slug string) (domain.ExternalIntegrationProfile, error)
+	AuthMethodByName(name string) (port.ExternalAuthMethod, bool)
+	ResolverByName(name string) (port.ExternalWorkspaceResolver, bool)
+}
+
+// ExternalIntegration resolves the external profile, auth method and workspace
+// resolver for a request, and stores the resulting state in the echo context.
+func ExternalIntegration(h ExternalIntegrationResolverStore) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			profile, err := loadExternalProfileForRequest(c, h)
+			if err != nil || responseCommitted(c) {
+				return err
+			}
+			if err := validateExternalRequiredHeaders(c, profile); err != nil || responseCommitted(c) {
+				return err
+			}
+
+			authMethod, resolver, err := resolveExternalDependencies(c, h, profile)
+			if err != nil || responseCommitted(c) {
+				return err
+			}
+
+			reqCtx := newExternalIntegrationRequest(c, profile)
+			authResult, err := authenticateExternalRequest(c, authMethod, reqCtx)
+			if err != nil || responseCommitted(c) {
+				return err
+			}
+
+			resolution, effectiveWorkspaceCode, readOnly, err := resolveExternalWorkspace(c, resolver, reqCtx, authResult)
+			if err != nil || responseCommitted(c) {
+				return err
+			}
+
+			applyExternalIntegrationContext(c, profile, reqCtx, authResult, resolution, effectiveWorkspaceCode, readOnly)
+			return next(c)
+		}
+	}
+}
+
+func loadExternalProfileForRequest(c *echo.Context, h ExternalIntegrationResolverStore) (domain.ExternalIntegrationProfile, error) {
+	profileSlug := strings.TrimSpace(c.Param("profile_slug"))
+	if profileSlug == "" {
+		return domain.ExternalIntegrationProfile{}, response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "missing profile slug")
+	}
+
+	profile, err := h.LoadProfileBySlug(c.Request().Context(), profileSlug)
+	if err != nil {
+		return domain.ExternalIntegrationProfile{}, mapExternalProfileLoadError(c, err)
+	}
+
+	return profile, nil
+}
+
+func validateExternalRequiredHeaders(c *echo.Context, profile domain.ExternalIntegrationProfile) error {
+	for _, header := range profile.RequiredHeaders {
+		if c.Request().Header.Get(header) == "" {
+			return response.WriteError(c, http.StatusUnauthorized, "UNAUTHORIZED", "missing required header "+header)
+		}
+	}
+
+	return nil
+}
+
+func resolveExternalDependencies(c *echo.Context, h ExternalIntegrationResolverStore, profile domain.ExternalIntegrationProfile) (port.ExternalAuthMethod, port.ExternalWorkspaceResolver, error) {
+	authMethod, ok := h.AuthMethodByName(profile.AuthMethodName)
+	if !ok {
+		return nil, nil, response.WriteError(c, http.StatusInternalServerError, "INTERNAL_ERROR", "external auth method not registered")
+	}
+
+	resolver, ok := h.ResolverByName(profile.ResolverName)
+	if !ok {
+		return nil, nil, response.WriteError(c, http.StatusInternalServerError, "INTERNAL_ERROR", "external workspace resolver not registered")
+	}
+
+	return authMethod, resolver, nil
+}
+
+func newExternalIntegrationRequest(c *echo.Context, profile domain.ExternalIntegrationProfile) *port.ExternalIntegrationRequest {
+	reqCtx := &port.ExternalIntegrationRequest{
+		ProfileSlug: profile.Slug,
+		TenantCode:  c.Param("tenant_code"),
+		Token:       externalIntegrationToken(c),
+		Headers:     collectAllowedHeaders(c.Request().Header, profile.AllowedHeaders),
+		QueryParams: copyQueryParams(c),
+		Path:        c.Request().URL.Path,
+		Method:      c.Request().Method,
+	}
+	if ws := c.Param("workspace_code"); ws != "" {
+		reqCtx.WorkspaceCodes = []string{ws}
+	}
+
+	return reqCtx
+}
+
+func authenticateExternalRequest(c *echo.Context, authMethod port.ExternalAuthMethod, reqCtx *port.ExternalIntegrationRequest) (*port.ExternalAuthResult, error) {
+	authResult, err := authMethod.Authenticate(c.Request().Context(), reqCtx)
+	if err != nil {
+		if errors.Is(err, errExternalAuthDenied) {
+			return nil, response.WriteError(c, http.StatusForbidden, "FORBIDDEN", "external integration access denied")
+		}
+		return nil, response.WriteError(c, http.StatusInternalServerError, "INTERNAL_ERROR", "external integration auth failed")
+	}
+	if authResult == nil {
+		authResult = &port.ExternalAuthResult{}
+	}
+
+	return authResult, nil
+}
+
+func resolveExternalWorkspace(c *echo.Context, resolver port.ExternalWorkspaceResolver, reqCtx *port.ExternalIntegrationRequest, authResult *port.ExternalAuthResult) (*port.ExternalWorkspaceResolution, string, bool, error) {
+	resolution, err := resolver.ResolveWorkspace(c.Request().Context(), reqCtx, authResult)
+	if err != nil || resolution == nil {
+		return nil, "", false, response.WriteError(c, http.StatusInternalServerError, "INTERNAL_ERROR", "external workspace resolution failed")
+	}
+
+	readOnly := resolution.ReadOnly
+	effectiveWorkspaceCode := resolution.WorkspaceCode
+	if readOnly {
+		effectiveWorkspaceCode = "_system"
+	}
+	if strings.TrimSpace(effectiveWorkspaceCode) == "" {
+		return nil, "", false, response.WriteError(c, http.StatusForbidden, "FORBIDDEN", "workspace resolution returned no workspace")
+	}
+	if effectiveWorkspaceCode == "_system" && !readOnly {
+		return nil, "", false, response.WriteError(c, http.StatusForbidden, "FORBIDDEN", "system workspace is read-only for this integration")
+	}
+
+	requestWorkspaceCode := c.Param("workspace_code")
+	if !readOnly && requestWorkspaceCode != "" && requestWorkspaceCode != effectiveWorkspaceCode {
+		return nil, "", false, response.WriteError(c, http.StatusForbidden, "FORBIDDEN", "workspace resolution mismatch")
+	}
+
+	return resolution, effectiveWorkspaceCode, readOnly, nil
+}
+
+func applyExternalIntegrationContext(c *echo.Context, profile domain.ExternalIntegrationProfile, reqCtx *port.ExternalIntegrationRequest, authResult *port.ExternalAuthResult, resolution *port.ExternalWorkspaceResolution, effectiveWorkspaceCode string, readOnly bool) {
+	effectivePermissions := combinePermissions(profile.Capabilities, authResult.Permissions)
+	c.Set(ContextKeyExternalIntegrationProfile, profile)
+	c.Set(ContextKeyExternalIntegrationAuthResult, authResult)
+	c.Set(ContextKeyExternalIntegrationResolution, resolution)
+	c.Set(ContextKeyExternalIntegrationPermissions, effectivePermissions)
+	c.Set(ContextKeyExternalIntegrationReadOnly, readOnly)
+	c.Set(ContextKeyExternalIntegrationEffectiveWorkspaceCode, effectiveWorkspaceCode)
+	c.Set(ContextKeyExternalIntegrationAllowedHeaders, cloneStringMap(reqCtx.Headers))
+	c.Set(ContextKeyTenantCode, reqCtx.TenantCode)
+	c.Set(ContextKeyWorkspaceCode, effectiveWorkspaceCode)
+
+	patchExternalWorkspaceParam(c, effectiveWorkspaceCode)
+}
+
+func mapExternalProfileLoadError(c *echo.Context, err error) error {
+	switch {
+	case errors.Is(err, domain.ErrForbidden):
+		return response.WriteError(c, http.StatusForbidden, "FORBIDDEN", "external integration profile is disabled")
+	case errors.Is(err, domain.ErrNotFound):
+		return response.WriteError(c, http.StatusNotFound, "NOT_FOUND", "external integration profile not found")
+	default:
+		return response.WriteError(c, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to load external integration profile")
+	}
+}
+
+func responseCommitted(c *echo.Context) bool {
+	resp, err := echo.UnwrapResponse(c.Response())
+	if err != nil {
+		return false
+	}
+	return resp.Committed
+}
+
+// ExternalIntegrationCORS enforces profile-scoped CORS for the external surface.
+func ExternalIntegrationCORS(h ExternalIntegrationResolverStore) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			profileSlug := externalProfileSlugFromRequest(c)
+			if profileSlug == "" {
+				return next(c)
+			}
+
+			profile, err := h.LoadProfileBySlug(c.Request().Context(), profileSlug)
+			if err != nil {
+				switch {
+				case errors.Is(err, domain.ErrForbidden):
+					return response.WriteError(c, http.StatusForbidden, "FORBIDDEN", "external integration profile is disabled")
+				case errors.Is(err, domain.ErrNotFound):
+					return response.WriteError(c, http.StatusNotFound, "NOT_FOUND", "external integration profile not found")
+				default:
+					return response.WriteError(c, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to load external integration profile")
+				}
+			}
+
+			origin := strings.TrimSpace(c.Request().Header.Get(echo.HeaderOrigin))
+			if origin == "" {
+				if c.Request().Method == http.MethodOptions {
+					return c.NoContent(http.StatusNoContent)
+				}
+				return next(c)
+			}
+
+			if !originAllowed(origin, profile.AllowedOrigins) {
+				return response.WriteError(c, http.StatusForbidden, "FORBIDDEN", "origin not allowed for this external integration profile")
+			}
+
+			applyExternalCORSHeaders(c, origin, profile.AllowedHeaders)
+			if c.Request().Method == http.MethodOptions {
+				return c.NoContent(http.StatusNoContent)
+			}
+
+			return next(c)
+		}
+	}
+}
+
+func externalProfileSlugFromRequest(c *echo.Context) string {
+	if slug := strings.TrimSpace(c.Param("profile_slug")); slug != "" {
+		return slug
+	}
+
+	path := strings.TrimPrefix(c.Request().URL.Path, "/api/v1/external/")
+	if path == c.Request().URL.Path {
+		return ""
+	}
+
+	slug, _, _ := strings.Cut(path, "/")
+	return strings.TrimSpace(slug)
+}
+
+// RequireExternalCapability enforces that the effective external permissions
+// allow the requested action. Mutations are blocked outright in read-only mode.
+func RequireExternalCapability(action ExternalAction) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			permissions := externalPermissions(c)
+			if !hasExternalCapability(permissions, action) {
+				return response.WriteError(c, http.StatusForbidden, "FORBIDDEN", "external capability not enabled")
+			}
+
+			return next(c)
+		}
+	}
+}
+
+// RequireExternalMutation blocks mutation routes when the resolver selected the
+// read-only fallback.
+func RequireExternalMutation() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			if isExternalReadOnly(c) {
+				return response.WriteError(c, http.StatusForbidden, "FORBIDDEN", "read-only integration cannot mutate resources")
+			}
+			return next(c)
+		}
+	}
+}
+
+func externalPermissions(c *echo.Context) port.ExternalPermissions {
+	perms, _ := c.Get(ContextKeyExternalIntegrationPermissions).(port.ExternalPermissions)
+	return perms
+}
+
+func isExternalReadOnly(c *echo.Context) bool {
+	readOnly, _ := c.Get(ContextKeyExternalIntegrationReadOnly).(bool)
+	return readOnly
+}
+
+func hasExternalCapability(perms port.ExternalPermissions, action ExternalAction) bool {
+	switch action {
+	case ExternalActionListTemplates:
+		return perms.ListTemplates
+	case ExternalActionViewVersions:
+		return perms.ViewVersions
+	case ExternalActionEditVersions:
+		return perms.EditVersions
+	case ExternalActionPublishVersions:
+		return perms.PublishVersions
+	case ExternalActionTestSend:
+		return perms.TestSend
+	case ExternalActionBuilderAccess:
+		return perms.BuilderAccess
+	case ExternalActionMetadataAccess:
+		return perms.MetadataAccess
+	case ExternalActionLocaleAccess:
+		return perms.LocaleAccess
+	default:
+		return false
+	}
+}
+
+func combinePermissions(profile domain.ExternalIntegrationCapabilities, auth port.ExternalPermissions) port.ExternalPermissions {
+	return port.ExternalPermissions{
+		ListTemplates:   profile.ListTemplates && auth.ListTemplates,
+		ViewVersions:    profile.ViewVersions && auth.ViewVersions,
+		EditVersions:    profile.EditVersions && auth.EditVersions,
+		PublishVersions: profile.PublishVersions && auth.PublishVersions,
+		TestSend:        profile.TestSend && auth.TestSend,
+		BuilderAccess:   profile.BuilderAccess && auth.BuilderAccess,
+		MetadataAccess:  profile.MetadataAccess && auth.MetadataAccess,
+		LocaleAccess:    profile.LocaleAccess && auth.LocaleAccess,
+	}
+}
+
+func collectAllowedHeaders(headers http.Header, allowed []string) map[string]string {
+	if len(allowed) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(allowed))
+	for _, header := range allowed {
+		if value := headers.Get(header); value != "" {
+			out[header] = value
+		}
+	}
+	return out
+}
+
+func externalIntegrationToken(c *echo.Context) string {
+	token := strings.TrimSpace(c.Request().Header.Get(ExternalIntegrationTokenHeader))
+	if token != "" {
+		return token
+	}
+
+	return strings.TrimSpace(c.QueryParam("token"))
+}
+
+func copyQueryParams(c *echo.Context) map[string]string {
+	query := c.QueryParams()
+	if len(query) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(query))
+	for key, values := range query {
+		if len(values) == 0 {
+			continue
+		}
+		out[key] = values[0]
+	}
+	return out
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func originAllowed(origin string, allowed []string) bool {
+	for _, candidate := range allowed {
+		if strings.EqualFold(strings.TrimSpace(candidate), origin) {
+			return true
+		}
+	}
+	return false
+}
+
+func applyExternalCORSHeaders(c *echo.Context, origin string, allowedHeaders []string) {
+	header := c.Response().Header()
+	header.Set(echo.HeaderAccessControlAllowOrigin, origin)
+	header.Add(echo.HeaderVary, echo.HeaderOrigin)
+	header.Set(echo.HeaderAccessControlAllowMethods, strings.Join([]string{
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodOptions,
+	}, ", "))
+	header.Set(echo.HeaderAccessControlAllowHeaders, strings.Join(externalCORSAllowedHeaders(allowedHeaders), ", "))
+	header.Set(echo.HeaderAccessControlExposeHeaders, "X-Request-ID")
+}
+
+func externalCORSAllowedHeaders(allowedHeaders []string) []string {
+	base := []string{
+		echo.HeaderContentType,
+		"X-Request-ID",
+		"X-Senda-External-Token",
+	}
+
+	seen := make(map[string]struct{}, len(base)+len(allowedHeaders))
+	out := make([]string, 0, len(base)+len(allowedHeaders))
+	for _, header := range append(base, allowedHeaders...) {
+		normalized := http.CanonicalHeaderKey(strings.TrimSpace(header))
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func ExternalAllowedHeaders(c *echo.Context) map[string]string {
+	headers, _ := c.Get(ContextKeyExternalIntegrationAllowedHeaders).(map[string]string)
+	return cloneStringMap(headers)
+}
+
+func patchExternalWorkspaceParam(c *echo.Context, workspaceCode string) {
+	paths := c.PathValues()
+	updated := make(echo.PathValues, 0, len(paths))
+	for _, pv := range paths {
+		if pv.Name == "workspace_code" {
+			pv.Value = workspaceCode
+		}
+		updated = append(updated, pv)
+	}
+	c.SetPathValues(updated)
+}
+
+// ExternalAuthDenied returns a sentinel error that external auth methods can
+// use to signal a hard deny instead of an infrastructure failure.
+func ExternalAuthDenied() error {
+	return errExternalAuthDenied
+}

--- a/internal/http/request/config.go
+++ b/internal/http/request/config.go
@@ -1,5 +1,7 @@
 package request
 
+import "github.com/rendis/senda/internal/domain"
+
 // EmailDefaultsUpdate is the email defaults section of the update request.
 type EmailDefaultsUpdate struct {
 	MaxRetries         *int `json:"max_retries"`
@@ -18,10 +20,77 @@ type DomainUpdate struct {
 	RecheckIntervalHours *int `json:"recheck_interval_hours"`
 }
 
+// ExternalIntegrationCapabilitiesUpdate is the capabilities block for a single profile.
+type ExternalIntegrationCapabilitiesUpdate struct {
+	ListTemplates   bool `json:"list_templates"`
+	ViewVersions    bool `json:"view_versions"`
+	EditVersions    bool `json:"edit_versions"`
+	PublishVersions bool `json:"publish_versions"`
+	TestSend        bool `json:"test_send"`
+	BuilderAccess   bool `json:"builder_access"`
+	MetadataAccess  bool `json:"metadata_access"`
+	LocaleAccess    bool `json:"locale_access"`
+}
+
+// ExternalIntegrationProfileUpdate is one external integration profile payload.
+type ExternalIntegrationProfileUpdate struct {
+	Slug            string                                `json:"slug"`
+	Name            string                                `json:"name"`
+	Description     string                                `json:"description"`
+	Enabled         bool                                  `json:"enabled"`
+	AuthMethodName  string                                `json:"auth_method_name"`
+	ResolverName    string                                `json:"resolver_name"`
+	AllowedOrigins  []string                              `json:"allowed_origins"`
+	AllowedHeaders  []string                              `json:"allowed_headers"`
+	RequiredHeaders []string                              `json:"required_headers"`
+	Capabilities    ExternalIntegrationCapabilitiesUpdate `json:"capabilities"`
+}
+
+func (u ExternalIntegrationProfileUpdate) ToDomain() domain.ExternalIntegrationProfile {
+	return domain.ExternalIntegrationProfile{
+		Slug:            u.Slug,
+		Name:            u.Name,
+		Description:     u.Description,
+		Enabled:         u.Enabled,
+		AuthMethodName:  u.AuthMethodName,
+		ResolverName:    u.ResolverName,
+		AllowedOrigins:  append([]string(nil), u.AllowedOrigins...),
+		AllowedHeaders:  append([]string(nil), u.AllowedHeaders...),
+		RequiredHeaders: append([]string(nil), u.RequiredHeaders...),
+		Capabilities: domain.ExternalIntegrationCapabilities{
+			ListTemplates:   u.Capabilities.ListTemplates,
+			ViewVersions:    u.Capabilities.ViewVersions,
+			EditVersions:    u.Capabilities.EditVersions,
+			PublishVersions: u.Capabilities.PublishVersions,
+			TestSend:        u.Capabilities.TestSend,
+			BuilderAccess:   u.Capabilities.BuilderAccess,
+			MetadataAccess:  u.Capabilities.MetadataAccess,
+			LocaleAccess:    u.Capabilities.LocaleAccess,
+		},
+	}
+}
+
+// ExternalIntegrationsUpdate replaces the external integration profiles list.
+type ExternalIntegrationsUpdate struct {
+	Profiles []ExternalIntegrationProfileUpdate `json:"profiles"`
+}
+
+func (u *ExternalIntegrationsUpdate) ToDomain() []domain.ExternalIntegrationProfile {
+	if u == nil {
+		return nil
+	}
+	profiles := make([]domain.ExternalIntegrationProfile, len(u.Profiles))
+	for i, profile := range u.Profiles {
+		profiles[i] = profile.ToDomain()
+	}
+	return profiles
+}
+
 // UpdateConfigRequest is the nested request body for PUT /api/v1/manage/config.
 // Matches the frontend UpdateSettingsRequest type.
 type UpdateConfigRequest struct {
-	EmailDefaults *EmailDefaultsUpdate `json:"email_defaults"`
-	Alerts        *AlertsUpdate        `json:"alerts"`
-	Domain        *DomainUpdate        `json:"domain"`
+	EmailDefaults        *EmailDefaultsUpdate        `json:"email_defaults"`
+	Alerts               *AlertsUpdate               `json:"alerts"`
+	Domain               *DomainUpdate               `json:"domain"`
+	ExternalIntegrations *ExternalIntegrationsUpdate `json:"external_integrations"`
 }

--- a/internal/http/response/config.go
+++ b/internal/http/response/config.go
@@ -29,17 +29,89 @@ type DomainConfigResponse struct {
 	RecheckIntervalHours int `json:"recheck_interval_hours"`
 }
 
+// ExternalIntegrationCapabilitiesResponse mirrors the domain capabilities.
+type ExternalIntegrationCapabilitiesResponse struct {
+	ListTemplates   bool `json:"list_templates"`
+	ViewVersions    bool `json:"view_versions"`
+	EditVersions    bool `json:"edit_versions"`
+	PublishVersions bool `json:"publish_versions"`
+	TestSend        bool `json:"test_send"`
+	BuilderAccess   bool `json:"builder_access"`
+	MetadataAccess  bool `json:"metadata_access"`
+	LocaleAccess    bool `json:"locale_access"`
+}
+
+// ExternalIntegrationProfileResponse exposes one external integration profile
+// in the global settings payload.
+type ExternalIntegrationProfileResponse struct {
+	Slug            string                                  `json:"slug"`
+	Name            string                                  `json:"name"`
+	Description     string                                  `json:"description"`
+	Enabled         bool                                    `json:"enabled"`
+	AuthMethodName  string                                  `json:"auth_method_name"`
+	ResolverName    string                                  `json:"resolver_name"`
+	AllowedOrigins  []string                                `json:"allowed_origins"`
+	AllowedHeaders  []string                                `json:"allowed_headers"`
+	RequiredHeaders []string                                `json:"required_headers"`
+	Capabilities    ExternalIntegrationCapabilitiesResponse `json:"capabilities"`
+}
+
+// ExternalIntegrationsConfigResponse groups all external integration profiles.
+type ExternalIntegrationsConfigResponse struct {
+	Profiles []ExternalIntegrationProfileResponse `json:"profiles"`
+}
+
+// ExternalIntegrationBootstrapResponse is returned by the external bootstrap
+// surface and only exposes the effective framing policy for the embed shell.
+type ExternalIntegrationBootstrapResponse struct {
+	FrameAncestors []string `json:"frame_ancestors"`
+}
+
+// ExternalIntegrationSessionResponse is returned by the authenticated external
+// embed state endpoint so the UI can render the effective permissions.
+type ExternalIntegrationSessionResponse struct {
+	ReadOnly               bool                                    `json:"read_only"`
+	EffectiveWorkspaceCode string                                  `json:"effective_workspace_code"`
+	Permissions            ExternalIntegrationCapabilitiesResponse `json:"permissions"`
+}
+
 // ConfigResponse is the nested JSON response for the global configuration.
 // Matches the frontend SystemSettings type.
 type ConfigResponse struct {
-	OIDC          OIDCConfigResponse          `json:"oidc"`
-	EmailDefaults EmailDefaultsConfigResponse `json:"email_defaults"`
-	Alerts        AlertsConfigResponse        `json:"alerts"`
-	Domain        DomainConfigResponse        `json:"domain"`
+	OIDC                 OIDCConfigResponse                 `json:"oidc"`
+	EmailDefaults        EmailDefaultsConfigResponse        `json:"email_defaults"`
+	Alerts               AlertsConfigResponse               `json:"alerts"`
+	Domain               DomainConfigResponse               `json:"domain"`
+	ExternalIntegrations ExternalIntegrationsConfigResponse `json:"external_integrations"`
 }
 
 // NewConfigResponse maps a domain GlobalConfig + OIDC info to a ConfigResponse.
 func NewConfigResponse(cfg *domain.GlobalConfig, oidcDiscoveryURL, oidcClientID string, oidcClientSecretSet bool) ConfigResponse {
+	profiles := make([]ExternalIntegrationProfileResponse, 0, len(cfg.ExternalIntegrations))
+	for _, profile := range cfg.ExternalIntegrations {
+		profiles = append(profiles, ExternalIntegrationProfileResponse{
+			Slug:            profile.Slug,
+			Name:            profile.Name,
+			Description:     profile.Description,
+			Enabled:         profile.Enabled,
+			AuthMethodName:  profile.AuthMethodName,
+			ResolverName:    profile.ResolverName,
+			AllowedOrigins:  append([]string(nil), profile.AllowedOrigins...),
+			AllowedHeaders:  append([]string(nil), profile.AllowedHeaders...),
+			RequiredHeaders: append([]string(nil), profile.RequiredHeaders...),
+			Capabilities: ExternalIntegrationCapabilitiesResponse{
+				ListTemplates:   profile.Capabilities.ListTemplates,
+				ViewVersions:    profile.Capabilities.ViewVersions,
+				EditVersions:    profile.Capabilities.EditVersions,
+				PublishVersions: profile.Capabilities.PublishVersions,
+				TestSend:        profile.Capabilities.TestSend,
+				BuilderAccess:   profile.Capabilities.BuilderAccess,
+				MetadataAccess:  profile.Capabilities.MetadataAccess,
+				LocaleAccess:    profile.Capabilities.LocaleAccess,
+			},
+		})
+	}
+
 	return ConfigResponse{
 		OIDC: OIDCConfigResponse{
 			DiscoveryURL:    oidcDiscoveryURL,
@@ -58,5 +130,16 @@ func NewConfigResponse(cfg *domain.GlobalConfig, oidcDiscoveryURL, oidcClientID 
 		Domain: DomainConfigResponse{
 			RecheckIntervalHours: cfg.DomainRecheckIntervalHours,
 		},
+		ExternalIntegrations: ExternalIntegrationsConfigResponse{
+			Profiles: profiles,
+		},
+	}
+}
+
+// NewExternalIntegrationBootstrapResponse converts the effective framing
+// policy to the minimal bootstrap payload used by the external embed surface.
+func NewExternalIntegrationBootstrapResponse(frameAncestors []string) ExternalIntegrationBootstrapResponse {
+	return ExternalIntegrationBootstrapResponse{
+		FrameAncestors: frameAncestors,
 	}
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -74,6 +74,9 @@ type Server struct {
 	// HT-25 handler (Onboarding).
 	onboardingHandler *handler.OnboardingHandler
 
+	// External integration handler.
+	externalIntegrationHandler *handler.ExternalIntegrationHandler
+
 	// HT-27 handler (API Keys).
 	apiKeyHandler *handler.APIKeyHandler
 
@@ -262,6 +265,14 @@ func WithOnboardingHandler(h *handler.OnboardingHandler) ServerOption {
 	}
 }
 
+// WithExternalIntegrationHandler sets the handler for the external integration
+// bootstrap route.
+func WithExternalIntegrationHandler(h *handler.ExternalIntegrationHandler) ServerOption {
+	return func(s *Server) {
+		s.externalIntegrationHandler = h
+	}
+}
+
 // WithAPIKeyHandler sets the APIKeyHandler for API key management routes.
 func WithAPIKeyHandler(h *handler.APIKeyHandler) ServerOption {
 	return func(s *Server) {
@@ -316,8 +327,14 @@ func NewServer(cfg *config.Config, logger *slog.Logger, opts ...ServerOption) *S
 		HSTSMaxAge:            31536000,
 		ContentSecurityPolicy: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'",
 	}))
+	if s.externalIntegrationHandler != nil {
+		e.Use(middleware.ExternalIntegrationCORS(s.externalIntegrationHandler))
+	}
 	if len(cfg.Server.AllowedOrigins) > 0 {
 		e.Use(echomw.CORSWithConfig(echomw.CORSConfig{
+			Skipper: func(c *echo.Context) bool {
+				return strings.HasPrefix(c.Request().URL.Path, "/api/v1/external/")
+			},
 			AllowOrigins: cfg.Server.AllowedOrigins,
 			AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions},
 			AllowHeaders: []string{"Authorization", "Content-Type", "X-Request-ID"},
@@ -383,6 +400,47 @@ func (s *Server) registerRoutes() { //nolint:gocognit,gocyclo,funlen // route re
 	if s.onboardingHandler != nil {
 		api.GET("/onboarding/status", s.onboardingHandler.Status)
 		api.POST("/onboarding/setup", s.onboardingHandler.Setup)
+	}
+
+	// External integration bootstrap surface — no OIDC.
+	if s.externalIntegrationHandler != nil {
+		external := s.echo.Group("/api/v1/external/:profile_slug")
+		external.GET("/bootstrap", s.externalIntegrationHandler.Bootstrap)
+
+		if s.templateTypeHandler != nil || s.templateHandler != nil || s.injectorHandler != nil {
+			externalScoped := external.Group("/tenants/:tenant_code/workspaces/:workspace_code")
+			externalScoped.Use(middleware.ExternalIntegration(s.externalIntegrationHandler))
+			externalScoped.GET("/session", s.externalIntegrationHandler.Session, middleware.RequireExternalCapability(middleware.ExternalActionBuilderAccess))
+
+			if s.templateTypeHandler != nil {
+				externalScoped.GET("/template-types", s.templateTypeHandler.List, middleware.RequireExternalCapability(middleware.ExternalActionListTemplates))
+				externalScoped.GET("/template-types/:slug", s.templateTypeHandler.Get, middleware.RequireExternalCapability(middleware.ExternalActionListTemplates))
+			}
+			if s.templateHandler != nil {
+				externalScoped.GET("/template-types/:slug/templates", s.templateHandler.ListByTemplateType, middleware.RequireExternalCapability(middleware.ExternalActionListTemplates))
+
+				externalScoped.GET("/templates/:template_id/versions", s.templateHandler.ListVersions, middleware.RequireExternalCapability(middleware.ExternalActionViewVersions))
+				externalScoped.GET("/templates/:template_id/versions/:version_id", s.templateHandler.GetVersion, middleware.RequireExternalCapability(middleware.ExternalActionViewVersions))
+				externalScoped.PUT("/templates/:template_id/versions/:version_id", s.templateHandler.UpdateVersion, middleware.RequireExternalCapability(middleware.ExternalActionEditVersions), middleware.RequireExternalMutation())
+				externalScoped.POST("/templates/:template_id/versions/:version_id/publish", s.templateHandler.PublishVersion, middleware.RequireExternalCapability(middleware.ExternalActionPublishVersions), middleware.RequireExternalMutation())
+
+				externalScoped.GET("/templates/:template_id/versions/:version_id/locales", s.templateHandler.ListLocales, middleware.RequireExternalCapability(middleware.ExternalActionLocaleAccess))
+				externalScoped.GET("/templates/:template_id/versions/:version_id/locales/:locale", s.templateHandler.GetLocale, middleware.RequireExternalCapability(middleware.ExternalActionLocaleAccess))
+				externalScoped.POST("/templates/:template_id/versions/:version_id/locales/:locale", s.templateHandler.SetLocale, middleware.RequireExternalCapability(middleware.ExternalActionLocaleAccess), middleware.RequireExternalMutation())
+				externalScoped.PUT("/templates/:template_id/versions/:version_id/locales/:locale", s.templateHandler.UpdateLocale, middleware.RequireExternalCapability(middleware.ExternalActionLocaleAccess), middleware.RequireExternalMutation())
+				externalScoped.DELETE("/templates/:template_id/versions/:version_id/locales/:locale", s.templateHandler.DeleteLocale, middleware.RequireExternalCapability(middleware.ExternalActionLocaleAccess), middleware.RequireExternalMutation())
+
+				externalScoped.POST("/templates/:template_id/preview-mjml", s.templateHandler.PreviewMJML, middleware.RequireExternalCapability(middleware.ExternalActionBuilderAccess))
+				externalScoped.POST("/templates/:template_id/test-send", s.templateHandler.TestSend, middleware.RequireExternalCapability(middleware.ExternalActionTestSend), middleware.RequireExternalMutation())
+			}
+			if s.injectorHandler != nil {
+				externalScoped.GET("/injectors", s.injectorHandler.List, middleware.RequireExternalCapability(middleware.ExternalActionBuilderAccess))
+				externalScoped.GET("/injectors/:name", s.injectorHandler.Get, middleware.RequireExternalCapability(middleware.ExternalActionBuilderAccess))
+			}
+			if s.workspacePolicyHandler != nil {
+				externalScoped.GET("/policies", s.workspacePolicyHandler.Get, middleware.RequireExternalCapability(middleware.ExternalActionBuilderAccess))
+			}
+		}
 	}
 
 	// Current authenticated member profile (OIDC only).

--- a/internal/http/server_external_test.go
+++ b/internal/http/server_external_test.go
@@ -1,0 +1,415 @@
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/rendis/senda/internal/domain"
+	sendahttp "github.com/rendis/senda/internal/http"
+	"github.com/rendis/senda/internal/http/handler"
+	"github.com/rendis/senda/internal/http/middleware"
+	"github.com/rendis/senda/internal/http/response"
+	"github.com/rendis/senda/internal/port"
+)
+
+type externalConfigStore struct {
+	getFn func(context.Context) (*domain.GlobalConfig, error)
+}
+
+func (m *externalConfigStore) Get(ctx context.Context) (*domain.GlobalConfig, error) {
+	if m.getFn != nil {
+		return m.getFn(ctx)
+	}
+	return &domain.GlobalConfig{}, nil
+}
+
+func (m *externalConfigStore) Upsert(context.Context, *domain.GlobalConfig) error { return nil }
+
+type externalAuthMethod struct {
+	name        string
+	description string
+	result      *port.ExternalAuthResult
+	err         error
+}
+
+func (m *externalAuthMethod) Name() string        { return m.name }
+func (m *externalAuthMethod) Description() string { return m.description }
+func (m *externalAuthMethod) Authenticate(context.Context, *port.ExternalIntegrationRequest) (*port.ExternalAuthResult, error) {
+	if m.result == nil && m.err == nil {
+		return &port.ExternalAuthResult{}, nil
+	}
+	return m.result, m.err
+}
+
+type externalResolver struct {
+	name        string
+	description string
+	result      *port.ExternalWorkspaceResolution
+	err         error
+}
+
+func (r *externalResolver) Name() string        { return r.name }
+func (r *externalResolver) Description() string { return r.description }
+func (r *externalResolver) ResolveWorkspace(context.Context, *port.ExternalIntegrationRequest, *port.ExternalAuthResult) (*port.ExternalWorkspaceResolution, error) {
+	if r.result == nil && r.err == nil {
+		return &port.ExternalWorkspaceResolution{WorkspaceCode: "main"}, nil
+	}
+	return r.result, r.err
+}
+
+func externalProfileConfig() *domain.GlobalConfig {
+	return &domain.GlobalConfig{
+		ExternalIntegrations: []domain.ExternalIntegrationProfile{
+			{
+				Slug:            "partner-portal",
+				Name:            "Partner Portal",
+				Description:     "External integration",
+				Enabled:         true,
+				AuthMethodName:  "signed-headers",
+				ResolverName:    "tenant-workspace-resolver",
+				AllowedOrigins:  []string{"https://app.example.com"},
+				AllowedHeaders:  []string{"x-tenant-code", "x-signature"},
+				RequiredHeaders: []string{"x-tenant-code"},
+				Capabilities: domain.ExternalIntegrationCapabilities{
+					ListTemplates:   true,
+					ViewVersions:    true,
+					EditVersions:    true,
+					PublishVersions: true,
+					TestSend:        true,
+					BuilderAccess:   true,
+					MetadataAccess:  true,
+					LocaleAccess:    true,
+				},
+			},
+		},
+	}
+}
+
+func setupExternalRouteServer(cfg *domain.GlobalConfig, auth *externalAuthMethod, resolver *externalResolver) *echo.Echo {
+	e := echo.New()
+	e.HTTPErrorHandler = response.HTTPErrorHandler
+	e.Use(middleware.RequestID())
+
+	h := handler.NewExternalIntegrationHandler(&externalConfigStore{
+		getFn: func(context.Context) (*domain.GlobalConfig, error) {
+			return cfg, nil
+		},
+	}, []port.ExternalAuthMethod{auth}, []port.ExternalWorkspaceResolver{resolver})
+
+	e.Use(middleware.ExternalIntegrationCORS(h))
+
+	group := e.Group("/api/v1/external/:profile_slug/tenants/:tenant_code/workspaces/:workspace_code")
+	group.Use(middleware.ExternalIntegration(h))
+
+	group.GET("/template-types", func(c *echo.Context) error {
+		state := map[string]any{
+			"workspace_code": c.Param("workspace_code"),
+			"read_only":      c.Get(middleware.ContextKeyExternalIntegrationReadOnly),
+		}
+		return c.JSON(http.StatusOK, state)
+	}, middleware.RequireExternalCapability(middleware.ExternalActionMetadataAccess))
+
+	group.PUT("/templates/:template_id/versions/:version_id", func(c *echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]any{
+			"workspace_code": c.Param("workspace_code"),
+			"read_only":      c.Get(middleware.ContextKeyExternalIntegrationReadOnly),
+		})
+	}, middleware.RequireExternalCapability(middleware.ExternalActionEditVersions), middleware.RequireExternalMutation())
+
+	group.POST("/templates/:template_id/test-send", func(c *echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	}, middleware.RequireExternalCapability(middleware.ExternalActionTestSend))
+
+	group.POST("/templates/:template_id/preview-mjml", func(c *echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]any{
+			"workspace_code": c.Param("workspace_code"),
+			"read_only":      c.Get(middleware.ContextKeyExternalIntegrationReadOnly),
+		})
+	}, middleware.RequireExternalCapability(middleware.ExternalActionViewVersions))
+
+	group.GET("/policies", func(c *echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]any{
+			"workspace_code": c.Param("workspace_code"),
+			"read_only":      c.Get(middleware.ContextKeyExternalIntegrationReadOnly),
+		})
+	}, middleware.RequireExternalCapability(middleware.ExternalActionBuilderAccess))
+
+	return e
+}
+
+func TestServer_ExternalIntegrationSurface_BootstrapRemainsOutsideOIDC(t *testing.T) {
+	srv := sendahttp.NewServer(testConfig(), testLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/bootstrap", nil)
+	rec := httptest.NewRecorder()
+	srv.Echo().ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusUnauthorized || rec.Code == http.StatusForbidden {
+		t.Fatalf("external integration route must not be behind OIDC middleware, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec = httptest.NewRecorder()
+	srv.Echo().ServeHTTP(rec, req)
+	if got := rec.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("expected global frame protection to remain DENY, got %q", got)
+	}
+}
+
+func TestExternalIntegrationMiddleware_SuccessAndPathRewrite(t *testing.T) {
+	cfg := externalProfileConfig()
+	auth := &externalAuthMethod{
+		name:        "signed-headers",
+		description: "Signed headers auth",
+		result: &port.ExternalAuthResult{
+			Permissions: port.ExternalPermissions{
+				ListTemplates:   true,
+				ViewVersions:    true,
+				EditVersions:    true,
+				PublishVersions: true,
+				TestSend:        true,
+				BuilderAccess:   true,
+				MetadataAccess:  true,
+				LocaleAccess:    true,
+			},
+		},
+	}
+	resolver := &externalResolver{
+		name:        "tenant-workspace-resolver",
+		description: "Tenant workspace resolver",
+		result:      &port.ExternalWorkspaceResolution{WorkspaceCode: "main"},
+	}
+	e := setupExternalRouteServer(cfg, auth, resolver)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
+	req.Header.Set("X-Tenant-Code", "acme")
+	req.Header.Set("X-Signature", "sig")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if body["workspace_code"] != "main" {
+		t.Fatalf("expected workspace_code to remain main, got %#v", body["workspace_code"])
+	}
+}
+
+func TestExternalIntegrationMiddleware_AllowsPoliciesReadForBuilder(t *testing.T) {
+	cfg := externalProfileConfig()
+	auth := &externalAuthMethod{
+		name:        "signed-headers",
+		description: "Signed headers auth",
+		result: &port.ExternalAuthResult{
+			Permissions: port.ExternalPermissions{
+				BuilderAccess: true,
+			},
+		},
+	}
+	resolver := &externalResolver{
+		name:        "tenant-workspace-resolver",
+		description: "Tenant workspace resolver",
+		result:      &port.ExternalWorkspaceResolution{WorkspaceCode: "main"},
+	}
+	e := setupExternalRouteServer(cfg, auth, resolver)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/policies", nil)
+	req.Header.Set("X-Tenant-Code", "acme")
+	req.Header.Set("X-Signature", "sig")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestExternalIntegrationMiddleware_DisabledProfile(t *testing.T) {
+	cfg := externalProfileConfig()
+	cfg.ExternalIntegrations[0].Enabled = false
+
+	e := setupExternalRouteServer(cfg, &externalAuthMethod{name: "signed-headers"}, &externalResolver{name: "tenant-workspace-resolver"})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
+	req.Header.Set("X-Tenant-Code", "acme")
+	req.Header.Set("X-Signature", "sig")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for disabled profile, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestExternalIntegrationMiddleware_MissingRequiredHeader(t *testing.T) {
+	e := setupExternalRouteServer(externalProfileConfig(), &externalAuthMethod{name: "signed-headers"}, &externalResolver{name: "tenant-workspace-resolver"})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
+	req.Header.Set("X-Signature", "sig")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for missing required header, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestExternalIntegrationMiddleware_AuthDenyAndError(t *testing.T) {
+	cfg := externalProfileConfig()
+
+	denyAuth := &externalAuthMethod{
+		name:        "signed-headers",
+		description: "Signed headers auth",
+		err:         middleware.ExternalAuthDenied(),
+	}
+	e := setupExternalRouteServer(cfg, denyAuth, &externalResolver{name: "tenant-workspace-resolver"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
+	req.Header.Set("X-Tenant-Code", "acme")
+	req.Header.Set("X-Signature", "sig")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for auth deny, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	errAuth := &externalAuthMethod{
+		name:        "signed-headers",
+		description: "Signed headers auth",
+		err:         errors.New("boom"),
+	}
+	e = setupExternalRouteServer(cfg, errAuth, &externalResolver{name: "tenant-workspace-resolver"})
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
+	req.Header.Set("X-Tenant-Code", "acme")
+	req.Header.Set("X-Signature", "sig")
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for auth error, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestExternalIntegrationMiddleware_ResolverMismatch(t *testing.T) {
+	cfg := externalProfileConfig()
+	auth := &externalAuthMethod{name: "signed-headers", result: &port.ExternalAuthResult{}}
+	resolver := &externalResolver{
+		name:   "tenant-workspace-resolver",
+		result: &port.ExternalWorkspaceResolution{WorkspaceCode: "main"},
+	}
+	e := setupExternalRouteServer(cfg, auth, resolver)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/other/template-types", nil)
+	req.Header.Set("X-Tenant-Code", "acme")
+	req.Header.Set("X-Signature", "sig")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for resolver mismatch, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestExternalIntegrationMiddleware_FallbackReadOnlyAllowsReadBlocksMutation(t *testing.T) {
+	cfg := externalProfileConfig()
+	auth := &externalAuthMethod{
+		name: "signed-headers",
+		result: &port.ExternalAuthResult{
+			Permissions: port.ExternalPermissions{
+				ListTemplates:   true,
+				ViewVersions:    true,
+				EditVersions:    true,
+				PublishVersions: true,
+				TestSend:        true,
+				BuilderAccess:   true,
+				MetadataAccess:  true,
+				LocaleAccess:    true,
+			},
+		},
+	}
+	resolver := &externalResolver{
+		name:   "tenant-workspace-resolver",
+		result: &port.ExternalWorkspaceResolution{WorkspaceCode: "_system", ReadOnly: true},
+	}
+	e := setupExternalRouteServer(cfg, auth, resolver)
+
+	readReq := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
+	readReq.Header.Set("X-Tenant-Code", "acme")
+	readReq.Header.Set("X-Signature", "sig")
+	readRec := httptest.NewRecorder()
+	e.ServeHTTP(readRec, readReq)
+	if readRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for read in read-only mode, got %d: %s", readRec.Code, readRec.Body.String())
+	}
+
+	var readBody map[string]any
+	if err := json.NewDecoder(readRec.Body).Decode(&readBody); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if readBody["workspace_code"] != "_system" {
+		t.Fatalf("expected read-only fallback to rewrite workspace_code to _system, got %#v", readBody["workspace_code"])
+	}
+
+	mutReq := httptest.NewRequest(http.MethodPut, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/templates/t1/versions/v1", nil)
+	mutReq.Header.Set("X-Tenant-Code", "acme")
+	mutReq.Header.Set("X-Signature", "sig")
+	mutRec := httptest.NewRecorder()
+	e.ServeHTTP(mutRec, mutReq)
+	if mutRec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for mutation in read-only mode, got %d: %s", mutRec.Code, mutRec.Body.String())
+	}
+}
+
+func TestExternalIntegrationCORS_PreflightHonorsProfileOriginsAndHeaders(t *testing.T) {
+	e := setupExternalRouteServer(
+		externalProfileConfig(),
+		&externalAuthMethod{name: "signed-headers"},
+		&externalResolver{name: "tenant-workspace-resolver"},
+	)
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
+	req.Header.Set(echo.HeaderOrigin, "https://app.example.com")
+	req.Header.Set(echo.HeaderAccessControlRequestMethod, http.MethodGet)
+	req.Header.Set(echo.HeaderAccessControlRequestHeaders, "x-tenant-code, x-senda-external-token")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for allowed preflight, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get(echo.HeaderAccessControlAllowOrigin); got != "https://app.example.com" {
+		t.Fatalf("expected profile origin to be echoed, got %q", got)
+	}
+	allowedHeaders := rec.Header().Get(echo.HeaderAccessControlAllowHeaders)
+	if !strings.Contains(allowedHeaders, "X-Tenant-Code") {
+		t.Fatalf("expected allow headers to contain X-Tenant-Code, got %q", allowedHeaders)
+	}
+	if !strings.Contains(allowedHeaders, "X-Senda-External-Token") {
+		t.Fatalf("expected allow headers to contain X-Senda-External-Token, got %q", allowedHeaders)
+	}
+}
+
+func TestExternalIntegrationCORS_DeniesUnexpectedOrigin(t *testing.T) {
+	e := setupExternalRouteServer(
+		externalProfileConfig(),
+		&externalAuthMethod{name: "signed-headers"},
+		&externalResolver{name: "tenant-workspace-resolver"},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
+	req.Header.Set(echo.HeaderOrigin, "https://evil.example.com")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for unexpected origin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/port/external_integration.go
+++ b/internal/port/external_integration.go
@@ -1,0 +1,61 @@
+package port
+
+import "context"
+
+// ExternalIntegrationRequest carries the request context for external
+// integration auth and workspace resolution flows.
+type ExternalIntegrationRequest struct {
+	ProfileSlug    string
+	TenantCode     string
+	WorkspaceCodes []string
+	Token          string
+	Headers        map[string]string
+	QueryParams    map[string]string
+	Path           string
+	Method         string
+}
+
+// ExternalPermissions captures the capabilities granted by the auth method.
+// The external surface enforces these booleans together with the profile
+// capabilities configured in system settings.
+type ExternalPermissions struct {
+	ListTemplates   bool
+	ViewVersions    bool
+	EditVersions    bool
+	PublishVersions bool
+	TestSend        bool
+	BuilderAccess   bool
+	MetadataAccess  bool
+	LocaleAccess    bool
+}
+
+// ExternalAuthResult is the normalized auth/access context returned by a
+// custom external auth method.
+type ExternalAuthResult struct {
+	Permissions ExternalPermissions
+	Context     map[string]any
+}
+
+// ExternalWorkspaceResolution is the outcome of a custom workspace resolver.
+// When ReadOnly is true, the caller must use the tenant _system workspace
+// and disallow all mutating operations.
+type ExternalWorkspaceResolution struct {
+	WorkspaceCode string
+	ReadOnly      bool
+}
+
+// ExternalAuthMethod validates the incoming external integration request and
+// returns a normalized context and permissions set.
+type ExternalAuthMethod interface {
+	Name() string
+	Description() string
+	Authenticate(ctx context.Context, req *ExternalIntegrationRequest) (*ExternalAuthResult, error)
+}
+
+// ExternalWorkspaceResolver maps the authenticated request to a workspace
+// code or a read-only fallback.
+type ExternalWorkspaceResolver interface {
+	Name() string
+	Description() string
+	ResolveWorkspace(ctx context.Context, req *ExternalIntegrationRequest, auth *ExternalAuthResult) (*ExternalWorkspaceResolution, error)
+}

--- a/internal/port/store.go
+++ b/internal/port/store.go
@@ -31,6 +31,13 @@ type WorkspaceStore interface {
 	SoftDelete(ctx context.Context, id uuid.UUID) error
 }
 
+// WorkspaceExistenceStore provides batch existence checks for tenant-scoped workspace codes.
+type WorkspaceExistenceStore interface {
+	// ExistsActiveByTenantCode returns a dense map where each requested workspace code is present
+	// and mapped to true only when the workspace exists for the tenant, is active, and is not soft-deleted.
+	ExistsActiveByTenantCode(ctx context.Context, tenantCode string, workspaceCodes []string) (map[string]bool, error)
+}
+
 // InjectorStore manages injector persistence.
 type InjectorStore interface {
 	// Definitions (schema)

--- a/internal/teststack/stack.go
+++ b/internal/teststack/stack.go
@@ -440,6 +440,8 @@ func startApp(ctx context.Context, root string, names resourceNames, report *Rep
 		"SENDA_TRACKING_BASE_URL":               "http://senda:8080",
 		"SENDA_SNS_SKIP_SIGNATURE_VERIFICATION": fmt.Sprintf("%t", report.Runtime.SkipSNSignatureVerification),
 		"SENDA_E2E_ENABLE_CODE_INJECTORS":       "true",
+		"SENDA_E2E_ENABLE_EXTERNAL_INTEGRATION": "true",
+		"SENDA_E2E_EXTERNAL_TOKEN":              "external-e2e-token",
 	}
 
 	req := testcontainers.ContainerRequest{

--- a/migrations/000039_workspace_active_lookup_index.down.sql
+++ b/migrations/000039_workspace_active_lookup_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_workspaces_active_code_lookup;

--- a/migrations/000039_workspace_active_lookup_index.up.sql
+++ b/migrations/000039_workspace_active_lookup_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_workspaces_active_code_lookup
+    ON workspaces (tenant_id, code)
+    WHERE deleted_at IS NULL AND is_active = true;

--- a/sdk/engine.go
+++ b/sdk/engine.go
@@ -17,11 +17,13 @@ import (
 // Engine is the main entry point for running Senda as a library.
 // Create one with New or NewWithConfig, register extensions, then call Run.
 type Engine struct {
-	configPath string
-	injectors  []Injector
-	initFunc   InitFunc
-	onStart    []func(ctx context.Context) error
-	onShutdown []func(ctx context.Context) error
+	configPath                 string
+	injectors                  []Injector
+	initFunc                   InitFunc
+	externalAuthMethods        []ExternalAuthMethod
+	externalWorkspaceResolvers []ExternalWorkspaceResolver
+	onStart                    []func(ctx context.Context) error
+	onShutdown                 []func(ctx context.Context) error
 }
 
 // New creates an Engine with default config path ("config.yaml").
@@ -44,6 +46,19 @@ func (e *Engine) RegisterInjector(inj Injector) *Engine {
 // Replaces any previously set InitFunc.
 func (e *Engine) SetInitFunc(fn InitFunc) *Engine {
 	e.initFunc = fn
+	return e
+}
+
+// RegisterExternalAuthMethod adds a custom external integration auth method.
+func (e *Engine) RegisterExternalAuthMethod(method ExternalAuthMethod) *Engine {
+	e.externalAuthMethods = append(e.externalAuthMethods, method)
+	return e
+}
+
+// RegisterExternalWorkspaceResolver adds a custom external integration
+// workspace resolver.
+func (e *Engine) RegisterExternalWorkspaceResolver(resolver ExternalWorkspaceResolver) *Engine {
+	e.externalWorkspaceResolvers = append(e.externalWorkspaceResolvers, resolver)
 	return e
 }
 
@@ -122,12 +137,14 @@ func (e *Engine) Run() error {
 }
 
 func (e *Engine) buildExtensions() *app.Extensions {
-	if len(e.injectors) == 0 && e.initFunc == nil {
+	if len(e.injectors) == 0 && e.initFunc == nil && len(e.externalAuthMethods) == 0 && len(e.externalWorkspaceResolvers) == 0 {
 		return nil
 	}
 	return &app.Extensions{
-		Injectors: e.injectors,
-		InitFunc:  e.initFunc,
+		Injectors:                  e.injectors,
+		InitFunc:                   e.initFunc,
+		ExternalAuthMethods:        e.externalAuthMethods,
+		ExternalWorkspaceResolvers: e.externalWorkspaceResolvers,
 	}
 }
 

--- a/sdk/external_extensions_test.go
+++ b/sdk/external_extensions_test.go
@@ -1,0 +1,111 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type testExternalAuthMethod struct {
+	name        string
+	description string
+}
+
+func (t *testExternalAuthMethod) Name() string        { return t.name }
+func (t *testExternalAuthMethod) Description() string { return t.description }
+func (t *testExternalAuthMethod) Authenticate(context.Context, *ExternalIntegrationRequest) (*ExternalAuthResult, error) {
+	return &ExternalAuthResult{}, nil
+}
+
+type testExternalWorkspaceResolver struct {
+	name        string
+	description string
+}
+
+func (t *testExternalWorkspaceResolver) Name() string        { return t.name }
+func (t *testExternalWorkspaceResolver) Description() string { return t.description }
+func (t *testExternalWorkspaceResolver) ResolveWorkspace(context.Context, *ExternalIntegrationRequest, *ExternalAuthResult) (*ExternalWorkspaceResolution, error) {
+	return &ExternalWorkspaceResolution{}, nil
+}
+
+func TestEngineExternalExtensionRegistration(t *testing.T) {
+	engine := New()
+
+	auth := &testExternalAuthMethod{name: "signed-header", description: "Validates signed request headers"}
+	resolver := &testExternalWorkspaceResolver{name: "workspace-slug", description: "Maps tenant + request to workspace"}
+
+	got := engine.
+		RegisterExternalAuthMethod(auth).
+		RegisterExternalWorkspaceResolver(resolver)
+
+	if got != engine {
+		t.Fatal("fluent external registration should return the same engine")
+	}
+
+	ext := engine.buildExtensions()
+	if ext == nil {
+		t.Fatal("expected buildExtensions to include external registrations")
+	}
+	if len(ext.ExternalAuthMethods) != 1 {
+		t.Fatalf("expected 1 external auth method, got %d", len(ext.ExternalAuthMethods))
+	}
+	if len(ext.ExternalWorkspaceResolvers) != 1 {
+		t.Fatalf("expected 1 external workspace resolver, got %d", len(ext.ExternalWorkspaceResolvers))
+	}
+	if ext.ExternalAuthMethods[0].Name() != "signed-header" {
+		t.Fatalf("unexpected auth method name: %q", ext.ExternalAuthMethods[0].Name())
+	}
+	if ext.ExternalWorkspaceResolvers[0].Description() != "Maps tenant + request to workspace" {
+		t.Fatalf("unexpected resolver description: %q", ext.ExternalWorkspaceResolvers[0].Description())
+	}
+}
+
+func TestEngineExternalExtensionRegistration_ChainWithExistingAPI(t *testing.T) {
+	engine := New()
+
+	got := engine.
+		RegisterExternalAuthMethod(&testExternalAuthMethod{name: "auth", description: "desc"}).
+		RegisterExternalWorkspaceResolver(&testExternalWorkspaceResolver{name: "resolver", description: "desc"}).
+		SetInitFunc(func(_ context.Context, _ *InjectorContext) (any, error) { return nil, nil }).
+		OnStart(func(context.Context) error { return nil }).
+		OnShutdown(func(context.Context) error { return nil })
+
+	if got != engine {
+		t.Fatal("expected fluent chaining to preserve the engine pointer")
+	}
+}
+
+func TestEngineBuildExtensions_NoExternalRegistrations(t *testing.T) {
+	engine := New()
+
+	if ext := engine.buildExtensions(); ext != nil {
+		t.Fatalf("expected nil extensions when nothing is registered, got %#v", ext)
+	}
+}
+
+func TestEngineExternalRegistration_DoesNotAffectExistingInjectorAPIs(t *testing.T) {
+	engine := New()
+	engine.RegisterInjector(&dummyInjector{}).RegisterExternalAuthMethod(&testExternalAuthMethod{name: "auth", description: "desc"})
+
+	ext := engine.buildExtensions()
+	if ext == nil {
+		t.Fatal("expected extensions to be built")
+	}
+	if len(ext.Injectors) != 1 {
+		t.Fatalf("expected 1 injector, got %d", len(ext.Injectors))
+	}
+	if len(ext.ExternalAuthMethods) != 1 {
+		t.Fatalf("expected 1 external auth method, got %d", len(ext.ExternalAuthMethods))
+	}
+}
+
+type dummyInjector struct{}
+
+func (d *dummyInjector) Code() string { return "dummy" }
+func (d *dummyInjector) Resolve() (ResolveFunc, []string) {
+	return func(context.Context, *InjectorContext) (map[string]any, error) {
+		return map[string]any{"ok": true}, nil
+	}, nil
+}
+func (d *dummyInjector) IsCritical() bool       { return false }
+func (d *dummyInjector) Timeout() time.Duration { return time.Second }

--- a/sdk/interfaces.go
+++ b/sdk/interfaces.go
@@ -16,3 +16,25 @@ type ResolveFunc = port.CodeResolveFunc
 // InitFunc runs once per send request before code injectors.
 // See port.CodeInitFunc for the full signature.
 type InitFunc = port.CodeInitFunc
+
+// ExternalAuthMethod validates external integration requests and returns a
+// normalized access context.
+type ExternalAuthMethod = port.ExternalAuthMethod
+
+// ExternalWorkspaceResolver maps a validated request to a workspace code or a
+// read-only fallback.
+type ExternalWorkspaceResolver = port.ExternalWorkspaceResolver
+
+// ExternalIntegrationRequest is the request context passed to auth and
+// resolver extensions.
+type ExternalIntegrationRequest = port.ExternalIntegrationRequest
+
+// ExternalPermissions describes the capability flags returned by an auth
+// method.
+type ExternalPermissions = port.ExternalPermissions
+
+// ExternalAuthResult is the normalized access context returned by auth.
+type ExternalAuthResult = port.ExternalAuthResult
+
+// ExternalWorkspaceResolution is the result of a workspace resolver.
+type ExternalWorkspaceResolution = port.ExternalWorkspaceResolution

--- a/test/e2e/external_integration_test.go
+++ b/test/e2e/external_integration_test.go
@@ -1,0 +1,366 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	externalProfileSlug = "partner-portal"
+	externalToken       = "external-e2e-token"
+	externalViewerToken = "external-e2e-viewer"
+)
+
+func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
+	ctx := t.Context()
+	_, err := ensureCoreHarness(ctx)
+	require.NoError(t, err)
+
+	ensureExternalSetup(t)
+
+	admin := NewTestClient(t)
+	admin.LoginAs(SuperadminEmail)
+	ensureExternalIntegrationProfile(t, admin)
+
+	templateTypeID := MustEnsureTemplateType(t, admin, TenantCode, WorkspaceCode, TemplateTypeSlug, TemplateTypeName, TemplateTypeDesc, "")
+	templateID := MustEnsureTemplate(t, admin, TenantCode, WorkspaceCode, templateTypeID)
+	draftVersionID := createDraftVersion(t, admin, TenantCode, WorkspaceCode, templateID)
+
+	t.Run("success_list_templates_and_versions", func(t *testing.T) {
+		resp := externalRequest(t, http.MethodGet,
+			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/template-types/%s/templates", TemplateTypeSlug),
+			nil,
+			map[string]string{"X-Tenant-Code": TenantCode},
+			"")
+		defer resp.Body.Close()
+		RequireStatus(t, resp, http.StatusOK)
+
+		var body struct {
+			Items []struct {
+				ID string `json:"id"`
+			} `json:"items"`
+		}
+		ParseJSONResponse(t, resp, &body)
+		require.NotEmpty(t, body.Items)
+
+		resp = externalRequest(t, http.MethodGet,
+			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/versions/%s", templateID, draftVersionID),
+			nil,
+			map[string]string{"X-Tenant-Code": TenantCode},
+			"")
+		defer resp.Body.Close()
+		RequireStatus(t, resp, http.StatusOK)
+	})
+
+	t.Run("success_update_preview_test_send_and_publish", func(t *testing.T) {
+		updateResp := externalRequest(t, http.MethodPut,
+			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/versions/%s", templateID, draftVersionID),
+			map[string]any{
+				"subject":        "External Updated Subject",
+				"preview_text":   "Updated preview",
+				"from_name":      TestFromName,
+				"body_mjml":      SampleMJML(),
+				"default_locale": "en",
+			},
+			map[string]string{"X-Tenant-Code": TenantCode},
+			"",
+		)
+		defer updateResp.Body.Close()
+		RequireStatus(t, updateResp, http.StatusOK)
+
+		previewResp := externalRequest(t, http.MethodPost,
+			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/preview-mjml", templateID),
+			map[string]any{"mjml": SampleMJML()},
+			map[string]string{"X-Tenant-Code": TenantCode},
+			"",
+		)
+		defer previewResp.Body.Close()
+		RequireStatus(t, previewResp, http.StatusOK)
+
+		var previewBody struct {
+			HTML string `json:"html"`
+		}
+		ParseJSONResponse(t, previewResp, &previewBody)
+		require.NotEmpty(t, previewBody.HTML)
+
+		testSendResp := externalRequest(t, http.MethodPost,
+			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/test-send", templateID),
+			map[string]any{
+				"recipient_email": "user@example.com",
+				"variables": map[string]any{
+					"first_name":   "Ada",
+					"company_name": "Tether",
+				},
+			},
+			map[string]string{"X-Tenant-Code": TenantCode},
+			"",
+		)
+		defer testSendResp.Body.Close()
+		RequireStatus(t, testSendResp, http.StatusOK)
+
+		publishResp := externalRequest(t, http.MethodPost,
+			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/versions/%s/publish", templateID, draftVersionID),
+			nil,
+			map[string]string{"X-Tenant-Code": TenantCode},
+			"",
+		)
+		defer publishResp.Body.Close()
+		require.Equal(t, http.StatusNoContent, publishResp.StatusCode, "publish should succeed: %s", ReadResponseBody(t, publishResp))
+	})
+
+	t.Run("chaos_fallback_to_system_is_read_only", func(t *testing.T) {
+		readResp := externalRequest(t, http.MethodGet,
+			externalWorkspacePath("missing")+"/template-types",
+			nil,
+			map[string]string{"X-Tenant-Code": TenantCode},
+			"fallback=system",
+		)
+		defer readResp.Body.Close()
+		RequireStatus(t, readResp, http.StatusOK)
+
+		writeResp := externalRequest(t, http.MethodPut,
+			externalWorkspacePath("missing")+fmt.Sprintf("/templates/%s/versions/%s", templateID, createDraftVersion(t, admin, TenantCode, WorkspaceCode, templateID)),
+			map[string]any{
+				"subject":        "Should Fail",
+				"preview_text":   "Should Fail",
+				"from_name":      TestFromName,
+				"body_mjml":      SampleMJML(),
+				"default_locale": "en",
+			},
+			map[string]string{"X-Tenant-Code": TenantCode},
+			"fallback=system",
+		)
+		defer writeResp.Body.Close()
+		require.Equal(t, http.StatusForbidden, writeResp.StatusCode, "fallback mutation must be blocked: %s", ReadResponseBody(t, writeResp))
+	})
+
+	t.Run("malicious_missing_header_invalid_token_and_tenant_spoof_are_denied", func(t *testing.T) {
+		resp := externalRequest(t, http.MethodGet,
+			externalWorkspacePath(WorkspaceCode)+"/template-types",
+			nil,
+			nil,
+			"",
+		)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "missing header should fail: %s", ReadResponseBody(t, resp))
+
+		resp = externalRequest(t, http.MethodGet,
+			externalWorkspacePath(WorkspaceCode)+"/template-types",
+			nil,
+			map[string]string{"X-Tenant-Code": TenantCode},
+			"token=wrong-token",
+		)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "invalid token should fail: %s", ReadResponseBody(t, resp))
+
+		resp = externalRequest(t, http.MethodGet,
+			externalWorkspacePath(WorkspaceCode)+"/template-types",
+			nil,
+			map[string]string{"X-Tenant-Code": "other-tenant"},
+			"",
+		)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "tenant spoof should fail: %s", ReadResponseBody(t, resp))
+	})
+
+	t.Run("viewer_permissions_allow_read_and_block_mutations", func(t *testing.T) {
+		readResp := externalRequest(t, http.MethodGet,
+			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/versions/%s", templateID, draftVersionID),
+			nil,
+			map[string]string{
+				"X-Tenant-Code":           TenantCode,
+				"X-Senda-External-Token": externalViewerToken,
+			},
+			"",
+		)
+		defer readResp.Body.Close()
+		RequireStatus(t, readResp, http.StatusOK)
+
+		updateResp := externalRequest(t, http.MethodPut,
+			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/versions/%s", templateID, draftVersionID),
+			map[string]any{
+				"subject":        "Viewer Should Fail",
+				"preview_text":   "Viewer Should Fail",
+				"from_name":      TestFromName,
+				"body_mjml":      SampleMJML(),
+				"default_locale": "en",
+			},
+			map[string]string{
+				"X-Tenant-Code":           TenantCode,
+				"X-Senda-External-Token": externalViewerToken,
+			},
+			"",
+		)
+		defer updateResp.Body.Close()
+		require.Equal(t, http.StatusForbidden, updateResp.StatusCode, "viewer update should fail: %s", ReadResponseBody(t, updateResp))
+
+		publishResp := externalRequest(t, http.MethodPost,
+			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/versions/%s/publish", templateID, draftVersionID),
+			nil,
+			map[string]string{
+				"X-Tenant-Code":           TenantCode,
+				"X-Senda-External-Token": externalViewerToken,
+			},
+			"",
+		)
+		defer publishResp.Body.Close()
+		require.Equal(t, http.StatusForbidden, publishResp.StatusCode, "viewer publish should fail: %s", ReadResponseBody(t, publishResp))
+
+		testSendResp := externalRequest(t, http.MethodPost,
+			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/test-send", templateID),
+			map[string]any{
+				"recipient_email": "user@example.com",
+				"variables": map[string]any{
+					"first_name": "Ada",
+				},
+			},
+			map[string]string{
+				"X-Tenant-Code":           TenantCode,
+				"X-Senda-External-Token": externalViewerToken,
+			},
+			"",
+		)
+		defer testSendResp.Body.Close()
+		require.Equal(t, http.StatusForbidden, testSendResp.StatusCode, "viewer test-send should fail: %s", ReadResponseBody(t, testSendResp))
+	})
+}
+
+func ensureExternalIntegrationProfile(t *testing.T, client *TestClient) {
+	t.Helper()
+
+	resp := client.Put("/api/v1/manage/config", map[string]any{
+		"external_integrations": map[string]any{
+			"profiles": []map[string]any{
+				{
+					"slug":             externalProfileSlug,
+					"name":             "Partner Portal",
+					"description":      "E2E external integration profile",
+					"enabled":          true,
+					"auth_method_name": "e2e-signed-token",
+					"resolver_name":    "e2e-workspace-resolver",
+					"allowed_origins":  []string{"http://localhost:3000"},
+					"allowed_headers":  []string{"x-tenant-code"},
+					"required_headers": []string{"x-tenant-code"},
+					"capabilities": map[string]bool{
+						"list_templates":   true,
+						"view_versions":    true,
+						"edit_versions":    true,
+						"publish_versions": true,
+						"test_send":        true,
+						"builder_access":   true,
+						"metadata_access":  true,
+						"locale_access":    true,
+					},
+				},
+			},
+		},
+	})
+	defer resp.Body.Close()
+	RequireStatus(t, resp, http.StatusOK)
+}
+
+func ensureExternalSetup(t *testing.T) {
+	t.Helper()
+	WaitForServer(t, 30*time.Second)
+	WaitForMailpit(t, 30*time.Second)
+
+	client := NewTestClient(t)
+	client.LoginAs(SuperadminEmail)
+
+	onboardingResp := client.Post("/api/v1/onboarding/setup", map[string]string{
+		"tenant_code": TenantCode,
+		"tenant_name": TenantName,
+	})
+	require.Contains(t, []int{http.StatusCreated, http.StatusConflict}, onboardingResp.StatusCode,
+		"expected 201 or 409 onboarding setup, got %d: %s", onboardingResp.StatusCode, ReadResponseBody(t, onboardingResp))
+	onboardingResp.Body.Close()
+
+	workspaceResp := client.Post(fmt.Sprintf("/api/v1/manage/tenants/%s/workspaces", TenantCode), map[string]string{
+		"code": WorkspaceCode,
+		"name": WorkspaceName,
+	})
+	require.Contains(t, []int{http.StatusCreated, http.StatusConflict}, workspaceResp.StatusCode,
+		"expected 201 or 409 workspace setup, got %d: %s", workspaceResp.StatusCode, ReadResponseBody(t, workspaceResp))
+	workspaceResp.Body.Close()
+
+	adapterID := mustEnsureWorkspaceAdapter(t, client, TenantCode, WorkspaceCode, 100)
+	EnsureDefaultAdapterIdentity(t, adapterID, TestFromEmail)
+
+	templateTypeID := MustEnsureTemplateType(t, client, TenantCode, WorkspaceCode, TemplateTypeSlug, TemplateTypeName, TemplateTypeDesc, adapterID)
+	templateID := MustEnsureTemplate(t, client, TenantCode, WorkspaceCode, templateTypeID)
+	_ = MustEnsureVersionPublished(t, client, TenantCode, WorkspaceCode, templateID)
+}
+
+func createDraftVersion(t *testing.T, client *TestClient, tenantCode, workspaceCode, templateID string) string {
+	t.Helper()
+
+	resp := client.Post(fmt.Sprintf("%s/templates/%s/versions", mustWorkspacePath(tenantCode, workspaceCode), templateID), CreateVersionRequest{
+		Subject:       "External Draft Subject",
+		PreviewText:   "External draft preview",
+		FromName:      TestFromName,
+		BodyMJML:      SampleMJML(),
+		DefaultLocale: "en",
+	})
+	defer resp.Body.Close()
+	RequireStatus(t, resp, http.StatusCreated)
+
+	var body struct {
+		ID string `json:"id"`
+	}
+	ParseJSONResponse(t, resp, &body)
+	require.NotEmpty(t, body.ID)
+	return body.ID
+}
+
+func externalWorkspacePath(workspaceCode string) string {
+	return fmt.Sprintf("/api/v1/external/%s/tenants/%s/workspaces/%s", externalProfileSlug, TenantCode, workspaceCode)
+}
+
+func externalRequest(t *testing.T, method, path string, body any, headers map[string]string, extraQuery string) *http.Response {
+	t.Helper()
+
+	client := NewTestClient(t)
+	url := client.baseURL + path
+	separator := "?"
+	if bytes.Contains([]byte(url), []byte("?")) {
+		separator = "&"
+	}
+	query := ""
+	if extraQuery != "" {
+		query += extraQuery
+	}
+	if query != "" {
+		url += separator + query
+	}
+
+	var payload bytes.Buffer
+	if body != nil {
+		require.NoError(t, json.NewEncoder(&payload).Encode(body))
+	}
+
+	req, err := http.NewRequest(method, url, &payload)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	_, hasCanonicalTokenHeader := headers["X-Senda-External-Token"]
+	_, hasLowerTokenHeader := headers["x-senda-external-token"]
+	if !hasCanonicalTokenHeader && !hasLowerTokenHeader && !bytes.Contains([]byte(extraQuery), []byte("token=")) {
+		req.Header.Set("X-Senda-External-Token", externalToken)
+	}
+
+	resp, err := client.httpClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}

--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -225,9 +225,11 @@ func startAppContainer(ctx context.Context, rootDir, networkName string) (testco
 		},
 		ExposedPorts: []string{"8080/tcp"},
 		Env: map[string]string{
-			"SENDA_E2E_ENABLE_CODE_INJECTORS": "true",
+			"SENDA_E2E_ENABLE_CODE_INJECTORS":       "true",
+			"SENDA_E2E_ENABLE_EXTERNAL_INTEGRATION": "true",
+			"SENDA_E2E_EXTERNAL_TOKEN":              "external-e2e-token",
 		},
-		Networks:     []string{networkName},
+		Networks: []string{networkName},
 		NetworkAliases: map[string][]string{
 			networkName: []string{"senda"},
 		},

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -212,6 +212,20 @@
     "tenant": "Tenant",
     "workspace": "Workspace"
   },
+  "externalBuilderPage": {
+    "title": "External Builder",
+    "description": "A simplified embedded builder for external integrations.",
+    "profileLabel": "Profile",
+    "readOnlyBadge": "Read-only fallback",
+    "readOnlyFallbackTitle": "Read-only fallback active",
+    "readOnlyFallbackDescription": "The backend resolved the tenant Default workspace, so editing, publishing, and test sends are disabled.",
+    "loadingAccessState": "Validating external access…",
+    "testSendDisabledByPermissions": "External integration permissions disabled test sends for this session.",
+    "accessDenied": {
+      "title": "Access denied",
+      "description": "This embedded builder session is not authorized to access the requested workspace."
+    }
+  },
   "settingsPage": {
     "accessDenied": {
       "title": "Access denied",
@@ -219,6 +233,60 @@
     },
     "saveChanges": "Save Changes",
     "saving": "Saving...",
+    "externalIntegrations": {
+      "title": "External integration profiles",
+      "description": "Define named auth/resolver pairs, allowed origins, allowed headers, and feature capabilities for embeddable builder and read-only API access.",
+      "addProfile": "Add profile",
+      "empty": {
+        "title": "No external profiles yet",
+        "description": "Create a profile so external apps can target a validated auth method and workspace resolver."
+      },
+      "profileTitle": "Profile {index}",
+      "profileDescription": "Configure the integration profile identity and authorization seams.",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "removeProfile": "Remove",
+      "slugLabel": "Slug",
+      "nameLabel": "Name",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Short human-friendly description",
+      "authMethodLabel": "Auth method",
+      "authMethodPlaceholder": "Select or type auth method",
+      "resolverLabel": "Resolver",
+      "resolverPlaceholder": "Select or type resolver",
+      "allowedOriginsLabel": "Allowed origins",
+      "allowedOriginsPlaceholder": "https://app.example.com",
+      "allowedHeadersLabel": "Allowed headers",
+      "allowedHeadersPlaceholder": "x-tenant-code",
+      "requiredHeadersLabel": "Required headers",
+      "requiredHeadersPlaceholder": "x-tenant-code",
+      "capabilitiesLabel": "Capabilities",
+      "registeredAuthMethods": "Registered auth methods",
+      "registeredResolvers": "Registered resolvers",
+      "noAuthMethods": "No auth methods registered yet.",
+      "noResolvers": "No resolvers registered yet.",
+      "methodFallbackDescription": "Enter a registered method name.",
+      "capabilityLabels": {
+        "list_templates": "List templates",
+        "view_versions": "View versions",
+        "edit_versions": "Edit versions",
+        "publish_versions": "Publish versions",
+        "test_send": "Test send",
+        "builder_access": "Builder access",
+        "metadata_access": "Metadata access",
+        "locale_access": "Locale access"
+      },
+      "capabilityDescriptions": {
+        "list_templates": "Allow catalog listing in the external UI.",
+        "view_versions": "Allow read-only version browsing.",
+        "edit_versions": "Allow draft editing in the embedded builder.",
+        "publish_versions": "Allow publishing a version.",
+        "test_send": "Allow test email sending.",
+        "builder_access": "Allow opening the embedded builder shell.",
+        "metadata_access": "Allow editing template metadata panels.",
+        "locale_access": "Allow editing locale variants."
+      }
+    },
     "global": {
       "loadErrorTitle": "Failed to load settings",
       "loadErrorDescription": "Could not retrieve system settings. You may not have superadmin permissions.",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -212,6 +212,20 @@
     "tenant": "Tenant",
     "workspace": "Workspace"
   },
+  "externalBuilderPage": {
+    "title": "Builder externo",
+    "description": "Una versión simplificada del builder para integraciones externas.",
+    "profileLabel": "Perfil",
+    "readOnlyBadge": "Fallback solo lectura",
+    "readOnlyFallbackTitle": "Fallback solo lectura activo",
+    "readOnlyFallbackDescription": "El backend resolvió el workspace Default del tenant, por lo que editar, publicar y enviar pruebas está deshabilitado.",
+    "loadingAccessState": "Validando acceso externo…",
+    "testSendDisabledByPermissions": "Los permisos de la integración externa deshabilitaron el envío de pruebas en esta sesión.",
+    "accessDenied": {
+      "title": "Acceso denegado",
+      "description": "Esta sesión del builder embebido no está autorizada para acceder al workspace solicitado."
+    }
+  },
   "settingsPage": {
     "accessDenied": {
       "title": "Acceso denegado",
@@ -219,6 +233,60 @@
     },
     "saveChanges": "Guardar cambios",
     "saving": "Guardando...",
+    "externalIntegrations": {
+      "title": "Perfiles de integración externa",
+      "description": "Define pares nombrados de auth/resolver, origins permitidos, headers permitidos y capacidades para acceso a API y builder embebido.",
+      "addProfile": "Agregar perfil",
+      "empty": {
+        "title": "Aún no hay perfiles externos",
+        "description": "Crea un perfil para que apps externas apunten a un auth method y resolver validados."
+      },
+      "profileTitle": "Perfil {index}",
+      "profileDescription": "Configura la identidad del perfil y sus puntos de autorización.",
+      "enabled": "Habilitado",
+      "disabled": "Deshabilitado",
+      "removeProfile": "Eliminar",
+      "slugLabel": "Slug",
+      "nameLabel": "Nombre",
+      "descriptionLabel": "Descripción",
+      "descriptionPlaceholder": "Descripción corta y legible",
+      "authMethodLabel": "Auth method",
+      "authMethodPlaceholder": "Selecciona o escribe el auth method",
+      "resolverLabel": "Resolver",
+      "resolverPlaceholder": "Selecciona o escribe el resolver",
+      "allowedOriginsLabel": "Origins permitidos",
+      "allowedOriginsPlaceholder": "https://app.ejemplo.com",
+      "allowedHeadersLabel": "Headers permitidos",
+      "allowedHeadersPlaceholder": "x-tenant-code",
+      "requiredHeadersLabel": "Headers requeridos",
+      "requiredHeadersPlaceholder": "x-tenant-code",
+      "capabilitiesLabel": "Capacidades",
+      "registeredAuthMethods": "Auth methods registrados",
+      "registeredResolvers": "Resolvers registrados",
+      "noAuthMethods": "Aún no hay auth methods registrados.",
+      "noResolvers": "Aún no hay resolvers registrados.",
+      "methodFallbackDescription": "Ingresa un nombre de método registrado.",
+      "capabilityLabels": {
+        "list_templates": "Listar templates",
+        "view_versions": "Ver versiones",
+        "edit_versions": "Editar versiones",
+        "publish_versions": "Publicar versiones",
+        "test_send": "Enviar prueba",
+        "builder_access": "Acceso al builder",
+        "metadata_access": "Acceso al metadata",
+        "locale_access": "Acceso a locales"
+      },
+      "capabilityDescriptions": {
+        "list_templates": "Permite listar el catálogo en la UI externa.",
+        "view_versions": "Permite navegar versiones en solo lectura.",
+        "edit_versions": "Permite editar borradores en el builder embebido.",
+        "publish_versions": "Permite publicar una versión.",
+        "test_send": "Permite enviar un email de prueba.",
+        "builder_access": "Permite abrir la shell embebida del builder.",
+        "metadata_access": "Permite editar los paneles de metadata del template.",
+        "locale_access": "Permite editar variantes por idioma."
+      }
+    },
     "global": {
       "loadErrorTitle": "No se pudo cargar la configuración",
       "loadErrorDescription": "No fue posible recuperar la configuración del sistema. Es posible que no tengas permisos de superadmin.",

--- a/web/public/external-embed-host/index.html
+++ b/web/public/external-embed-host/index.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>External Embed Host</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 0; padding: 24px; background: #f8fafc; color: #0f172a; }
+      .layout { display: grid; gap: 20px; }
+      .card { background: white; border: 1px solid #cbd5e1; border-radius: 12px; padding: 16px; box-shadow: 0 1px 2px rgba(0,0,0,.04); }
+      iframe { width: 100%; height: 900px; border: 1px solid #94a3b8; border-radius: 12px; background: white; }
+      code, pre { background: #0f172a; color: #e2e8f0; padding: 10px; border-radius: 8px; overflow: auto; }
+      .ok { color: #166534; font-weight: 600; }
+      .err { color: #b91c1c; font-weight: 600; }
+      .muted { color: #475569; }
+    </style>
+  </head>
+  <body>
+    <div class="layout">
+      <section class="card">
+        <h1>External Embed Host</h1>
+        <p class="muted">Simula una app externa que consume la API externa y monta el builder en un iframe.</p>
+        <div id="meta"></div>
+      </section>
+      <section class="card">
+        <h2>API fetch</h2>
+        <p id="api-status">Pending…</p>
+        <pre id="api-result"></pre>
+      </section>
+      <section class="card">
+        <h2>Builder iframe</h2>
+        <p id="iframe-status">Pending…</p>
+        <iframe id="builder-frame" title="External Builder"></iframe>
+      </section>
+    </div>
+    <script>
+      const qs = new URLSearchParams(window.location.search);
+      const frontendBase = qs.get('frontend');
+      const backendBase = qs.get('backend');
+      const profile = qs.get('profile') || 'partner-portal';
+      const tenant = qs.get('tenant') || 'test-corp';
+      const workspace = qs.get('workspace') || 'main';
+      const slug = qs.get('slug') || 'welcome-email';
+      const templateId = qs.get('templateId') || '';
+      const versionId = qs.get('versionId') || '';
+      const token = qs.get('token') || '';
+      const fallback = qs.get('fallback') || '';
+      const requiredHeader = qs.get('tenantHeader') !== '0';
+      const fetchMode = qs.get('fetch') || 'templates';
+      const badHeader = qs.get('badHeader') || '';
+
+      const meta = document.getElementById('meta');
+      const apiStatus = document.getElementById('api-status');
+      const apiResult = document.getElementById('api-result');
+      const iframeStatus = document.getElementById('iframe-status');
+      const iframe = document.getElementById('builder-frame');
+
+      meta.textContent = JSON.stringify({ frontendBase, backendBase, profile, tenant, workspace, slug, templateId, versionId, token, fallback, fetchMode }, null, 2);
+
+      function externalApiUrl() {
+        if (fetchMode === 'version' && templateId && versionId) {
+          return `${backendBase}/api/v1/external/${profile}/tenants/${tenant}/workspaces/${workspace}/templates/${templateId}/versions/${versionId}`;
+        }
+        return `${backendBase}/api/v1/external/${profile}/tenants/${tenant}/workspaces/${workspace}/template-types/${slug}/templates`;
+      }
+
+      async function runFetch() {
+        if (!backendBase) {
+          apiStatus.textContent = 'Missing backend query param';
+          apiStatus.className = 'err';
+          return;
+        }
+        const headers = { 'x-senda-external-token': token };
+        if (requiredHeader) headers['x-tenant-code'] = badHeader || tenant;
+        try {
+          const resp = await fetch(externalApiUrl(), { headers });
+          const text = await resp.text();
+          apiStatus.textContent = `HTTP ${resp.status}`;
+          apiStatus.className = resp.ok ? 'ok' : 'err';
+          apiResult.textContent = text;
+        } catch (error) {
+          apiStatus.textContent = `FETCH ERROR: ${error}`;
+          apiStatus.className = 'err';
+          apiResult.textContent = String(error?.stack || error);
+        }
+      }
+
+      function mountIframe() {
+        if (!frontendBase) {
+          iframeStatus.textContent = 'Missing frontend query param';
+          iframeStatus.className = 'err';
+          return;
+        }
+        const iframeUrl = new URL(`${frontendBase}/embed/${profile}/t/${tenant}/w/${workspace}/templates/${slug}/edit`);
+        if (templateId) iframeUrl.searchParams.set('templateId', templateId);
+        if (versionId) iframeUrl.searchParams.set('versionId', versionId);
+        if (token) iframeUrl.searchParams.set('token', token);
+        if (fallback) iframeUrl.searchParams.set('fallback', fallback);
+        iframe.addEventListener('load', () => {
+          iframeStatus.textContent = `loaded: ${iframe.src}`;
+          iframeStatus.className = 'ok';
+        }, { once: true });
+        iframe.src = iframeUrl.toString();
+      }
+
+      runFetch();
+      mountIframe();
+    </script>
+  </body>
+</html>

--- a/web/src/app/embed/[profileSlug]/t/[tenantCode]/w/[workspaceCode]/templates/[slug]/edit/page.tsx
+++ b/web/src/app/embed/[profileSlug]/t/[tenantCode]/w/[workspaceCode]/templates/[slug]/edit/page.tsx
@@ -1,0 +1,45 @@
+import { ExternalTemplateBuilderShell } from "@/components/templates/external-template-builder-shell";
+import { SYSTEM_WORKSPACE_CODE, type ScopeContext } from "@/types/api";
+
+interface ExternalTemplateBuilderPageProps {
+  params: Promise<{
+    profileSlug: string;
+    tenantCode: string;
+    workspaceCode: string;
+    slug: string;
+  }>;
+  searchParams: Promise<{
+    templateId?: string;
+    versionId?: string;
+    fallback?: string;
+    readonly?: string;
+  }>;
+}
+
+export default async function ExternalTemplateBuilderPage({
+  params,
+  searchParams,
+}: ExternalTemplateBuilderPageProps) {
+  const { profileSlug, tenantCode, workspaceCode, slug } = await params;
+  const query = await searchParams;
+
+  const scope: ScopeContext = {
+    level: "workspace",
+    tenantCode,
+    workspaceCode,
+  };
+
+  const fallbackToSystem =
+    workspaceCode === SYSTEM_WORKSPACE_CODE ||
+    query.fallback === "system" ||
+    query.readonly === "1";
+
+  return (
+    <ExternalTemplateBuilderShell
+      profileSlug={profileSlug}
+      templateSlug={slug}
+      scope={scope}
+      fallbackToSystem={fallbackToSystem}
+    />
+  );
+}

--- a/web/src/components/settings/external-integrations-section.tsx
+++ b/web/src/components/settings/external-integrations-section.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  ExternalIntegrationMethodDescriptor,
+  ExternalIntegrationProfile,
+  ExternalIntegrationsSettings,
+} from "@/types/settings";
+import {
+  EXTERNAL_INTEGRATION_CAPABILITY_KEYS,
+  createEmptyExternalIntegrationProfile,
+  findExternalIntegrationMethodDescription,
+  normalizeExternalIntegrationProfile,
+  parseDelimitedEntries,
+  stringifyDelimitedEntries,
+} from "@/lib/external-integration-profiles";
+
+interface ExternalIntegrationsSectionProps {
+  value: ExternalIntegrationsSettings;
+  onChange: (next: ExternalIntegrationsSettings) => void;
+}
+
+export function ExternalIntegrationsSection({
+  value,
+  onChange,
+}: ExternalIntegrationsSectionProps) {
+  const t = useTranslations("settingsPage.externalIntegrations");
+
+  const profiles = useMemo(
+    () =>
+      (value.profiles ?? []).map((profile, index) =>
+        normalizeExternalIntegrationProfile(profile, index + 1),
+      ),
+    [value.profiles],
+  );
+
+  const availableAuthMethods = value.available_auth_methods ?? [];
+  const availableResolvers = value.available_resolvers ?? [];
+
+  const updateProfiles = (nextProfiles: ExternalIntegrationProfile[]) => {
+    onChange({
+      ...value,
+      profiles: nextProfiles,
+    });
+  };
+
+  const addProfile = () => {
+    updateProfiles([...profiles, createEmptyExternalIntegrationProfile(profiles.length + 1)]);
+  };
+
+  const removeProfile = (index: number) => {
+    updateProfiles(profiles.filter((_, currentIndex) => currentIndex !== index));
+  };
+
+  const updateProfile = (
+    index: number,
+    updater: (profile: ExternalIntegrationProfile) => ExternalIntegrationProfile,
+  ) => {
+    updateProfiles(
+      profiles.map((profile, currentIndex) =>
+        currentIndex === index ? updater(profile) : profile,
+      ),
+    );
+  };
+
+  return (
+    <section className="rounded-lg border bg-card p-6 space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1.5">
+          <h2 className="text-base font-semibold tracking-[-0.02em]">
+            {t("title")}
+          </h2>
+          <p className="text-sm text-muted-foreground max-w-3xl">
+            {t("description")}
+          </p>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={addProfile}>
+          <Plus className="h-4 w-4" />
+          {t("addProfile")}
+        </Button>
+      </div>
+
+      {profiles.length > 0 ? (
+        <div className="space-y-4">
+          {profiles.map((profile, index) => (
+            <ProfileCard
+              key={`${profile.slug}-${index}`}
+              profile={profile}
+              index={index}
+              authMethods={availableAuthMethods}
+              resolvers={availableResolvers}
+              onRemove={() => removeProfile(index)}
+              onChange={(next) => updateProfile(index, () => next)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed bg-background px-4 py-8 text-center">
+          <h3 className="text-sm font-medium">{t("empty.title")}</h3>
+          <p className="mt-1 text-sm text-muted-foreground">{t("empty.description")}</p>
+          <Button type="button" variant="outline" size="sm" className="mt-4" onClick={addProfile}>
+            <Plus className="h-4 w-4" />
+            {t("addProfile")}
+          </Button>
+        </div>
+      )}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <DescriptorList
+          title={t("registeredAuthMethods")}
+          emptyLabel={t("noAuthMethods")}
+          items={availableAuthMethods}
+        />
+        <DescriptorList
+          title={t("registeredResolvers")}
+          emptyLabel={t("noResolvers")}
+          items={availableResolvers}
+        />
+      </div>
+    </section>
+  );
+}
+
+function ProfileCard({
+  profile,
+  index,
+  authMethods,
+  resolvers,
+  onRemove,
+  onChange,
+}: {
+  profile: ExternalIntegrationProfile;
+  index: number;
+  authMethods: ExternalIntegrationMethodDescriptor[];
+  resolvers: ExternalIntegrationMethodDescriptor[];
+  onRemove: () => void;
+  onChange: (next: ExternalIntegrationProfile) => void;
+}) {
+  const t = useTranslations("settingsPage.externalIntegrations");
+  const selectedAuthMethodDescription = findExternalIntegrationMethodDescription(
+    authMethods,
+    profile.auth_method_name,
+  );
+  const selectedResolverDescription = findExternalIntegrationMethodDescription(
+    resolvers,
+    profile.resolver_name,
+  );
+
+  return (
+    <article className="rounded-lg border bg-background p-4 shadow-sm space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-semibold">{t("profileTitle", { index: index + 1 })}</h3>
+            <Badge variant={profile.enabled ? "default" : "outline"}>
+              {profile.enabled ? t("enabled") : t("disabled")}
+            </Badge>
+          </div>
+          <p className="text-xs text-muted-foreground">{t("profileDescription")}</p>
+        </div>
+        <Button type="button" variant="ghost" size="sm" onClick={onRemove}>
+          <Trash2 className="h-4 w-4" />
+          {t("removeProfile")}
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field
+          label={t("slugLabel")}
+          value={profile.slug}
+          onChange={(slug) => onChange({ ...profile, slug })}
+          placeholder="external-builder"
+        />
+        <Field
+          label={t("nameLabel")}
+          value={profile.name}
+          onChange={(name) => onChange({ ...profile, name })}
+          placeholder="External builder"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-sm font-medium">{t("descriptionLabel")}</Label>
+        <textarea
+          value={profile.description}
+          onChange={(event) => onChange({ ...profile, description: event.target.value })}
+          rows={3}
+          className="min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+          placeholder={t("descriptionPlaceholder")}
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <MethodSelector
+          label={t("authMethodLabel")}
+          placeholder={t("authMethodPlaceholder")}
+          value={profile.auth_method_name}
+          options={authMethods}
+          onChange={(auth_method_name) => onChange({ ...profile, auth_method_name })}
+          description={
+            selectedAuthMethodDescription || t("methodFallbackDescription")
+          }
+        />
+        <MethodSelector
+          label={t("resolverLabel")}
+          placeholder={t("resolverPlaceholder")}
+          value={profile.resolver_name}
+          options={resolvers}
+          onChange={(resolver_name) => onChange({ ...profile, resolver_name })}
+          description={
+            selectedResolverDescription || t("methodFallbackDescription")
+          }
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <ListField
+          label={t("allowedOriginsLabel")}
+          value={profile.allowed_origins}
+          placeholder={t("allowedOriginsPlaceholder")}
+          onChange={(next) =>
+            onChange({ ...profile, allowed_origins: parseDelimitedEntries(next) })
+          }
+        />
+        <ListField
+          label={t("allowedHeadersLabel")}
+          value={profile.allowed_headers}
+          placeholder={t("allowedHeadersPlaceholder")}
+          onChange={(next) =>
+            onChange({ ...profile, allowed_headers: parseDelimitedEntries(next) })
+          }
+        />
+        <ListField
+          label={t("requiredHeadersLabel")}
+          value={profile.required_headers}
+          placeholder={t("requiredHeadersPlaceholder")}
+          onChange={(next) =>
+            onChange({ ...profile, required_headers: parseDelimitedEntries(next) })
+          }
+        />
+      </div>
+
+      <div className="space-y-3">
+        <Label className="text-sm font-medium">{t("capabilitiesLabel")}</Label>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {EXTERNAL_INTEGRATION_CAPABILITY_KEYS.map((key) => (
+            <CapabilityToggle
+              key={key}
+              capability={key}
+              checked={profile.capabilities[key]}
+              onChange={(checked) =>
+                onChange({
+                  ...profile,
+                  capabilities: {
+                    ...profile.capabilities,
+                    [key]: checked,
+                  },
+                })
+              }
+            />
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-sm font-medium">{label}</Label>
+      <Input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="h-9 text-sm"
+      />
+    </div>
+  );
+}
+
+function ListField({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string[];
+  onChange: (value: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-sm font-medium">{label}</Label>
+      <textarea
+        value={stringifyDelimitedEntries(value)}
+        onChange={(event) => onChange(event.target.value)}
+        rows={5}
+        className="min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+        placeholder={placeholder}
+      />
+      <p className="text-xs text-muted-foreground">
+        {value.length} {value.length === 1 ? "entry" : "entries"}
+      </p>
+    </div>
+  );
+}
+
+function MethodSelector({
+  label,
+  placeholder,
+  value,
+  options,
+  description,
+  onChange,
+}: {
+  label: string;
+  placeholder: string;
+  value: string;
+  options: ExternalIntegrationMethodDescriptor[];
+  description: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-sm font-medium">{label}</Label>
+      {options.length > 0 ? (
+        <Select value={value} onValueChange={onChange}>
+          <SelectTrigger className="h-9 w-full">
+            <SelectValue placeholder={placeholder} />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((option) => (
+              <SelectItem key={option.name} value={option.name}>
+                {option.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : (
+        <Input
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={placeholder}
+          className="h-9 text-sm"
+        />
+      )}
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+function CapabilityToggle({
+  capability,
+  checked,
+  onChange,
+}: {
+  capability: (typeof EXTERNAL_INTEGRATION_CAPABILITY_KEYS)[number];
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  const t = useTranslations("settingsPage.externalIntegrations");
+
+  return (
+    <label className="flex items-start gap-3 rounded-lg border bg-muted/20 p-3">
+      <input
+        type="checkbox"
+        className="mt-0.5 h-4 w-4 rounded border-border"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      <span className="space-y-1">
+        <span className="block text-sm font-medium text-foreground">
+          {t(`capabilityLabels.${capability}`)}
+        </span>
+        <span className="block text-xs text-muted-foreground">
+          {t(`capabilityDescriptions.${capability}`)}
+        </span>
+      </span>
+    </label>
+  );
+}
+
+function DescriptorList({
+  title,
+  emptyLabel,
+  items,
+}: {
+  title: string;
+  emptyLabel: string;
+  items: ExternalIntegrationMethodDescriptor[];
+}) {
+  return (
+    <div className="rounded-lg border bg-background p-4 space-y-3">
+      <h3 className="text-sm font-semibold">{title}</h3>
+      {items.length > 0 ? (
+        <div className="space-y-2">
+          {items.map((item) => (
+            <div key={item.name} className="rounded-md border bg-card p-3">
+              <p className="text-sm font-medium">{item.name}</p>
+              <p className="text-xs text-muted-foreground">{item.description}</p>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">{emptyLabel}</p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/settings/settings-content.tsx
+++ b/web/src/components/settings/settings-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useMinimumLoading } from "@/hooks/use-minimum-loading";
 import { type UseFormRegisterReturn, useForm } from "react-hook-form";
 import { Save, ShieldAlert } from "lucide-react";
@@ -16,6 +16,7 @@ import {
   useUpdateSettings,
   useUpdateWorkspacePolicies,
 } from "@/hooks/use-settings";
+import { ExternalIntegrationsSection } from "@/components/settings/external-integrations-section";
 import { SettingsSection } from "@/components/settings/settings-section";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -26,7 +27,9 @@ import { ThemeSelector } from "@/components/shared/theme-selector";
 import type {
   UpdateSettingsRequest,
   UpdateWorkspacePoliciesRequest,
+  ExternalIntegrationsSettings,
 } from "@/types/settings";
+import { normalizeExternalIntegrationSettings } from "@/lib/external-integration-profiles";
 import { useTranslations } from "next-intl";
 
 interface SettingsFormValues {
@@ -116,6 +119,10 @@ function GlobalSettingsContent({
   const isLoading = useMinimumLoading(rawLoading);
   const updateSettings = useUpdateSettings();
   const { register, handleSubmit, reset } = useForm<SettingsFormValues>();
+  const [externalIntegrations, setExternalIntegrations] =
+    useState<ExternalIntegrationsSettings>(
+      normalizeExternalIntegrationSettings(data?.external_integrations),
+    );
 
   useEffect(() => {
     if (data) {
@@ -126,6 +133,10 @@ function GlobalSettingsContent({
         bounce_threshold_percent: data.alerts.bounce_threshold_percent,
         complaint_threshold_percent: data.alerts.complaint_threshold_percent,
       });
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- hydrate local external profile form state from server data
+      setExternalIntegrations(
+        normalizeExternalIntegrationSettings(data.external_integrations),
+      );
     }
   }, [data, reset]);
 
@@ -151,6 +162,9 @@ function GlobalSettingsContent({
       alerts: {
         bounce_threshold_percent: Number(values.bounce_threshold_percent),
         complaint_threshold_percent: Number(values.complaint_threshold_percent),
+      },
+      external_integrations: {
+        profiles: externalIntegrations.profiles,
       },
     };
 
@@ -219,6 +233,11 @@ function GlobalSettingsContent({
           </div>
         </div>
       </SettingsSection>
+
+      <ExternalIntegrationsSection
+        value={externalIntegrations}
+        onChange={setExternalIntegrations}
+      />
 
       {/* Alerts Section */}
       <SettingsSection title={tSettings("global.alertsTitle")}>

--- a/web/src/components/templates/external-embed-token-bridge.tsx
+++ b/web/src/components/templates/external-embed-token-bridge.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  captureExternalEmbedTokenFromSearch,
+  EXTERNAL_EMBED_TOKEN_CHANGED_EVENT,
+  isExternalEmbedPath,
+} from "@/lib/external-api-context";
+
+export function ExternalEmbedTokenBridge() {
+  useEffect(() => {
+    if (!isExternalEmbedPath(window.location.pathname)) {
+      return;
+    }
+
+    const { token, cleanedSearch } = captureExternalEmbedTokenFromSearch(
+      window.location.search,
+      window.sessionStorage,
+    );
+
+    if (token) {
+      const nextUrl = new URL(window.location.href);
+      nextUrl.search = cleanedSearch;
+      window.history.replaceState(window.history.state, "", `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`);
+      window.dispatchEvent(new Event(EXTERNAL_EMBED_TOKEN_CHANGED_EVENT));
+    }
+  }, []);
+
+  return null;
+}

--- a/web/src/components/templates/external-template-builder-shell.tsx
+++ b/web/src/components/templates/external-template-builder-shell.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { HTTPError } from "ky";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/shared/empty-state";
+import { ScopeIndicator } from "@/components/shared/scope-indicator";
+import { MjmlEditor } from "@/components/templates/mjml-editor";
+import { ExternalEmbedTokenBridge } from "@/components/templates/external-embed-token-bridge";
+import type { ScopeContext } from "@/types/api";
+import { ShieldAlert, LoaderCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  resolveExternalTemplateBuilderViewState,
+  type ExternalEmbedSessionState,
+} from "@/lib/external-template-builder";
+import { useApi, useApiReady } from "@/hooks/use-api";
+
+interface ExternalTemplateBuilderShellProps {
+  profileSlug: string;
+  templateSlug: string;
+  scope: ScopeContext;
+  fallbackToSystem?: boolean;
+}
+
+export function ExternalTemplateBuilderShell({
+  profileSlug,
+  templateSlug,
+  scope,
+  fallbackToSystem,
+}: ExternalTemplateBuilderShellProps) {
+  const t = useTranslations("externalBuilderPage");
+  const api = useApi();
+  const apiReady = useApiReady();
+  const sessionPath =
+    scope.tenantCode && scope.workspaceCode
+      ? `external/${profileSlug}/tenants/${scope.tenantCode}/workspaces/${scope.workspaceCode}/session`
+      : null;
+  const sessionQuery = useQuery({
+    queryKey: ["external-builder-session", sessionPath],
+    queryFn: () => api.get(sessionPath!).json<ExternalEmbedSessionState>(),
+    enabled: apiReady && !!sessionPath,
+    retry: false,
+  });
+  const accessDenied =
+    sessionQuery.error instanceof HTTPError &&
+    (sessionQuery.error.response.status === 401 ||
+      sessionQuery.error.response.status === 403);
+  const viewState = resolveExternalTemplateBuilderViewState({
+    profileSlug,
+    scope,
+    fallbackToSystem,
+    session: sessionQuery.data,
+    accessDenied,
+  });
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <ExternalEmbedTokenBridge />
+      <header className="border-b bg-card/70 px-6 py-4 backdrop-blur">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-lg font-semibold tracking-[-0.02em]">
+                {t("title")}
+              </h1>
+              <Badge variant="outline">{profileSlug}</Badge>
+              <Badge variant="secondary">{templateSlug}</Badge>
+              <ScopeIndicator
+                scope={viewState.readOnly ? "system" : "workspace"}
+                label={viewState.workspaceLabel}
+              />
+              {viewState.readOnly ? (
+                <Badge variant="secondary">{t("readOnlyBadge")}</Badge>
+              ) : null}
+            </div>
+            <p className="text-sm text-muted-foreground">{t("description")}</p>
+          </div>
+          <div className="text-right text-xs text-muted-foreground">
+            <p className="font-medium text-foreground">{t("profileLabel")}</p>
+            <p>{profileSlug}</p>
+          </div>
+        </div>
+      </header>
+
+      {viewState.readOnly && !viewState.accessDenied ? (
+        <div className="border-b border-sky-500/30 bg-sky-500/10 px-6 py-3 text-sm text-sky-900 dark:text-sky-100">
+          <p className="font-medium">{t("readOnlyFallbackTitle")}</p>
+          <p>{t("readOnlyFallbackDescription")}</p>
+        </div>
+      ) : null}
+
+      <div className="flex-1 min-h-0">
+        {sessionQuery.isLoading || (apiReady && sessionPath && !sessionQuery.data && !sessionQuery.error) ? (
+          <div className="flex h-full items-center justify-center px-6 py-10">
+            <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              <LoaderCircle className="h-4 w-4 animate-spin" />
+              <span>{t("loadingAccessState")}</span>
+            </div>
+          </div>
+        ) : null}
+        {viewState.accessDenied ? (
+          <EmptyState
+            icon={ShieldAlert}
+            title={t("accessDenied.title")}
+            description={t("accessDenied.description")}
+            className="py-20"
+          />
+        ) : null}
+        {!viewState.accessDenied && !(sessionQuery.isLoading || (apiReady && sessionPath && !sessionQuery.data && !sessionQuery.error)) ? (
+        <MjmlEditor
+          embedded
+          forceReadOnly={viewState.readOnly}
+          lockEditing={!viewState.canEdit}
+          canPublish={viewState.canPublish}
+          canSendTest={viewState.canTestSend}
+          showBulkSend={false}
+        />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -221,6 +221,15 @@ type BuilderDocument = {
 
 type EditorMode = "visual" | "code";
 
+interface MjmlEditorProps {
+  embedded?: boolean;
+  forceReadOnly?: boolean;
+  lockEditing?: boolean;
+  canPublish?: boolean;
+  canSendTest?: boolean;
+  showBulkSend?: boolean;
+}
+
 type TemplateVariable = {
   id: string;
   token: string;
@@ -1639,8 +1648,16 @@ function makeVariableToken(name: string, category: "event" | "injector") {
 }
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-export function MjmlEditor() {
+export function MjmlEditor({
+  embedded = false,
+  forceReadOnly = false,
+  lockEditing = false,
+  canPublish: canPublishOverride,
+  canSendTest: canSendTestOverride,
+  showBulkSend = true,
+}: MjmlEditorProps = {}) {
   const t = useTranslations("editor");
+  const tExternal = useTranslations("externalBuilderPage");
 
   const defaultBlockLabel: Record<BuilderBlockType, string> = {
     text: t("blocks.text"),
@@ -1732,7 +1749,7 @@ export function MjmlEditor() {
   const [previewFrameUrl, setPreviewFrameUrl] = useState("");
   const [showPublishConfirm, setShowPublishConfirm] = useState(false);
   const [showTestSend, setShowTestSend] = useState(false);
-  const [showBulkSend, setShowBulkSend] = useState(false);
+  const [showBulkSendModal, setShowBulkSendModal] = useState(false);
   const [activeLocale, setActiveLocale] = useState<string>("default");
   const activeLocaleRef = useRef(activeLocale);
   useEffect(() => { activeLocaleRef.current = activeLocale; }, [activeLocale]);
@@ -1751,8 +1768,6 @@ export function MjmlEditor() {
   const resizeRef = useRef<{ startX: number; startWidth: number } | null>(
     null
   );
-  const bulkSendEnabled = scope.level === "workspace";
-
   const [builderDocument, setBuilderDocument] = useState<BuilderDocument | null>(
     null
   );
@@ -1813,7 +1828,21 @@ export function MjmlEditor() {
   });
 
   const isDraft = version?.status === "draft";
-  const canEditDraft = Boolean(isDraft && templateState.canManageVersions);
+  const canEditDraft = Boolean(
+    isDraft && templateState.canManageVersions && !lockEditing,
+  );
+  const isReadOnlyMode = forceReadOnly || !canEditDraft;
+  const canMutate = canEditDraft && !forceReadOnly;
+  const canSendTest =
+    testSendAvailability.enabled &&
+    !forceReadOnly &&
+    (canSendTestOverride ?? true);
+  const canPublish = canMutate && (canPublishOverride ?? true);
+  const testSendDisabledReason =
+    canSendTestOverride === false
+      ? tExternal("testSendDisabledByPermissions")
+      : testSendAvailability.reason;
+  const bulkSendEnabled = showBulkSend && scope.level === "workspace" && !forceReadOnly;
 
   const autoSave = useAutoSave({
     getPayload: () => {
@@ -3518,12 +3547,14 @@ export function MjmlEditor() {
       <div className="flex flex-col gap-2 px-6 py-3 border-b bg-card shrink-0">
         <div className="flex items-center justify-between h-14">
           <div className="flex items-center gap-3">
-            <button
-              onClick={() => router.push(buildBackPath())}
-              className="text-muted-foreground hover:text-foreground"
-            >
-              <ArrowLeft className="h-5 w-5" />
-            </button>
+            {!embedded ? (
+              <button
+                onClick={() => router.push(buildBackPath())}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <ArrowLeft className="h-5 w-5" />
+              </button>
+            ) : null}
             <div className="flex items-center gap-2 text-sm">
               <span className="text-muted-foreground">Templates</span>
               <span className="text-muted-foreground">/</span>
@@ -3646,7 +3677,7 @@ export function MjmlEditor() {
                 </Button>
               </>
             )}
-            {testSendAvailability.enabled ? (
+            {canSendTest ? (
               <Button
                 variant="outline"
                 size="sm"
@@ -3666,37 +3697,24 @@ export function MjmlEditor() {
                   </span>
                 </TooltipTrigger>
                 <TooltipContent>
-                  {testSendAvailability.reason}
+                  {testSendDisabledReason}
                 </TooltipContent>
               </Tooltip>
             )}
-            <div className="mx-1 h-6 w-px bg-border" />
             {bulkSendEnabled ? (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowBulkSend(true)}
-              >
-                <List className="h-4 w-4 mr-1.5" />
-                Bulk Send
-              </Button>
-            ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span>
-                    <Button variant="outline" size="sm" disabled>
-                      <List className="h-4 w-4 mr-1.5" />
-                      Bulk Send
-                    </Button>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>
-                  Bulk send is available only in workspace scope because it reuses the workspace
-                  queueing flow.
-                </TooltipContent>
-              </Tooltip>
-            )}
-            {canEditDraft && (
+              <>
+                <div className="mx-1 h-6 w-px bg-border" />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowBulkSendModal(true)}
+                >
+                  <List className="h-4 w-4 mr-1.5" />
+                  Bulk Send
+                </Button>
+              </>
+            ) : null}
+            {canPublish && (
               <Button size="sm" onClick={() => setShowPublishConfirm(true)}>
                 <Rocket className="h-4 w-4 mr-1.5" />
                 Publish
@@ -3706,7 +3724,11 @@ export function MjmlEditor() {
         </div>
       </div>
 
-      {isDraft && !canEditDraft ? (
+      {forceReadOnly ? (
+        <div className="mx-4 rounded-lg border border-sky-500/30 bg-sky-500/10 px-4 py-3 text-sm text-sky-900 dark:text-sky-200">
+          {tExternal("readOnlyFallbackDescription")}
+        </div>
+      ) : isDraft && !canEditDraft ? (
         <div className="mx-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
           This draft is visible in this workspace but locked for editing. Fork
           the default template or enable workspace version management from the
@@ -4096,7 +4118,7 @@ export function MjmlEditor() {
                                 <button
                                   type="button"
                                   className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded hover:bg-muted cursor-grab active:cursor-grabbing"
-                                  draggable={canEditDraft}
+                                  draggable={!isReadOnlyMode}
                                   onDragStart={(event) =>
                                     onBlockHandleDragStart(event, block.id)
                                   }
@@ -4120,7 +4142,7 @@ export function MjmlEditor() {
                                     }
                                   }}
                                   onClick={(ev) => ev.stopPropagation()}
-                                  readOnly={!canEditDraft}
+                                  readOnly={isReadOnlyMode}
                                 />
                               </div>
                               {canEditDraft ? (
@@ -4165,7 +4187,7 @@ export function MjmlEditor() {
                                         delete blockEditorRefs.current[block.id];
                                       }
                                     }}
-                                    contentEditable={canEditDraft}
+                                    contentEditable={!isReadOnlyMode}
                                     suppressContentEditableWarning
                                     className="min-h-6 w-full whitespace-pre-wrap break-words text-sm font-mono outline-none empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground"
                                     data-placeholder={t("textPlaceholder")}
@@ -4202,7 +4224,7 @@ export function MjmlEditor() {
                                   onChange={(ev) =>
                                     updateButtonHref(block.id, ev.target.value)
                                   }
-                                  readOnly={!canEditDraft}
+                                  readOnly={isReadOnlyMode}
                                 />
                               </div>
                             ) : null}
@@ -4216,7 +4238,7 @@ export function MjmlEditor() {
                                   onChange={(ev) =>
                                     updateImageBlock(block.id, "src", ev.target.value)
                                   }
-                                  readOnly={!canEditDraft}
+                                  readOnly={isReadOnlyMode}
                                 />
                                 <Label className="text-xs mt-2">Alt</Label>
                                 <Input
@@ -4225,7 +4247,7 @@ export function MjmlEditor() {
                                   onChange={(ev) =>
                                     updateImageBlock(block.id, "alt", ev.target.value)
                                   }
-                                  readOnly={!canEditDraft}
+                                  readOnly={isReadOnlyMode}
                                 />
                                 <Label className="text-xs mt-2">Width</Label>
                                 <Input
@@ -4234,7 +4256,7 @@ export function MjmlEditor() {
                                   onChange={(ev) =>
                                     updateImageBlock(block.id, "width", ev.target.value)
                                   }
-                                  readOnly={!canEditDraft}
+                                  readOnly={isReadOnlyMode}
                                 />
                               </>
                             ) : null}
@@ -4254,7 +4276,7 @@ export function MjmlEditor() {
                                       Number.parseInt(ev.target.value, 10)
                                     )
                                   }
-                                  readOnly={!canEditDraft}
+                                  readOnly={isReadOnlyMode}
                                 />
                               </>
                             ) : null}
@@ -4274,7 +4296,7 @@ export function MjmlEditor() {
                                     className="h-8 mt-1"
                                     placeholder="https://example.com/hero.jpg"
                                     onChange={(ev) => updateBannerBlock(block.id, "backgroundUrl", ev.target.value)}
-                                    readOnly={!canEditDraft}
+                                    readOnly={isReadOnlyMode}
                                   />
                                 </div>
                                 <div className="flex gap-2">
@@ -4285,7 +4307,7 @@ export function MjmlEditor() {
                                       value={block.backgroundColor}
                                       className="h-8 mt-1 w-16"
                                       onChange={(ev) => updateBannerBlock(block.id, "backgroundColor", ev.target.value)}
-                                      readOnly={!canEditDraft}
+                                      readOnly={isReadOnlyMode}
                                     />
                                   </div>
                                   <div className="flex-1">
@@ -4310,7 +4332,7 @@ export function MjmlEditor() {
                                       value={block.height}
                                       className="h-8 mt-1"
                                       onChange={(ev) => updateBannerBlock(block.id, "height", Number.parseInt(ev.target.value, 10) || 400)}
-                                      readOnly={!canEditDraft}
+                                      readOnly={isReadOnlyMode}
                                     />
                                   </div>
                                 )}
@@ -4325,7 +4347,7 @@ export function MjmlEditor() {
                                           delete blockEditorRefs.current[block.id];
                                         }
                                       }}
-                                      contentEditable={canEditDraft}
+                                      contentEditable={!isReadOnlyMode}
                                       suppressContentEditableWarning
                                       className="min-h-6 w-full whitespace-pre-wrap break-words text-sm font-mono outline-none empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground"
                                       data-placeholder="Headline text..."
@@ -4358,7 +4380,7 @@ export function MjmlEditor() {
                                     className="h-8 mt-1"
                                     placeholder="Leave empty for no button"
                                     onChange={(ev) => updateBannerBlock(block.id, "buttonText", ev.target.value)}
-                                    readOnly={!canEditDraft}
+                                    readOnly={isReadOnlyMode}
                                   />
                                 </div>
                                 {block.buttonText && (
@@ -4369,7 +4391,7 @@ export function MjmlEditor() {
                                         value={block.buttonHref}
                                         className="h-8 mt-1"
                                         onChange={(ev) => updateBannerBlock(block.id, "buttonHref", ev.target.value)}
-                                        readOnly={!canEditDraft}
+                                        readOnly={isReadOnlyMode}
                                       />
                                     </div>
                                     <div>
@@ -4379,7 +4401,7 @@ export function MjmlEditor() {
                                         value={block.buttonColor}
                                         className="h-8 mt-1 w-16"
                                         onChange={(ev) => updateBannerBlock(block.id, "buttonColor", ev.target.value)}
-                                        readOnly={!canEditDraft}
+                                        readOnly={isReadOnlyMode}
                                       />
                                     </div>
                                   </div>
@@ -4406,7 +4428,7 @@ export function MjmlEditor() {
                                       value={block.padding}
                                       className="h-8 mt-1"
                                       onChange={(ev) => updateBannerBlock(block.id, "padding", Number.parseInt(ev.target.value, 10) || 0)}
-                                      readOnly={!canEditDraft}
+                                      readOnly={isReadOnlyMode}
                                     />
                                   </div>
                                 </div>
@@ -4437,7 +4459,7 @@ export function MjmlEditor() {
                                         }),
                                       });
                                     }}
-                                    readOnly={!canEditDraft}
+                                    readOnly={isReadOnlyMode}
                                   />
                                 </div>
                                 <div>
@@ -4447,7 +4469,7 @@ export function MjmlEditor() {
                                     className="h-8 mt-1"
                                     placeholder="https://img.youtube.com/vi/ID/maxresdefault.jpg"
                                     onChange={(ev) => updateVideoBlock(block.id, "thumbnailUrl", ev.target.value)}
-                                    readOnly={!canEditDraft}
+                                    readOnly={isReadOnlyMode}
                                   />
                                 </div>
                                 {block.thumbnailUrl && (
@@ -4471,7 +4493,7 @@ export function MjmlEditor() {
                                     value={block.alt}
                                     className="h-8 mt-1"
                                     onChange={(ev) => updateVideoBlock(block.id, "alt", ev.target.value)}
-                                    readOnly={!canEditDraft}
+                                    readOnly={isReadOnlyMode}
                                   />
                                 </div>
                                 <div>
@@ -4481,7 +4503,7 @@ export function MjmlEditor() {
                                     className="h-8 mt-1"
                                     placeholder="100%"
                                     onChange={(ev) => updateVideoBlock(block.id, "width", ev.target.value)}
-                                    readOnly={!canEditDraft}
+                                    readOnly={isReadOnlyMode}
                                   />
                                 </div>
                               </div>
@@ -4580,7 +4602,7 @@ export function MjmlEditor() {
                                               onChange={(ev) =>
                                                 updateListItemSegments(block.id, item.id, ev.target.value)
                                               }
-                                              readOnly={!canEditDraft}
+                                              readOnly={isReadOnlyMode}
                                             />
                                             {canEditDraft && (
                                               <div className="flex items-center gap-0.5 shrink-0">
@@ -4679,7 +4701,7 @@ export function MjmlEditor() {
                   <MonacoEditorWrapper
                     value={codeMjml}
                     onChange={handleCodeChange}
-                    readOnly={!canEditDraft}
+                    readOnly={isReadOnlyMode}
                   />
                 </div>
               </div>
@@ -4710,7 +4732,7 @@ export function MjmlEditor() {
                 <Input
                   {...register("subject")}
                   className="h-8 text-sm"
-                  readOnly={!canEditDraft}
+                  readOnly={isReadOnlyMode}
                 />
                 {errors.subject && (
                   <span className="text-xs text-destructive">
@@ -4723,7 +4745,7 @@ export function MjmlEditor() {
                 <Input
                   {...register("preview_text")}
                   className="h-8 text-sm"
-                  readOnly={!canEditDraft}
+                  readOnly={isReadOnlyMode}
                 />
               </div>
               <div className="flex flex-col gap-1.5">
@@ -4731,7 +4753,7 @@ export function MjmlEditor() {
                 <Input
                   {...register("from_name")}
                   className="h-8 text-sm"
-                  readOnly={!canEditDraft}
+                  readOnly={isReadOnlyMode}
                 />
                 {errors.from_name && (
                   <span className="text-xs text-destructive">
@@ -4745,7 +4767,7 @@ export function MjmlEditor() {
                   <Input
                     {...register("reply_to")}
                     className="h-8 text-sm"
-                    readOnly={!canEditDraft}
+                    readOnly={isReadOnlyMode}
                   />
                 </div>
               )}
@@ -4843,18 +4865,20 @@ export function MjmlEditor() {
         scopedPath={scopedPath}
         templateId={templateId}
         locale={activeLocale === "default" ? undefined : activeLocale}
-        sendEnabled={testSendAvailability.enabled}
+        sendEnabled={canSendTest}
         sendDisabledReason={testSendAvailability.reason}
         allowedInjectorUsage={usedInjectorUsage}
       />
 
-      <BulkSendModal
-        open={showBulkSend}
-        onOpenChange={setShowBulkSend}
-        scopedPath={scopedPath}
-        templateId={templateId}
-        enabled={bulkSendEnabled}
-      />
+      {bulkSendEnabled ? (
+        <BulkSendModal
+          open={showBulkSendModal}
+          onOpenChange={setShowBulkSendModal}
+          scopedPath={scopedPath}
+          templateId={templateId}
+          enabled={bulkSendEnabled}
+        />
+      ) : null}
     </div>
   );
 }

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -1,25 +1,64 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { useMemo } from "react";
+import { useMemo, useSyncExternalStore } from "react";
+import { usePathname } from "next/navigation";
 import { api, createAuthenticatedApi } from "@/lib/api";
+import {
+  EXTERNAL_EMBED_TOKEN_CHANGED_EVENT,
+  isExternalEmbedPath,
+  readExternalEmbedToken,
+} from "@/lib/external-api-context";
 import type { KyInstance } from "ky";
 
 /**
  * Returns an authenticated ky instance using the current session's id_token.
  * Falls back to the base (unauthenticated) instance if no session.
- * Also returns `isReady` to indicate whether the session has loaded.
  */
 export function useApi(): KyInstance {
+  const pathname = usePathname();
   const { data: session } = useSession();
   const idToken = session?.idToken;
+  const externalEmbedReady = useExternalEmbedReady(pathname);
 
   return useMemo(() => {
+    if (externalEmbedReady) {
+      return api;
+    }
     if (idToken) {
       return createAuthenticatedApi(idToken);
     }
     return api;
-  }, [idToken]);
+  }, [externalEmbedReady, idToken]);
+}
+
+export function useExternalEmbedReady(pathname: string): boolean {
+  return useSyncExternalStore(
+    (onStoreChange) => {
+      if (typeof window === "undefined") {
+        return () => undefined;
+      }
+
+      window.addEventListener(EXTERNAL_EMBED_TOKEN_CHANGED_EVENT, onStoreChange);
+      window.addEventListener("storage", onStoreChange);
+
+      return () => {
+        window.removeEventListener(
+          EXTERNAL_EMBED_TOKEN_CHANGED_EVENT,
+          onStoreChange,
+        );
+        window.removeEventListener("storage", onStoreChange);
+      };
+    },
+    () => {
+      if (!isExternalEmbedPath(pathname)) {
+        return false;
+      }
+
+      return readExternalEmbedToken() !== null;
+    },
+    () => false,
+  );
 }
 
 /**
@@ -28,7 +67,14 @@ export function useApi(): KyInstance {
  * Returns false if the session has a refresh token error.
  */
 export function useApiReady(): boolean {
+  const pathname = usePathname();
   const { data: session, status } = useSession();
+  const externalReady = useExternalEmbedReady(pathname);
+
+  if (externalReady) {
+    return true;
+  }
+
   return (
     status === "authenticated" &&
     !!session?.idToken &&

--- a/web/src/hooks/use-scope.ts
+++ b/web/src/hooks/use-scope.ts
@@ -2,6 +2,7 @@
 
 import { useParams } from "next/navigation";
 import type { ScopeContext, ScopeLevel } from "@/types/api";
+import { resolveScopedPathFromParams } from "@/lib/external-api-context";
 
 /**
  * Extract scope context from URL params.
@@ -13,6 +14,7 @@ import type { ScopeContext, ScopeLevel } from "@/types/api";
  */
 export function useScope(): ScopeContext {
   const params = useParams<{
+    profileSlug?: string;
     tenantCode?: string;
     workspaceCode?: string;
   }>();
@@ -36,14 +38,11 @@ export function useScope(): ScopeContext {
  * Build the management API base path for the current scope.
  */
 export function useScopedPath(): string {
-  const { level, tenantCode, workspaceCode } = useScope();
+  const params = useParams<{
+    profileSlug?: string;
+    tenantCode?: string;
+    workspaceCode?: string;
+  }>();
 
-  switch (level) {
-    case "global":
-      return "manage/global";
-    case "tenant":
-      return `manage/tenants/${tenantCode}`;
-    case "workspace":
-      return `manage/tenants/${tenantCode}/workspaces/${workspaceCode}`;
-  }
+  return resolveScopedPathFromParams(params);
 }

--- a/web/src/hooks/use-settings.ts
+++ b/web/src/hooks/use-settings.ts
@@ -2,10 +2,12 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useApi, useApiReady } from "@/hooks/use-api";
+import { useParams } from "next/navigation";
 import {
   canManageSystemWorkspacePolicies,
   isWorkspaceScope,
 } from "@/lib/workspace-resource-policies";
+import { resolveWorkspacePoliciesPathFromParams } from "@/lib/external-api-context";
 import { type ScopeContext } from "@/types/api";
 import type {
   SystemSettings,
@@ -84,11 +86,21 @@ export function useUpdateWorkspacePolicies(
 }
 
 export function useResolvedWorkspacePolicies(scope: ScopeContext) {
-  const query = useWorkspacePolicies(
-    scope.tenantCode,
-    scope.workspaceCode,
-    isWorkspaceScope(scope),
-  );
+  const params = useParams<{
+    profileSlug?: string;
+    tenantCode?: string;
+    workspaceCode?: string;
+  }>();
+  const policiesPath = resolveWorkspacePoliciesPathFromParams(params);
+  const api = useApi();
+  const ready = useApiReady();
+
+  const query = useQuery({
+    queryKey: ["workspace-policies", policiesPath],
+    queryFn: () => api.get(policiesPath!).json<WorkspacePolicies>(),
+    enabled: ready && isWorkspaceScope(scope) && !!policiesPath,
+    retry: false,
+  });
 
   return {
     ...query,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,6 @@
 import ky, { type Options, type KyInstance, HTTPError } from "ky";
 import type { ApiError } from "@/types/api";
+import { buildExternalEmbedApiRequest } from "@/lib/external-api-context";
 
 /**
  * Base ky instance for Senda API.
@@ -38,6 +39,25 @@ export const api = ky.create({
         // Only trigger logout if the session itself reports RefreshTokenError
         // (handled by SessionGuard, not here).
         // 401 after retry — let error propagate. SessionGuard handles real auth failures.
+      },
+    ],
+    beforeRequest: [
+      ({ request }) => {
+        if (typeof window === "undefined") {
+          return;
+        }
+
+        const nextRequest = buildExternalEmbedApiRequest(
+          request,
+          window.location.pathname,
+          undefined,
+          window.location.search,
+        );
+        if (!nextRequest) {
+          return;
+        }
+
+        return nextRequest;
       },
     ],
   },

--- a/web/src/lib/external-api-context.test.ts
+++ b/web/src/lib/external-api-context.test.ts
@@ -1,0 +1,219 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildExternalEmbedApiRequest,
+  captureExternalEmbedTokenFromSearch,
+  clearExternalEmbedToken,
+  EXTERNAL_EMBED_TOKEN_HEADER,
+  EXTERNAL_EMBED_TOKEN_STORAGE_KEY,
+  EXTERNAL_TENANT_HEADER,
+  isExternalEmbedPath,
+  isExternalEmbedRuntimeReady,
+  readExternalEmbedToken,
+  resolveScopedPathFromParams,
+  resolveWorkspacePoliciesPathFromParams,
+  storeExternalEmbedToken,
+  stripExternalEmbedTokenFromSearch,
+} from "./external-api-context.ts";
+
+const SIGNED_TOKEN = "signed-token";
+
+function createStorage(initial: Record<string, string> = {}) {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem(key: string) {
+      return data.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      data.set(key, value);
+    },
+    removeItem(key: string) {
+      data.delete(key);
+    },
+  };
+}
+
+test("resolveScopedPathFromParams returns external path for embed params", () => {
+  assert.equal(
+    resolveScopedPathFromParams({
+      profileSlug: "partner-portal",
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+    }),
+    "external/partner-portal/tenants/acme/workspaces/marketing",
+  );
+});
+
+test("resolveScopedPathFromParams keeps management paths for regular scopes", () => {
+  assert.equal(
+    resolveScopedPathFromParams({
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+    }),
+    "manage/tenants/acme/workspaces/marketing",
+  );
+  assert.equal(
+    resolveScopedPathFromParams({ tenantCode: "acme" }),
+    "manage/tenants/acme",
+  );
+  assert.equal(resolveScopedPathFromParams({}), "manage/global");
+});
+
+test("resolveWorkspacePoliciesPathFromParams returns external policies path for embed params", () => {
+  assert.equal(
+    resolveWorkspacePoliciesPathFromParams({
+      profileSlug: "partner-portal",
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+    }),
+    "external/partner-portal/tenants/acme/workspaces/marketing/policies",
+  );
+});
+
+test("resolveWorkspacePoliciesPathFromParams returns management path outside embed", () => {
+  assert.equal(
+    resolveWorkspacePoliciesPathFromParams({
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+    }),
+    "manage/tenants/acme/workspaces/marketing/policies",
+  );
+  assert.equal(resolveWorkspacePoliciesPathFromParams({ tenantCode: "acme" }), null);
+});
+
+test("stripExternalEmbedTokenFromSearch removes token but preserves other params", () => {
+  assert.equal(
+    stripExternalEmbedTokenFromSearch(`?templateId=1&versionId=2&token=${SIGNED_TOKEN}`),
+    "?templateId=1&versionId=2",
+  );
+
+  assert.equal(stripExternalEmbedTokenFromSearch(`token=${SIGNED_TOKEN}`), "");
+});
+
+test("captureExternalEmbedTokenFromSearch stores token and returns cleaned search", () => {
+  const storage = createStorage();
+  const result = captureExternalEmbedTokenFromSearch(
+    `?templateId=1&token=${SIGNED_TOKEN}`,
+    storage,
+  );
+
+  assert.equal(result.token, SIGNED_TOKEN);
+  assert.equal(result.cleanedSearch, "?templateId=1");
+  assert.equal(readExternalEmbedToken(storage), SIGNED_TOKEN);
+});
+
+test("isExternalEmbedPath only matches embed routes", () => {
+  assert.equal(isExternalEmbedPath("/embed/partner-portal/t/acme"), true);
+  assert.equal(isExternalEmbedPath("/t/acme"), false);
+});
+
+test("isExternalEmbedRuntimeReady only returns true when session token exists", () => {
+  const storage = createStorage({ [EXTERNAL_EMBED_TOKEN_STORAGE_KEY]: SIGNED_TOKEN });
+  assert.equal(isExternalEmbedRuntimeReady("/embed/partner-portal/t/acme", storage), true);
+  assert.equal(isExternalEmbedRuntimeReady("/t/acme", storage), false);
+  assert.equal(isExternalEmbedRuntimeReady("/embed/partner-portal/t/acme"), false);
+});
+
+test("buildExternalEmbedApiRequest adds the dedicated external headers for external api requests", () => {
+  const storage = createStorage({ [EXTERNAL_EMBED_TOKEN_STORAGE_KEY]: SIGNED_TOKEN });
+  const request = new Request(
+    "https://senda.tether.education/api/v1/external/partner-portal/bootstrap",
+    {
+      headers: {
+        accept: "application/json",
+      },
+    },
+  );
+
+  const nextRequest = buildExternalEmbedApiRequest(
+    request,
+    "/embed/partner-portal/t/acme/w/marketing/templates/newsletter/edit",
+    storage,
+  );
+
+  assert.ok(nextRequest);
+  assert.equal(nextRequest?.headers.get(EXTERNAL_EMBED_TOKEN_HEADER), SIGNED_TOKEN);
+  assert.equal(nextRequest?.headers.get(EXTERNAL_TENANT_HEADER), "acme");
+  assert.equal(nextRequest?.headers.get("accept"), "application/json");
+});
+
+
+
+test("buildExternalEmbedApiRequest mutates POST requests in place when the URL does not change", async () => {
+  const storage = createStorage({ [EXTERNAL_EMBED_TOKEN_STORAGE_KEY]: SIGNED_TOKEN });
+  const request = new Request(
+    "https://senda.tether.education/api/v1/external/partner-portal/tenants/acme/workspaces/marketing/templates/123/preview-mjml",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ mjml: "<mjml />" }),
+    },
+  );
+
+  const nextRequest = buildExternalEmbedApiRequest(
+    request,
+    "/embed/partner-portal/t/acme/w/marketing/templates/newsletter/edit",
+    storage,
+    `?templateId=123&versionId=456&token=${SIGNED_TOKEN}`,
+  );
+
+  assert.ok(nextRequest);
+  assert.equal(nextRequest, request);
+  assert.equal(nextRequest?.headers.get(EXTERNAL_EMBED_TOKEN_HEADER), SIGNED_TOKEN);
+  assert.equal(nextRequest?.headers.get(EXTERNAL_TENANT_HEADER), "acme");
+  assert.equal(await nextRequest?.clone().text(), JSON.stringify({ mjml: "<mjml />" }));
+});
+
+test("buildExternalEmbedApiRequest forwards embed fallback query params to external api requests", () => {
+  const storage = createStorage({ [EXTERNAL_EMBED_TOKEN_STORAGE_KEY]: SIGNED_TOKEN });
+  const request = new Request(
+    "https://senda.tether.education/api/v1/external/partner-portal/tenants/acme/workspaces/missing/templates/123/versions/456",
+  );
+
+  const nextRequest = buildExternalEmbedApiRequest(
+    request,
+    "/embed/partner-portal/t/acme/w/missing/templates/newsletter/edit",
+    storage,
+    "?templateId=123&versionId=456&fallback=system&token=signed-token",
+  );
+
+  assert.ok(nextRequest);
+  const url = new URL(nextRequest!.url);
+  assert.equal(url.searchParams.get("fallback"), "system");
+  assert.equal(url.searchParams.get("token"), null);
+  assert.equal(url.searchParams.get("templateId"), null);
+});
+
+test("buildExternalEmbedApiRequest ignores non-embed pages and non-external requests", () => {
+  const storage = createStorage({ [EXTERNAL_EMBED_TOKEN_STORAGE_KEY]: SIGNED_TOKEN });
+  const request = new Request("https://senda.tether.education/api/v1/manage/tenants");
+
+  assert.equal(
+    buildExternalEmbedApiRequest(
+      request,
+      "/t/acme",
+      storage,
+    ),
+    undefined,
+  );
+
+  assert.equal(
+    buildExternalEmbedApiRequest(
+      new Request("https://senda.tether.education/api/v1/manage/tenants"),
+      "/embed/partner-portal/t/acme/w/marketing/templates/newsletter/edit",
+      storage,
+    ),
+    undefined,
+  );
+});
+
+test("clearExternalEmbedToken removes the stored token", () => {
+  const storage = createStorage({ [EXTERNAL_EMBED_TOKEN_STORAGE_KEY]: SIGNED_TOKEN });
+  assert.equal(clearExternalEmbedToken(storage), true);
+  assert.equal(readExternalEmbedToken(storage), null);
+  assert.equal(storeExternalEmbedToken("another-token", storage), true);
+  assert.equal(readExternalEmbedToken(storage), "another-token");
+});

--- a/web/src/lib/external-api-context.ts
+++ b/web/src/lib/external-api-context.ts
@@ -1,0 +1,221 @@
+export interface ScopedPathParams {
+  profileSlug?: string;
+  tenantCode?: string;
+  workspaceCode?: string;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export const EXTERNAL_EMBED_TOKEN_STORAGE_KEY = "senda.external.embed.token";
+export const EXTERNAL_EMBED_TOKEN_CHANGED_EVENT =
+  "senda:external-embed-token-changed";
+export const EXTERNAL_EMBED_TOKEN_HEADER = "x-senda-external-token";
+export const EXTERNAL_TENANT_HEADER = "x-tenant-code";
+
+function normalizeSearchString(currentSearch: string): string {
+  if (!currentSearch) {
+    return "";
+  }
+
+  return currentSearch.startsWith("?") ? currentSearch : `?${currentSearch}`;
+}
+
+function externalEmbedURL(currentSearch: string): URL {
+  return new URL(`https://local${normalizeSearchString(currentSearch)}`);
+}
+
+function normalizeToken(value: string | null | undefined): string | null {
+  const token = value?.trim() ?? "";
+  return token || null;
+}
+
+function getDefaultExternalEmbedTokenStorage(): StorageLike | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  return window.sessionStorage;
+}
+
+function isExternalAPIRequest(requestURL: string): boolean {
+  return new URL(requestURL, "https://local").pathname.startsWith(
+    "/api/v1/external/",
+  );
+}
+
+const FORWARDED_EXTERNAL_QUERY_PARAMS = new Set(["fallback", "readonly"]);
+
+function extractTenantCodeFromEmbedPath(currentPathname: string): string | null {
+  const segments = currentPathname.split("/").filter(Boolean);
+  if (segments.length < 5 || segments[0] !== "embed" || segments[2] !== "t") {
+    return null;
+  }
+
+  const tenantCode = segments[3]?.trim();
+  return tenantCode || null;
+}
+
+export function resolveScopedPathFromParams(params: ScopedPathParams): string {
+  if (params.profileSlug && params.tenantCode && params.workspaceCode) {
+    return `external/${params.profileSlug}/tenants/${params.tenantCode}/workspaces/${params.workspaceCode}`;
+  }
+
+  if (params.tenantCode && params.workspaceCode) {
+    return `manage/tenants/${params.tenantCode}/workspaces/${params.workspaceCode}`;
+  }
+
+  if (params.tenantCode) {
+    return `manage/tenants/${params.tenantCode}`;
+  }
+
+  return "manage/global";
+}
+
+export function resolveWorkspacePoliciesPathFromParams(
+  params: ScopedPathParams,
+): string | null {
+  if (!params.tenantCode || !params.workspaceCode) {
+    return null;
+  }
+
+  if (params.profileSlug) {
+    return `external/${params.profileSlug}/tenants/${params.tenantCode}/workspaces/${params.workspaceCode}/policies`;
+  }
+
+  return `manage/tenants/${params.tenantCode}/workspaces/${params.workspaceCode}/policies`;
+}
+
+export function isExternalEmbedPath(currentPathname: string): boolean {
+  return currentPathname.startsWith("/embed/");
+}
+
+export function extractExternalEmbedTokenFromSearch(
+  currentSearch: string,
+): string | null {
+  const current = externalEmbedURL(currentSearch);
+  return normalizeToken(current.searchParams.get("token"));
+}
+
+export function stripExternalEmbedTokenFromSearch(
+  currentSearch: string,
+): string {
+  const url = externalEmbedURL(currentSearch);
+  url.searchParams.delete("token");
+  const search = url.searchParams.toString();
+  return search ? `?${search}` : "";
+}
+
+export function readExternalEmbedToken(
+  storage: StorageLike | undefined = getDefaultExternalEmbedTokenStorage(),
+): string | null {
+  if (!storage) {
+    return null;
+  }
+
+  return normalizeToken(storage.getItem(EXTERNAL_EMBED_TOKEN_STORAGE_KEY));
+}
+
+export function storeExternalEmbedToken(
+  token: string,
+  storage: StorageLike | undefined = getDefaultExternalEmbedTokenStorage(),
+): boolean {
+  const normalized = normalizeToken(token);
+  if (!normalized || !storage) {
+    return false;
+  }
+
+  storage.setItem(EXTERNAL_EMBED_TOKEN_STORAGE_KEY, normalized);
+  return true;
+}
+
+export function clearExternalEmbedToken(
+  storage: StorageLike | undefined = getDefaultExternalEmbedTokenStorage(),
+): boolean {
+  if (!storage) {
+    return false;
+  }
+
+  storage.removeItem(EXTERNAL_EMBED_TOKEN_STORAGE_KEY);
+  return true;
+}
+
+export function captureExternalEmbedTokenFromSearch(
+  currentSearch: string,
+  storage: StorageLike | undefined = getDefaultExternalEmbedTokenStorage(),
+): { token: string | null; cleanedSearch: string } {
+  const token = extractExternalEmbedTokenFromSearch(currentSearch);
+  if (token) {
+    storeExternalEmbedToken(token, storage);
+  }
+
+  return {
+    token,
+    cleanedSearch: stripExternalEmbedTokenFromSearch(currentSearch),
+  };
+}
+
+export function isExternalEmbedRuntimeReady(
+  currentPathname: string,
+  storage: StorageLike | undefined = getDefaultExternalEmbedTokenStorage(),
+): boolean {
+  if (!isExternalEmbedPath(currentPathname)) {
+    return false;
+  }
+
+  return readExternalEmbedToken(storage) !== null;
+}
+
+export function buildExternalEmbedApiRequest(
+  request: Request,
+  currentPathname: string,
+  storage: StorageLike | undefined = getDefaultExternalEmbedTokenStorage(),
+  currentSearch = "",
+): Request | undefined {
+  if (!isExternalEmbedPath(currentPathname)) {
+    return undefined;
+  }
+
+  if (!isExternalAPIRequest(request.url)) {
+    return undefined;
+  }
+
+  const token = readExternalEmbedToken(storage);
+  if (!token) {
+    return undefined;
+  }
+
+  const headers = new Headers(request.headers);
+  headers.set(EXTERNAL_EMBED_TOKEN_HEADER, token);
+  const tenantCode = extractTenantCodeFromEmbedPath(currentPathname);
+  if (tenantCode) {
+    headers.set(EXTERNAL_TENANT_HEADER, tenantCode);
+  }
+
+  const url = new URL(request.url);
+  const current = externalEmbedURL(currentSearch);
+  for (const [key, value] of current.searchParams.entries()) {
+    if (!FORWARDED_EXTERNAL_QUERY_PARAMS.has(key)) {
+      continue;
+    }
+    if (!url.searchParams.has(key)) {
+      url.searchParams.set(key, value);
+    }
+  }
+
+  if (url.toString() === request.url) {
+    headers.forEach((value, key) => {
+      request.headers.set(key, value);
+    });
+    return request;
+  }
+
+  const nextRequest = new Request(url, request);
+  headers.forEach((value, key) => {
+    nextRequest.headers.set(key, value);
+  });
+  return nextRequest;
+}

--- a/web/src/lib/external-embed-proxy.test.ts
+++ b/web/src/lib/external-embed-proxy.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { NextRequest, NextResponse } from "next/server.js";
+
+import {
+  applyExternalEmbedSecurityHeaders,
+  buildExternalBootstrapUrl,
+  createExternalEmbedProxyRouter,
+  loadExternalEmbedFrameAncestors,
+  normalizeFrameAncestors,
+  type ProxyRouteContext,
+} from "./external-embed-proxy.ts";
+
+const EMBED_PATH = "/embed/partner-portal/t/acme/w/marketing/templates/newsletter/edit";
+const BACKEND_ORIGIN = "https://backend.example.com";
+const HOST_ORIGIN = "https://host.example.com";
+const SELF_ANCESTOR = "'self'";
+const NONE_ANCESTOR = "'none'";
+const BOOTSTRAP_URL =
+  "https://backend.example.com/api/v1/external/partner-portal/bootstrap";
+const ROUTE_CONTEXT: ProxyRouteContext = {
+  params: Promise.resolve({}),
+};
+
+function mockEmbedRequest(pathname: string) {
+  return new NextRequest(`https://senda.example.com${pathname}`);
+}
+
+test("buildExternalBootstrapUrl targets the profile bootstrap endpoint", () => {
+  const request = mockEmbedRequest(EMBED_PATH);
+
+  const url = buildExternalBootstrapUrl(request, BACKEND_ORIGIN);
+
+  assert.equal(
+    url?.toString(),
+    BOOTSTRAP_URL,
+  );
+});
+
+test("normalizeFrameAncestors falls back to none when empty", () => {
+  assert.deepEqual(normalizeFrameAncestors([]), [NONE_ANCESTOR]);
+  assert.deepEqual(normalizeFrameAncestors([SELF_ANCESTOR, HOST_ORIGIN]), [
+    SELF_ANCESTOR,
+    HOST_ORIGIN,
+  ]);
+});
+
+test("loadExternalEmbedFrameAncestors falls back to none on bootstrap errors", async () => {
+  const frameAncestors = await loadExternalEmbedFrameAncestors(
+    mockEmbedRequest(EMBED_PATH),
+    BACKEND_ORIGIN,
+    async () =>
+      new Response("nope", {
+        status: 500,
+      }),
+  );
+
+  assert.deepEqual(frameAncestors, [NONE_ANCESTOR]);
+});
+
+test("loadExternalEmbedFrameAncestors returns profile frame ancestors from bootstrap", async () => {
+  const frameAncestors = await loadExternalEmbedFrameAncestors(
+    mockEmbedRequest(EMBED_PATH),
+    BACKEND_ORIGIN,
+    async (input) => {
+      assert.equal(
+        String(input),
+        BOOTSTRAP_URL,
+      );
+      return new Response(
+        JSON.stringify({
+          frame_ancestors: [SELF_ANCESTOR, HOST_ORIGIN],
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    },
+  );
+
+  assert.deepEqual(frameAncestors, [SELF_ANCESTOR, HOST_ORIGIN]);
+});
+
+test("applyExternalEmbedSecurityHeaders sets frame-ancestors and removes x-frame-options", () => {
+  const response = NextResponse.next();
+  response.headers.set("X-Frame-Options", "DENY");
+
+  applyExternalEmbedSecurityHeaders(response, [SELF_ANCESTOR, HOST_ORIGIN]);
+
+  assert.equal(
+    response.headers.get("Content-Security-Policy"),
+    `frame-ancestors ${SELF_ANCESTOR} ${HOST_ORIGIN}`,
+  );
+  assert.equal(response.headers.get("X-Frame-Options"), null);
+});
+
+test("createExternalEmbedProxyRouter bypasses auth for embed requests", async () => {
+  let authenticatedProxyCalls = 0;
+  const proxy = createExternalEmbedProxyRouter({
+    authenticatedProxy: async () => {
+      authenticatedProxyCalls += 1;
+      return NextResponse.next();
+    },
+    externalEmbedProxyRequest: async () =>
+      NextResponse.next({
+        headers: {
+          "Content-Security-Policy": `frame-ancestors ${NONE_ANCESTOR}`,
+        },
+      }),
+  });
+
+  const response = (await proxy(mockEmbedRequest(EMBED_PATH), ROUTE_CONTEXT)) as Response;
+
+  assert.equal(authenticatedProxyCalls, 0);
+  assert.equal(
+    response.headers.get("Content-Security-Policy"),
+    `frame-ancestors ${NONE_ANCESTOR}`,
+  );
+});

--- a/web/src/lib/external-embed-proxy.ts
+++ b/web/src/lib/external-embed-proxy.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server.js";
+import { isExternalEmbedPath } from "./external-api-context.ts";
+
+export type FetchLike = typeof fetch;
+export interface ProxyRouteContext {
+  params: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export type ProxyHandler = (
+  req: NextRequest,
+  ctx: ProxyRouteContext,
+) => Response | void | Promise<Response | void>;
+
+interface ExternalBootstrapResponseShape {
+  frame_ancestors?: string[];
+}
+
+export function buildExternalBootstrapUrl(
+  request: NextRequest,
+  backendOrigin: string,
+): URL | null {
+  const segments = request.nextUrl.pathname.split("/").filter(Boolean);
+  if (segments[0] !== "embed" || !segments[1]) {
+    return null;
+  }
+
+  return new URL(`/api/v1/external/${segments[1]}/bootstrap`, backendOrigin);
+}
+
+export function normalizeFrameAncestors(
+  frameAncestors?: readonly string[],
+): string[] {
+  const cleaned = (frameAncestors ?? [])
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return cleaned.length > 0 ? cleaned : ["'none'"];
+}
+
+export function applyExternalEmbedSecurityHeaders(
+  response: NextResponse,
+  frameAncestors: readonly string[],
+): NextResponse {
+  response.headers.delete("X-Frame-Options");
+  response.headers.set(
+    "Content-Security-Policy",
+    `frame-ancestors ${normalizeFrameAncestors(frameAncestors).join(" ")}`,
+  );
+  return response;
+}
+
+export async function loadExternalEmbedFrameAncestors(
+  request: NextRequest,
+  backendOrigin: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<string[]> {
+  const bootstrapUrl = buildExternalBootstrapUrl(request, backendOrigin);
+  if (!bootstrapUrl) {
+    return ["'none'"];
+  }
+
+  try {
+    const upstream = await fetchImpl(bootstrapUrl, {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+      },
+      cache: "no-store",
+    });
+
+    if (!upstream.ok) {
+      return ["'none'"];
+    }
+
+    const body = (await upstream.json()) as ExternalBootstrapResponseShape;
+    return normalizeFrameAncestors(body.frame_ancestors);
+  } catch {
+    return ["'none'"];
+  }
+}
+
+export function createExternalEmbedProxyRouter({
+  authenticatedProxy,
+  externalEmbedProxyRequest,
+}: {
+  authenticatedProxy: ProxyHandler;
+  externalEmbedProxyRequest: ProxyHandler;
+}) {
+  return async function proxy(
+    req: NextRequest,
+    ctx: ProxyRouteContext,
+  ): Promise<Response | void> {
+    if (isExternalEmbedPath(req.nextUrl.pathname)) {
+      return externalEmbedProxyRequest(req, ctx);
+    }
+
+    return authenticatedProxy(req, ctx);
+  };
+}

--- a/web/src/lib/external-integration-profiles.test.ts
+++ b/web/src/lib/external-integration-profiles.test.ts
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES,
+  createEmptyExternalIntegrationProfile,
+  normalizeExternalIntegrationProfile,
+  normalizeExternalIntegrationSettings,
+  parseDelimitedEntries,
+  stringifyDelimitedEntries,
+} from "./external-integration-profiles.ts";
+
+const DEMO_ORIGINS = ["https://app.example.com"];
+const DEMO_HEADERS = ["x-tenant-code"];
+const DEMO_AUTH_METHOD = "hmac";
+const DEMO_RESOLVER = "tenant-slug";
+
+test("parseDelimitedEntries trims, splits, and deduplicates values", () => {
+  assert.deepEqual(
+    parseDelimitedEntries(" https://a.example.com\nhttps://b.example.com, https://a.example.com \n"),
+    ["https://a.example.com", "https://b.example.com"],
+  );
+});
+
+test("stringifyDelimitedEntries keeps one entry per line", () => {
+  assert.equal(
+    stringifyDelimitedEntries(["https://a.example.com", "https://b.example.com"]),
+    "https://a.example.com\nhttps://b.example.com",
+  );
+});
+
+test("normalizeExternalIntegrationProfile fills safe defaults", () => {
+  assert.deepEqual(
+    normalizeExternalIntegrationProfile({}, 3),
+    {
+      slug: "external-profile-3",
+      name: "External profile 3",
+      description: "",
+      enabled: false,
+      auth_method_name: "",
+      resolver_name: "",
+      allowed_origins: [],
+      allowed_headers: [],
+      required_headers: [],
+      capabilities: DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES,
+    },
+  );
+});
+
+test("createEmptyExternalIntegrationProfile is deterministic per index", () => {
+  assert.deepEqual(createEmptyExternalIntegrationProfile(2).slug, "external-profile-2");
+  assert.deepEqual(createEmptyExternalIntegrationProfile(2).name, "External profile 2");
+});
+
+test("normalizeExternalIntegrationSettings keeps method and resolver descriptors", () => {
+  assert.deepEqual(
+    normalizeExternalIntegrationSettings({
+      profiles: [
+        {
+          slug: "embed",
+          name: "Embed",
+          description: "External embed profile",
+          enabled: true,
+          auth_method_name: DEMO_AUTH_METHOD,
+          resolver_name: DEMO_RESOLVER,
+          allowed_origins: DEMO_ORIGINS,
+          allowed_headers: DEMO_HEADERS,
+          required_headers: DEMO_HEADERS,
+          capabilities: {
+            list_templates: true,
+            view_versions: true,
+            edit_versions: false,
+            publish_versions: false,
+            test_send: false,
+            builder_access: true,
+            metadata_access: true,
+            locale_access: false,
+          },
+        },
+      ],
+      available_auth_methods: [
+        { name: "hmac", description: "Signed request validation" },
+      ],
+      available_resolvers: [
+        { name: "tenant-slug", description: "Resolve by tenant and slug" },
+      ],
+    }),
+    {
+      profiles: [
+        {
+          slug: "embed",
+          name: "Embed",
+          description: "External embed profile",
+          enabled: true,
+          auth_method_name: DEMO_AUTH_METHOD,
+          resolver_name: DEMO_RESOLVER,
+          allowed_origins: DEMO_ORIGINS,
+          allowed_headers: DEMO_HEADERS,
+          required_headers: DEMO_HEADERS,
+          capabilities: {
+            list_templates: true,
+            view_versions: true,
+            edit_versions: false,
+            publish_versions: false,
+            test_send: false,
+            builder_access: true,
+            metadata_access: true,
+            locale_access: false,
+          },
+        },
+      ],
+      available_auth_methods: [
+        { name: "hmac", description: "Signed request validation" },
+      ],
+      available_resolvers: [
+        { name: "tenant-slug", description: "Resolve by tenant and slug" },
+      ],
+    },
+  );
+});

--- a/web/src/lib/external-integration-profiles.ts
+++ b/web/src/lib/external-integration-profiles.ts
@@ -1,0 +1,155 @@
+import type {
+  ExternalIntegrationCapabilities,
+  ExternalIntegrationMethodDescriptor,
+  ExternalIntegrationProfile,
+  ExternalIntegrationsSettings,
+} from "@/types/settings";
+
+export const EXTERNAL_INTEGRATION_CAPABILITY_KEYS = [
+  "list_templates",
+  "view_versions",
+  "edit_versions",
+  "publish_versions",
+  "test_send",
+  "builder_access",
+  "metadata_access",
+  "locale_access",
+] as const satisfies ReadonlyArray<keyof ExternalIntegrationCapabilities>;
+
+export const DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES: ExternalIntegrationCapabilities =
+  {
+    list_templates: false,
+    view_versions: false,
+    edit_versions: false,
+    publish_versions: false,
+    test_send: false,
+    builder_access: false,
+    metadata_access: false,
+    locale_access: false,
+  };
+
+function normalizeList(values?: readonly string[] | null) {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  for (const rawValue of values ?? []) {
+    const value = rawValue.trim();
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    normalized.push(value);
+  }
+
+  return normalized;
+}
+
+export function parseDelimitedEntries(value: string) {
+  return normalizeList(
+    value
+      .split(/[\n,]/g)
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+}
+
+export function stringifyDelimitedEntries(values: readonly string[]) {
+  return values.join("\n");
+}
+
+export function normalizeExternalIntegrationCapabilities(
+  capabilities?: Partial<ExternalIntegrationCapabilities> | null,
+): ExternalIntegrationCapabilities {
+  return {
+    list_templates:
+      capabilities?.list_templates ??
+      DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES.list_templates,
+    view_versions:
+      capabilities?.view_versions ??
+      DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES.view_versions,
+    edit_versions:
+      capabilities?.edit_versions ??
+      DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES.edit_versions,
+    publish_versions:
+      capabilities?.publish_versions ??
+      DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES.publish_versions,
+    test_send:
+      capabilities?.test_send ?? DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES.test_send,
+    builder_access:
+      capabilities?.builder_access ??
+      DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES.builder_access,
+    metadata_access:
+      capabilities?.metadata_access ??
+      DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES.metadata_access,
+    locale_access:
+      capabilities?.locale_access ??
+      DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES.locale_access,
+  };
+}
+
+export function createEmptyExternalIntegrationProfile(index = 1): ExternalIntegrationProfile {
+  return {
+    slug: `external-profile-${index}`,
+    name: `External profile ${index}`,
+    description: "",
+    enabled: false,
+    auth_method_name: "",
+    resolver_name: "",
+    allowed_origins: [],
+    allowed_headers: [],
+    required_headers: [],
+    capabilities: {
+      ...DEFAULT_EXTERNAL_INTEGRATION_CAPABILITIES,
+    },
+  };
+}
+
+export function normalizeExternalIntegrationProfile(
+  profile?: Partial<ExternalIntegrationProfile> | null,
+  fallbackIndex = 1,
+): ExternalIntegrationProfile {
+  const base = createEmptyExternalIntegrationProfile(fallbackIndex);
+
+  return {
+    slug: profile?.slug?.trim() || base.slug,
+    name: profile?.name?.trim() || base.name,
+    description: profile?.description?.trim() || "",
+    enabled: profile?.enabled ?? base.enabled,
+    auth_method_name: profile?.auth_method_name?.trim() || "",
+    resolver_name: profile?.resolver_name?.trim() || "",
+    allowed_origins: normalizeList(profile?.allowed_origins),
+    allowed_headers: normalizeList(profile?.allowed_headers),
+    required_headers: normalizeList(profile?.required_headers),
+    capabilities: normalizeExternalIntegrationCapabilities(profile?.capabilities),
+  };
+}
+
+export function normalizeExternalIntegrationSettings(
+  settings?: Partial<ExternalIntegrationsSettings> | null,
+): ExternalIntegrationsSettings {
+  return {
+    profiles: (settings?.profiles ?? []).map((profile, index) =>
+      normalizeExternalIntegrationProfile(profile, index + 1),
+    ),
+    available_auth_methods: normalizeMethodDescriptors(
+      settings?.available_auth_methods,
+    ),
+    available_resolvers: normalizeMethodDescriptors(settings?.available_resolvers),
+  };
+}
+
+function normalizeMethodDescriptors(
+  descriptors?: readonly ExternalIntegrationMethodDescriptor[] | null,
+) {
+  return (descriptors ?? []).map((descriptor) => ({
+    name: descriptor.name.trim(),
+    description: descriptor.description.trim(),
+  }));
+}
+
+export function findExternalIntegrationMethodDescription(
+  descriptors: readonly ExternalIntegrationMethodDescriptor[] | undefined,
+  name: string,
+) {
+  return descriptors?.find((descriptor) => descriptor.name === name)?.description ?? "";
+}

--- a/web/src/lib/external-template-builder.test.ts
+++ b/web/src/lib/external-template-builder.test.ts
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveExternalTemplateBuilderViewState } from "./external-template-builder.ts";
+
+const PROFILE_SLUG = "partner-embed";
+const TENANT_CODE = "acme";
+const WORKSPACE_CODE = "marketing";
+
+test("embedded builder falls back to read-only on the system workspace", () => {
+  assert.deepEqual(
+    resolveExternalTemplateBuilderViewState({
+      profileSlug: PROFILE_SLUG,
+      scope: {
+        level: "workspace",
+        tenantCode: TENANT_CODE,
+        workspaceCode: "_system",
+      },
+    }),
+    {
+      readOnly: true,
+      readOnlyReason: "Resolved to the tenant Default workspace fallback.",
+      workspaceLabel: "Default",
+      scopeLabel: "Default scope",
+      canEdit: false,
+      canPublish: false,
+      canTestSend: false,
+      accessDenied: false,
+    },
+  );
+});
+
+test("embedded builder remains editable for a regular workspace", () => {
+  assert.deepEqual(
+    resolveExternalTemplateBuilderViewState({
+      profileSlug: PROFILE_SLUG,
+      scope: {
+        level: "workspace",
+        tenantCode: TENANT_CODE,
+        workspaceCode: WORKSPACE_CODE,
+      },
+    }),
+    {
+      readOnly: false,
+      workspaceLabel: WORKSPACE_CODE,
+      scopeLabel: "Workspace",
+      canEdit: true,
+      canPublish: true,
+      canTestSend: true,
+      accessDenied: false,
+    },
+  );
+});
+
+test("embedded builder uses external permissions to disable mutating actions for partial viewers", () => {
+  assert.deepEqual(
+    resolveExternalTemplateBuilderViewState({
+      profileSlug: PROFILE_SLUG,
+      scope: {
+        level: "workspace",
+        tenantCode: TENANT_CODE,
+        workspaceCode: WORKSPACE_CODE,
+      },
+      session: {
+        read_only: false,
+        effective_workspace_code: WORKSPACE_CODE,
+        permissions: {
+          list_templates: true,
+          view_versions: true,
+          edit_versions: false,
+          publish_versions: false,
+          test_send: false,
+          builder_access: true,
+          metadata_access: true,
+          locale_access: true,
+        },
+      },
+    }),
+    {
+      readOnly: false,
+      workspaceLabel: WORKSPACE_CODE,
+      scopeLabel: "Workspace",
+      canEdit: false,
+      canPublish: false,
+      canTestSend: false,
+      accessDenied: false,
+    },
+  );
+});
+
+test("embedded builder surfaces access denied when builder access is missing", () => {
+  assert.deepEqual(
+    resolveExternalTemplateBuilderViewState({
+      profileSlug: PROFILE_SLUG,
+      scope: {
+        level: "workspace",
+        tenantCode: TENANT_CODE,
+        workspaceCode: WORKSPACE_CODE,
+      },
+      accessDenied: true,
+    }),
+    {
+      readOnly: true,
+      workspaceLabel: WORKSPACE_CODE,
+      scopeLabel: "Workspace",
+      canEdit: false,
+      canPublish: false,
+      canTestSend: false,
+      accessDenied: true,
+    },
+  );
+});

--- a/web/src/lib/external-template-builder.ts
+++ b/web/src/lib/external-template-builder.ts
@@ -1,0 +1,83 @@
+import type { ScopeContext } from "../types/api";
+import type { ExternalIntegrationCapabilities } from "../types/settings";
+
+const SYSTEM_WORKSPACE_CODE = "_system";
+const SYSTEM_WORKSPACE_LABEL = "Default";
+const SYSTEM_WORKSPACE_SCOPE_LABEL = "Default scope";
+
+function isSystemWorkspaceCode(code?: string | null) {
+  return code === SYSTEM_WORKSPACE_CODE;
+}
+
+export interface ExternalTemplateBuilderContext {
+  profileSlug: string;
+  scope: ScopeContext;
+  fallbackToSystem?: boolean;
+  session?: ExternalEmbedSessionState | null;
+  accessDenied?: boolean;
+}
+
+export interface ExternalEmbedSessionState {
+  read_only: boolean;
+  effective_workspace_code: string;
+  permissions: ExternalIntegrationCapabilities;
+}
+
+export interface ExternalTemplateBuilderViewState {
+  readOnly: boolean;
+  readOnlyReason?: string;
+  workspaceLabel: string;
+  scopeLabel: string;
+  canEdit: boolean;
+  canPublish: boolean;
+  canTestSend: boolean;
+  accessDenied: boolean;
+}
+
+export function resolveExternalTemplateBuilderViewState(
+  context: ExternalTemplateBuilderContext,
+): ExternalTemplateBuilderViewState {
+  const fallbackToSystem =
+    context.session?.read_only ??
+    context.fallbackToSystem ??
+    isSystemWorkspaceCode(context.scope.workspaceCode);
+  const effectiveWorkspaceCode =
+    context.session?.effective_workspace_code ?? context.scope.workspaceCode;
+  const accessDenied = context.accessDenied ?? false;
+
+  if (accessDenied) {
+    return {
+      readOnly: true,
+      workspaceLabel: effectiveWorkspaceCode ?? SYSTEM_WORKSPACE_CODE,
+      scopeLabel: "Workspace",
+      canEdit: false,
+      canPublish: false,
+      canTestSend: false,
+      accessDenied: true,
+    };
+  }
+
+  if (fallbackToSystem) {
+    return {
+      readOnly: true,
+      readOnlyReason: "Resolved to the tenant Default workspace fallback.",
+      workspaceLabel: SYSTEM_WORKSPACE_LABEL,
+      scopeLabel: SYSTEM_WORKSPACE_SCOPE_LABEL,
+      canEdit: false,
+      canPublish: false,
+      canTestSend: false,
+      accessDenied: false,
+    };
+  }
+
+  const permissions = context.session?.permissions;
+  return {
+    readOnly: false,
+    workspaceLabel: effectiveWorkspaceCode ?? SYSTEM_WORKSPACE_CODE,
+    scopeLabel: "Workspace",
+    canEdit: permissions?.edit_versions ?? true,
+    canPublish: permissions?.publish_versions ?? true,
+    canTestSend: permissions?.test_send ?? true,
+    accessDenied: false,
+  };
+}

--- a/web/src/providers/index.tsx
+++ b/web/src/providers/index.tsx
@@ -6,8 +6,12 @@ import { ThemeProvider } from "next-themes";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { SessionGuard } from "@/providers/session-guard";
 import { useState } from "react";
+import { usePathname } from "next/navigation";
+import { isExternalEmbedPath } from "@/providers/session-guard-policy";
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const externalEmbedMode = isExternalEmbedPath(pathname);
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -21,7 +25,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <SessionProvider refetchInterval={3 * 60} refetchOnWindowFocus={true}>
+    <SessionProvider
+      session={externalEmbedMode ? null : undefined}
+      refetchInterval={externalEmbedMode ? 0 : 3 * 60}
+      refetchOnWindowFocus={!externalEmbedMode}
+    >
       <SessionGuard>
         <QueryClientProvider client={queryClient}>
           <ThemeProvider

--- a/web/src/providers/session-guard-policy.test.ts
+++ b/web/src/providers/session-guard-policy.test.ts
@@ -1,9 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { shouldTriggerFederatedLogout } = await import(
+const { isExternalEmbedPath, shouldRedirectUnauthenticatedToLogin, shouldTriggerFederatedLogout } = await import(
   new URL("./session-guard-policy.ts", import.meta.url).href,
 );
+
+test("detects embed routes for external session mode", () => {
+  assert.equal(
+    isExternalEmbedPath("/embed/partner-portal/t/acme/w/main/templates/newsletter/edit"),
+    true,
+  );
+  assert.equal(isExternalEmbedPath("/global"), false);
+});
 
 test("triggers logout on authenticated refresh token error in app routes", () => {
   assert.equal(
@@ -35,6 +43,40 @@ test("does not trigger federated logout on /login", () => {
       pathname: "/login",
       status: "authenticated",
       sessionError: "RefreshTokenError",
+      alreadyTriggered: false,
+    }),
+    false,
+  );
+});
+
+test("does not trigger federated logout on embed routes", () => {
+  assert.equal(
+    shouldTriggerFederatedLogout({
+      pathname: "/embed/partner-portal/t/acme/w/main/templates/newsletter/edit",
+      status: "authenticated",
+      sessionError: "RefreshTokenError",
+      alreadyTriggered: false,
+    }),
+    false,
+  );
+});
+
+test("redirects unauthenticated users on app routes", () => {
+  assert.equal(
+    shouldRedirectUnauthenticatedToLogin({
+      pathname: "/global",
+      status: "unauthenticated",
+      alreadyTriggered: false,
+    }),
+    true,
+  );
+});
+
+test("does not redirect unauthenticated users on embed routes", () => {
+  assert.equal(
+    shouldRedirectUnauthenticatedToLogin({
+      pathname: "/embed/partner-portal/t/acme/w/main/templates/newsletter/edit",
+      status: "unauthenticated",
       alreadyTriggered: false,
     }),
     false,

--- a/web/src/providers/session-guard-policy.ts
+++ b/web/src/providers/session-guard-policy.ts
@@ -1,3 +1,7 @@
+export function isExternalEmbedPath(pathname: string): boolean {
+  return pathname.startsWith("/embed/");
+}
+
 export function shouldTriggerFederatedLogout(params: {
   pathname: string;
   status: "authenticated" | "unauthenticated" | "loading";
@@ -9,7 +13,22 @@ export function shouldTriggerFederatedLogout(params: {
   if (alreadyTriggered) return false;
   if (status !== "authenticated") return false;
   if (sessionError !== "RefreshTokenError") return false;
+  if (isExternalEmbedPath(pathname)) return false;
   if (pathname === "/logout" || pathname === "/login") return false;
+
+  return true;
+}
+
+export function shouldRedirectUnauthenticatedToLogin(params: {
+  pathname: string;
+  status: "authenticated" | "unauthenticated" | "loading";
+  alreadyTriggered: boolean;
+}): boolean {
+  const { pathname, status, alreadyTriggered } = params;
+
+  if (alreadyTriggered) return false;
+  if (status !== "unauthenticated") return false;
+  if (isExternalEmbedPath(pathname)) return false;
 
   return true;
 }

--- a/web/src/providers/session-guard.tsx
+++ b/web/src/providers/session-guard.tsx
@@ -4,7 +4,10 @@ import { useEffect, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import { startFederatedLogout } from "@/lib/logout";
-import { shouldTriggerFederatedLogout } from "@/providers/session-guard-policy";
+import {
+  shouldRedirectUnauthenticatedToLogin,
+  shouldTriggerFederatedLogout,
+} from "@/providers/session-guard-policy";
 
 /**
  * SessionGuard watches for expired/invalid sessions and redirects to login.
@@ -38,7 +41,14 @@ export function SessionGuard({ children }: { children: React.ReactNode }) {
   // 3. Handle tab visibility change (user returns to tab after long absence).
   useEffect(() => {
     function handlePageShow(event: PageTransitionEvent) {
-      if (event.persisted && status === "unauthenticated") {
+      if (
+        event.persisted &&
+        shouldRedirectUnauthenticatedToLogin({
+          pathname,
+          status,
+          alreadyTriggered: logoutTriggered.current,
+        })
+      ) {
         window.location.replace("/login");
       }
     }
@@ -46,8 +56,11 @@ export function SessionGuard({ children }: { children: React.ReactNode }) {
     function handleVisibilityChange() {
       if (
         document.visibilityState === "visible" &&
-        status === "unauthenticated" &&
-        !logoutTriggered.current
+        shouldRedirectUnauthenticatedToLogin({
+          pathname,
+          status,
+          alreadyTriggered: logoutTriggered.current,
+        })
       ) {
         window.location.replace("/login");
       }
@@ -60,7 +73,7 @@ export function SessionGuard({ children }: { children: React.ReactNode }) {
       window.removeEventListener("pageshow", handlePageShow);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [status]);
+  }, [pathname, status]);
 
   return <>{children}</>;
 }

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -1,10 +1,18 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server.js";
 import { auth } from "@/auth";
 import { LOCALE_COOKIE, DEFAULT_LOCALE } from "@/lib/locale";
+import {
+  applyExternalEmbedSecurityHeaders,
+  createExternalEmbedProxyRouter,
+  loadExternalEmbedFrameAncestors,
+} from "@/lib/external-embed-proxy";
 
-// next-auth v5: auth(handler) wraps the handler with auth checks.
-// The authorized callback in auth.ts handles redirect to /login.
-export default auth(function proxy(req: NextRequest) {
+const defaultBackendOrigin =
+  process.env.SENDA_SERVER_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8080";
+
+function buildBaseProxyResponse(req: NextRequest): NextResponse {
   const requestHeaders = new Headers(req.headers);
   requestHeaders.set("x-senda-pathname", req.nextUrl.pathname);
 
@@ -15,11 +23,9 @@ export default auth(function proxy(req: NextRequest) {
   });
 
   // Prevent browser bfcache from showing stale authenticated pages after logout.
-  // Without this, pressing "back" after logout can show cached dashboard content.
   res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate");
   res.headers.set("Pragma", "no-cache");
 
-  // Set default locale cookie on first visit if absent
   if (!req.cookies.get(LOCALE_COOKIE)) {
     res.cookies.set(LOCALE_COOKIE, DEFAULT_LOCALE, {
       path: "/",
@@ -29,6 +35,24 @@ export default auth(function proxy(req: NextRequest) {
   }
 
   return res;
+}
+
+async function proxyExternalEmbedRequest(req: NextRequest): Promise<NextResponse> {
+  const response = buildBaseProxyResponse(req);
+  const frameAncestors = await loadExternalEmbedFrameAncestors(
+    req,
+    defaultBackendOrigin,
+  );
+  return applyExternalEmbedSecurityHeaders(response, frameAncestors);
+}
+
+const authenticatedProxy = auth(function proxy(req: NextRequest) {
+  return buildBaseProxyResponse(req);
+});
+
+export default createExternalEmbedProxyRouter({
+  authenticatedProxy,
+  externalEmbedProxyRequest: proxyExternalEmbedRequest,
 });
 
 export const config = {

--- a/web/src/types/settings.ts
+++ b/web/src/types/settings.ts
@@ -3,6 +3,7 @@ export interface SystemSettings {
   oidc: OidcSettings;
   email_defaults: EmailDefaultSettings;
   alerts: AlertSettings;
+  external_integrations?: ExternalIntegrationsSettings;
 }
 
 /** Tenant-local workspace policies configured from the _system workspace */
@@ -29,10 +30,46 @@ export interface AlertSettings {
   complaint_threshold_percent: number;
 }
 
+export interface ExternalIntegrationMethodDescriptor {
+  name: string;
+  description: string;
+}
+
+export interface ExternalIntegrationCapabilities {
+  list_templates: boolean;
+  view_versions: boolean;
+  edit_versions: boolean;
+  publish_versions: boolean;
+  test_send: boolean;
+  builder_access: boolean;
+  metadata_access: boolean;
+  locale_access: boolean;
+}
+
+export interface ExternalIntegrationProfile {
+  slug: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  auth_method_name: string;
+  resolver_name: string;
+  allowed_origins: string[];
+  allowed_headers: string[];
+  required_headers: string[];
+  capabilities: ExternalIntegrationCapabilities;
+}
+
+export interface ExternalIntegrationsSettings {
+  profiles: ExternalIntegrationProfile[];
+  available_auth_methods?: ExternalIntegrationMethodDescriptor[];
+  available_resolvers?: ExternalIntegrationMethodDescriptor[];
+}
+
 /** Update settings request (partial) */
 export interface UpdateSettingsRequest {
   email_defaults?: Partial<EmailDefaultSettings>;
   alerts?: Partial<AlertSettings>;
+  external_integrations?: Partial<ExternalIntegrationsSettings>;
 }
 
 export type UpdateWorkspacePoliciesRequest = Partial<WorkspacePolicies>;


### PR DESCRIPTION
## Summary

- Add external integration profiles with pluggable auth and workspace resolver registration in the SDK/core.
- Add the external API/embed surface plus a simplified embeddable builder with capability enforcement and `_system` read-only fallback.
- Harden the embed boundary with profile-aware CORS, frame-ancestor protection, token transport cleanup, and end-to-end API/browser coverage.

## Context

- Related issue: none
- Related story (if any): external integration surface + embeddable builder for third-party apps
- Risk / tradeoffs:
  - This is a security-sensitive cross-layer feature touching config, HTTP middleware, SDK seams, migrations, and the web shell.
  - Synthetic fallback deep-links that point at IDs not present in `_system` can still end in `Version not found`; the security boundary is preserved, but hosts should navigate using the effective catalog/session data.

## Validation

Mark everything you actually ran.

- [ ] `make ci-backend-pr` (if backend, infra, migrations, or tests changed)
- [ ] `make ci-frontend` (if `web/` changed)
- [x] `make ci-pr` (if both backend and frontend changed)
- [ ] `make ci-main` (required for pushes to `main` and systemic/cross-layer changes; fast gate, no Docker)

Optional deeper checks when you intentionally want Docker-backed coverage:

- [ ] `make test-integration`
- [ ] `make test-e2e`

Additional checks run:

- [x] `go test ./internal/http/... ./internal/domain ./internal/adapter/postgres ./sdk -count=1`
- [x] `go test -tags=e2e ./test/e2e -run TestExternalIntegration01_APIHappyChaosAndMaliciousFlows -count=1`
- [x] `cd web && node --test src/lib/external-api-context.test.ts src/lib/external-embed-proxy.test.ts src/lib/external-template-builder.test.ts src/providers/session-guard-policy.test.ts`
- [x] `cd web && pnpm typecheck`
- [x] `cd web && pnpm lint --max-warnings=0`
- [x] Browser E2E for the embedded host against the local stack (`/Users/rendis/Documents/Tether/project_aggregation/senda-aggregation/sandbox/playwright-e2e/external-ui-e2e.mjs`)
- [x] Security review with the dedicated OWASP/web-security subagent (`Ohm`) and follow-up hardening fixes in the embed boundary

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test-only
- [x] Security-sensitive

## Contributor checklist

- [x] I kept the change focused and reviewable.
- [x] I added or updated tests where behavior changed.
- [x] I updated docs when behavior, setup, API, or workflows changed.
- [x] I did not add build-only validation as a substitute for the required local gates.
- [x] I did not add AI attribution or `Co-Authored-By` trailers.

## Compatibility / ops impact

- [ ] No migration
- [x] Migration included
- [ ] No config changes
- [x] Config changes included
- [ ] No security impact
- [x] Security impact described above
