### PR TITLE
feat(environments): add prod and test workspace modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Senda is an open-source email orchestration platform built with Go + PostgreSQL (no Redis). It implements a 3-level hierarchy (Global → Tenant → Workspace) with inheritance chain resolution for templates, injectors, and adapters.
+Senda is an open-source email orchestration platform built with Go + PostgreSQL (no Redis). It implements hierarchical resolution across Global → Tenant → `_system` → Workspace, supports operational workspace environments `prod|test`, and exposes management, data-plane, external integration, and SDK embedding surfaces.
 
 - **Module:** `github.com/rendis/senda`
 - **Backend:** Go 1.25+ / PostgreSQL 16 + pg_cron / Echo v5 / River (PG-native queue) / pgx v5 / gomjml / golang-migrate
@@ -16,8 +16,8 @@ Senda is an open-source email orchestration platform built with Go + PostgreSQL 
 ### Key Paths
 
 ```
-sdk/                    PUBLIC SDK — Engine, Injector interface, InjectorContext, InitFunc
-                        Users `go get` this to extend Senda as a library.
+sdk/                    PUBLIC SDK — Engine, Injector interface, InjectorContext, InitFunc,
+                        ExternalAuthMethod, ExternalWorkspaceResolver. Users `go get` this to extend Senda as a library.
 cmd/senda/              Entry point (uses sdk.NewWithConfig + engine.Run)
 internal/
   domain/               Entities, value objects, domain errors
@@ -34,11 +34,11 @@ internal/
     mjml/               MJML -> HTML compiler (gomjml)
     crypto/             AES-256-GCM encryption (HKDF)
   http/
-    handler/            HTTP handlers (26+)
-    middleware/          Auth, RBAC, scope, logger, metrics, recovery, requestid
+    handler/            HTTP handlers for management, data plane, external integrations, and onboarding
+    middleware/         Auth, RBAC, scope, external integration, logger, metrics, recovery, requestid
   app/                  Bootstrap + DI wiring + Extensions bridge
 pkg/                    apperr (error mapping), slug (validation), tracking (ID gen)
-migrations/             24 SQL migrations (golang-migrate)
+migrations/             SQL migrations (golang-migrate)
 config/                 YAML config + env overrides (SENDA_* prefix)
 web/src/                Frontend app (Next.js App Router)
 ```
@@ -231,7 +231,7 @@ Documentation lives in `docs/`:
 | --- | --- | --- |
 | `docs/ARCHITECTURE.md` | Hexagonal layer diagrams, domain entities, port interfaces, resolution engine flow (chain → template → injector → adapter), send pipeline sequence, River workers, cache/rate-limit/encryption infrastructure, ADR summary | Understanding system design or adding new adapters/services |
 | `docs/API.md` | All endpoints (health, data-plane, management, global), auth schemes (OIDC + API Key), RBAC roles, error codes, pagination (cursor-based), curl examples, webhook events + HMAC signatures | Building handlers, integrations, or debugging API calls |
-| `docs/DEVELOPMENT.md` | First-time setup, Docker stacks (dev vs e2e comparison), all 27 Makefile targets, frontend npm scripts, DB migrations, Keycloak test users/credentials, service URLs/ports, testing guide (unit → system), troubleshooting | First session, env setup, or when something breaks |
+| `docs/DEVELOPMENT.md` | First-time setup, Docker stacks, current Make targets, frontend `pnpm` workflow, testing guide (unit → system), environment-aware validation, troubleshooting | First session, env setup, or when something breaks |
 | `docs/DEPLOYMENT.md` | Production Dockerfile, required/optional env vars, PG + pg_cron setup, OIDC provider config, email provider setup (SES/Gmail/SMTP), health endpoints, reverse proxy examples, docker run example | Deploying to production |
 | `docs/specs/PRD_v5.md` | Product requirements, user stories, business rules, scope hierarchy rules | Understanding "why" and "what" |
 | `docs/specs/TECH_SPEC_v1.md` | Complete technical spec (~5000 lines): SQL schema (16+ tables), migrations, folder structure, port interfaces, domain models, resolution engine, send flow, middleware, API contract, workers, config, Docker, observability, PG cache, rate limiting | **Primary reference for implementation** |
@@ -240,9 +240,9 @@ Documentation lives in `docs/`:
 | `docs/specs/SECURITY_CHECKLIST.md` | OWASP Top 10 mapping, AES-256-GCM encryption spec, auth requirements, API key security model | Security-sensitive code |
 | `docs/specs/DESIGN_BRIEF.md` | UX/UI screens, component specs, responsive breakpoints, Design System tokens | Frontend implementation |
 | `docs/specs/ADR-0001-...md` | **Why no DKIM/SPF/DMARC in app** — provider-managed email auth decision, consequences for send flow and identity validation | When questioning email auth approach |
-| `docs/extensibility-guide.md` | SDK extension guide: Engine, Injectors, InitFunc, InjectorContext, lifecycle hooks, merge flow, consumer project structure, troubleshooting | Extending Senda as a Go library |
-| `skills/senda/SKILL.md` | MCP tool reference, API groups, auth schemes, RBAC, SES lifecycle (provision + deprovision), AWS permission matrix | Working with Senda API via MCP, or understanding SES adapter lifecycle |
-| `docs/postman/` | Postman collection (116KB, all endpoints) + local/staging environments | API testing and exploration |
+| `docs/extensibility-guide.md` | SDK extension guide: Engine, injectors, InitFunc, external auth methods, workspace resolvers, InjectorContext, environment propagation, lifecycle hooks | Extending Senda as a Go library |
+| `skills/senda/SKILL.md` | Self-contained agent bundle for MCP operation, SDK embedding, environments, resolution, external integrations, and conventions; see bundled `references/` for detail | Working with Senda from another repo or through MCP without relying on external docs |
+| `docs/postman/` | Postman collection + local/staging environments | API testing and exploration |
 
 ### UI/UX Design — Pencil MCP (MANDATORY)
 
@@ -628,7 +628,7 @@ These are non-negotiable decisions documented in TECH_SPEC v1.4:
 2. **Adapter assigned per template_type** — not per workspace or template
 3. **Resolution chain** via scope hierarchy (workspace → _system → global)
 4. **River** for job queue (Go + PG native, no external broker)
-5. **OIDC for humans, API Keys for machines** — dual auth. Keys are SHA-256 hashed, workspace-scoped, raw shown once at creation. Blast radius of a compromised key = 1 workspace (data-plane only, no management access)
+5. **OIDC for humans, API Keys for machines** — dual auth. Keys are hashed at rest, workspace-environment scoped, raw shown once at creation, and use `senda_prod_` / `senda_test_` prefixes. Blast radius of a compromised key = 1 workspace environment (data-plane only, no management access)
 6. **Hexagonal architecture** — ports define contracts, adapters implement
 7. **UUIDs v7** — time-ordered, non-sequential
 8. **Partitioned tables** — emails and audit_logs by month
@@ -636,7 +636,7 @@ These are non-negotiable decisions documented in TECH_SPEC v1.4:
 10. **Cursor-based pagination** — no offset, UUIDv7 as cursor
 11. **Provider-managed email auth** — SPF/DKIM/DMARC are the provider's responsibility (SES/Gmail), NOT the app. Senda validates sender capability via adapter identities (sync from provider + default identity). No DKIM signing, no DNS record management in app code. See [ADR-0001](docs/specs/ADR-0001-provider-managed-email-auth.md)
 12. **No app-level email address validation** — `from_email` is verified by the provider's identity system. If an identity isn't verified, the provider rejects the send. Senda tracks identity status (`verified`/`pending`/`failed`) via `AdapterIdentity` but doesn't duplicate provider checks
-13. **SDK extensibility model** — Senda exposes a public `sdk/` package. Users extend via code injectors (implement `sdk.Injector`), init functions (`sdk.InitFunc`), and lifecycle hooks (`OnStart`/`OnShutdown`). Built-in adapters (SES, Gmail, SMTP, PG stores, River, cache, crypto) stay internal, managed by YAML config. The `sdk.Engine` wraps `internal/app.Bootstrap` with an extensions bridge. Code injectors resolve alongside DB injectors in the `InjectorMerger`; on name collision, code wins with a warning. Pattern follows pdf-forge/doc-assembly SDK model.
+13. **SDK extensibility model** — Senda exposes a public `sdk/` package. Users extend via code injectors (`sdk.Injector`), init functions (`sdk.InitFunc`), external auth methods, external workspace resolvers, and lifecycle hooks (`OnStart`/`OnShutdown`). Built-in adapters, stores, River, cache, crypto, and middleware stay internal and config-driven. `sdk.Engine` wraps `internal/app.Bootstrap` with an extensions bridge, and environment is propagated through `InjectorContext` and `ExternalIntegrationRequest`.
 14. **SES adapter lifecycle** — Provision (6 steps) and Deprovision (4 steps), both tracked in `adapter_provisioning_steps`. Delete permissions validated at creation. Full reference in `skills/senda/SKILL.md` "SES Adapter Lifecycle" and `docs/DEPLOYMENT.md`.
 
 ---
@@ -712,8 +712,8 @@ my-senda-app/
 |             | `make test-e2e-core-run`        | E2E core gate (assumes stack running)                     |
 |             | `make test-e2e-chaos`           | Chaos E2E suite (starts stack, stops)                     |
 |             | `make test-e2e-chaos-run`       | Chaos E2E suite (assumes stack running)                   |
-|             | `make test-e2e-up`              | Start E2E stack with --wait                               |
-|             | `make test-e2e-down`            | Stop E2E stack + remove volumes                           |
+|             | `make test-e2e-up`              | No-op (Testcontainers harness is self-managed)            |
+|             | `make test-e2e-down`            | No-op (Testcontainers harness is self-managed)            |
 | **System**  | `make system-validate-manifest` | Validate screen manifest vs app routes                    |
 |             | `make system-matrix`            | Generate system coverage matrix CSV                       |
 |             | `make system-pr`                | PR system gate (functional + UI + visual)                 |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+
 <div align="center">
   <img src="web/public/senda-logo.svg" width="80" alt="Senda" />
   <h1>Senda</h1>
   <p><strong>Open-source email orchestration for multi-tenant SaaS</strong></p>
-  <p>Templates, inheritance, provider-agnostic delivery — one API call.</p>
+  <p>Templates, inheritance, environment-aware delivery, and embeddable builder flows — one platform.</p>
 
 [![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-16-4169E1?logo=postgresql&logoColor=white)](https://www.postgresql.org)
@@ -18,116 +19,99 @@
 
 ## Why Senda?
 
-Most email services are either too simple (no multi-tenancy) or too complex (Kafka, Redis, microservices). Senda sits in the sweet spot:
+Most email products are either too simple for multi-tenant SaaS or too operationally heavy. Senda stays in the middle:
 
-- **Zero external dependencies** — PostgreSQL handles queue ([River](https://riverqueue.com)), cache (UNLOGGED tables), and rate limiting (PL/pgSQL token bucket). No Redis. No Kafka.
-- **3-level hierarchy** — Configure templates, injectors, and adapters at Global scope. Override at Tenant or Workspace level. Inheritance chain resolves automatically.
-- **Selective system sharing** — Tenant `_system` can share Gmail adapters to specific workspaces and SES **email identities** (not whole domains) to the exact workspaces allowed to send from them.
-- **MJML-native** — Write responsive email templates in MJML. Compiled to battle-tested HTML at send time with variable injection and locale fallback.
-- **Dual auth model** — OIDC/JWT for humans on the management plane. Workspace-scoped API keys for machines on the data plane. 5-tier RBAC.
-- **Full-stack** — Go backend + Next.js 16 dashboard with dark mode, scope switcher, template editor (Monaco), and real-time metrics.
-
----
+- **PostgreSQL-first** — queue, cache, rate limiting, and state all stay close to the core application. No Redis required.
+- **Hierarchical resolution** — global, tenant, `_system`, and workspace cooperate through explicit inheritance and selective sharing.
+- **Real environments** — each logical workspace operates as `prod` and `test`, with isolated API keys, runtime state, and safety controls.
+- **Embeddable** — external builder/editor surfaces can be exposed through custom auth methods and workspace resolvers.
+- **SDK-friendly** — embedders can register code injectors, per-request init, external auth/resolver seams, and lifecycle hooks without forking Senda.
 
 ## Features
 
-|               | Feature             | Description                                                                                                    |
-| ------------- | ------------------- | -------------------------------------------------------------------------------------------------------------- |
-| **Hierarchy** | Multi-tenant scopes | Global > Tenant > Workspace with inheritance chain resolution                                                  |
-| **Sharing**   | System-owned adapters | Tenant `_system` can grant Gmail adapters per workspace and SES sender emails per workspace, with read-only inherited rows in child workspaces |
-| **Templates** | Versioned + i18n    | Draft > Published > Archived lifecycle. Locale fallback (exact > prefix > workspace default > version default) |
-| **Providers** | Adapter system      | SES, Gmail, SMTP built-in. Add any provider by implementing one interface                                      |
-| **Rendering** | MJML compiler       | Responsive HTML from MJML templates. Variable injection via injector merge                                     |
-| **Webhooks**  | Event delivery      | HMAC-SHA256 signed. Exponential backoff. Auto-disable after 10 consecutive failures                            |
-| **Tracking**  | Open & click        | Pixel injection for opens. Provider event ingestion (delivered, bounced, complained)                           |
-| **Security**  | Defense in depth    | AES-256-GCM at rest, HMAC API keys, SSRF protection, CSP/HSTS headers, advisory-locked onboarding              |
-| **Audit**     | Full trail          | Every mutation logged with actor, scope, entity, and change diff                                               |
-| **MCP**       | AI-ready            | OpenAPI-backed MCP server for Claude Code, Codex, and Gemini CLI                                               |
-| **Dashboard** | Full-stack UI       | Next.js 16 + shadcn/ui. Templates, adapters, members, metrics, settings                                        |
+| Area | Feature | Description |
+| --- | --- | --- |
+| Hierarchy | Scope resolution | Global → Tenant → `_system` → Workspace resolution with owned, inherited, and shared resources |
+| Environments | `prod` / `test` workspaces | One logical workspace, two operational environments with isolated runtime state |
+| Templates | Versioned + localized | Draft/published/archive lifecycle, locale overrides, exact version cloning |
+| Providers | Adapter model | SES, Gmail, SMTP built in; adapter and identity sharing from `_system` |
+| Safety | Test recipient policy | `replace` or `append` safe-recipient behavior in `test` only |
+| External | Embeddable builder surface | Bootstrap, session, template editing, locale editing, preview, and test-send via external profiles |
+| Security | OIDC + API keys | OIDC for management, environment-aware API keys for data plane |
+| SDK | Public extension seams | Injectors, init function, external auth method, workspace resolver, lifecycle hooks |
 
----
+## Environment model
 
-## Shared Adapters from Tenant `_system`
+Each logical workspace has two physical operational environments:
 
-Senda supports **selective adapter inheritance** from a tenant's `_system` workspace down to its child workspaces:
+- `prod`
+- `test`
 
-- **Gmail** is shared at the **adapter** level. `_system` decides exactly which workspaces can see and use the adapter.
-- **SES** is shared at the **email identity** level. `_system` can grant `a@example.dev` to one workspace and `b@example.dev` to another. Domain identities stay in `_system`; they are **not** shareable.
-- In child workspaces, inherited adapters appear in the adapters UI as **read-only shared rows**. Workspace-owned adapters remain editable.
-- For a workspace using a shared SES adapter, `sender_identity_id` is mandatory on the template type so each send is attributed to the correct workspace + sender identity combination.
+Important rules:
+
+- The **send ref stays** `tenant:workspace:templateType`.
+- Environment is selected by **route**, **API key prefix**, or **external header**, depending on the surface.
+- Test-only runtime reset is exposed on the environment-scoped management surface.
+- Test-only recipient safety controls exist at workspace level and can be overridden by template type in the test environment.
+
+See `docs/API.md` and `skills/senda/` for the operational details.
+
+## Shared adapters from tenant `_system`
+
+Senda supports **selective sharing** from a tenant `_system` workspace:
+
+- **Gmail** sharing is adapter-level.
+- **SES** sharing is email-identity-level; domain identities are not shareable.
+- Shared entries are read-only in child workspaces.
+- Child workspaces can fork inherited template content when they need local ownership.
 
 ## Quick Start
 
-**Prerequisites:** Docker, Go 1.25+, Node 25 (or `nvm use` from `web/.nvmrc`), Make
+**Prerequisites:** Docker, Go 1.25+, Node 25 (or `web/.nvmrc`), Make, Corepack.
 
 ```bash
-# 1. Clone and start
-git clone https://github.com/rendis/senda.git && cd senda
+git clone https://github.com/rendis/senda.git
+cd senda
 make dev
-
-# 2. Verify (wait ~30s for Keycloak)
 curl http://localhost:8081/health
-# {"status":"ok"}
+```
 
-# 3. Send your first email
+Start the frontend:
+
+```bash
+corepack enable
+(cd web && corepack install)
+pnpm --dir web install
+pnpm --dir web dev
+```
+
+Example data-plane send:
+
+```bash
 curl -X POST http://localhost:8081/api/v1/send \
-  -H "Authorization: Bearer senda_live_YOUR_KEY" \
+  -H "Authorization: Bearer senda_prod_YOUR_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "ref": "acme:main:welcome-email",
     "to": ["user@example.com"],
-    "variables": { "name": "Jane" },
+    "variables": {"name": "Jane"},
     "locale": "es"
   }'
 ```
 
-Check the email in [Mailpit UI](http://localhost:8026). Start the frontend with `corepack enable && (cd web && corepack install) && pnpm --dir web install && pnpm --dir web dev`.
-
-For local PR-style validation, run the same fast gates used by CI:
+For local validation, prefer the repo gates used by CI:
 
 ```bash
 make ci-backend-pr
 make ci-frontend      # if you changed web/
-make ci-pr            # if the change spans backend + frontend
-make ci-main          # for systemic flows
+make ci-pr            # backend + frontend
+make ci-main          # systemic flows
 make install-githooks
 ```
 
----
-
-## E2E Validation
-
-Para correr la suite E2E desde un clon fresco no hace falta levantar un stack manualmente: el harness usa **Testcontainers** y provisiona lo necesario.
-
-### Prerrequisitos
-
-- Docker corriendo
-- Go 1.25+
-- Make
-
-### Gate determinística completa
-
-```bash
-make test-e2e
-```
-
-### Solo SES lifecycle + SNS signed replay
-
-```bash
-make test-e2e-ses
-```
-
-Más detalle en:
-
-- `docs/DEVELOPMENT.md`
-- `test/e2e/README.md`
-- `test/e2e/QUICK_START.md`
-
----
-
 ## Use as a Library
 
-Senda can be imported as a Go module. Register custom **code injectors** to feed business-specific data into templates, add an **init function** for shared per-request context, and wire **lifecycle hooks** for your infrastructure.
+Senda exposes a public Go SDK for embedders.
 
 ```bash
 go get github.com/rendis/senda
@@ -144,416 +128,100 @@ import (
 func main() {
     engine := sdk.NewWithConfig("config.yaml")
 
-    // Per-request init: load shared data before injectors run.
     engine.SetInitFunc(func(ctx context.Context, injCtx *sdk.InjectorContext) (any, error) {
         return loadStudent(ctx, injCtx.Header("X-Case-Id"))
     })
 
-    // Custom injector: values merge with DB injectors into templates.
-    // Templates use {{ injector.student.full_name }}.
     engine.RegisterInjector(&StudentInjector{})
+    engine.RegisterExternalAuthMethod(&PortalAuthMethod{})
+    engine.RegisterExternalWorkspaceResolver(&PortalWorkspaceResolver{})
 
-    // Lifecycle hooks for your infrastructure.
-    engine.OnStart(func(ctx context.Context) error  { return connectMongo(ctx) })
+    engine.OnStart(func(ctx context.Context) error { return connectMongo(ctx) })
     engine.OnShutdown(func(ctx context.Context) error { return closeMongo(ctx) })
 
-    engine.Run()
+    _ = engine.Run()
 }
 ```
 
-<details>
-<summary><strong>Implementing an Injector</strong></summary>
+Public extension seams:
 
-```go
-type StudentInjector struct{}
+- `RegisterInjector(...)`
+- `SetInitFunc(...)`
+- `RegisterExternalAuthMethod(...)`
+- `RegisterExternalWorkspaceResolver(...)`
+- `OnStart(...)`
+- `OnShutdown(...)`
 
-func (i *StudentInjector) Code() string { return "student" }
+`InjectorContext.Environment()` and `ExternalIntegrationRequest.Environment` are the public runtime sources of truth for `prod` / `test` behavior.
 
-func (i *StudentInjector) Resolve() (sdk.ResolveFunc, []string) {
-    return func(ctx context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
-        student := injCtx.InitData().(*Student)
-        return map[string]any{
-            "full_name": student.FullName,
-            "email":     student.Email,
-            "grade":     student.Grade,
-        }, nil
-    }, nil // no dependencies on other injectors
-}
+## External integrations
 
-func (i *StudentInjector) IsCritical() bool        { return true }
-func (i *StudentInjector) Timeout() time.Duration   { return 10 * time.Second }
+Senda exposes an embeddable external surface under:
+
+- `/api/v1/external/:profile_slug/bootstrap`
+- `/api/v1/external/:profile_slug/environments/:environment/bootstrap`
+- `/api/v1/external/:profile_slug/tenants/:tenant_code/workspaces/:workspace_code/...`
+
+External authenticated requests must include:
+
+```http
+X-Senda-Environment: prod|test
 ```
 
-**Key concepts:**
-- `Code()` maps to the template namespace: `{{ injector.<Code()>.<field> }}`
-- `Resolve()` returns `(resolveFunc, dependencies)` — dependencies are other injector codes that must resolve first
-- `IsCritical()` — if `true`, a failure aborts the send; if `false`, the injector is silently skipped
-- `InjectorContext.RequestInjectors()` exposes request-body runtime overrides
-- Runtime precedence is **per field**:
-  - `allow_overwrite=false` → always use `default_value`
-  - `allow_overwrite=true` → `reqBody.injectors > code injector value > default_value`
-- If a code injector and a DB injector share the same code, the code injector still wins for that injector name, but overwrite rules are evaluated field by field
-- `InjectorContext` provides: HTTP headers, send request variables, init data, tenant/workspace IDs, and other resolved injectors
+External profiles select a registered auth method and workspace resolver, which together determine effective permissions and effective workspace.
 
-</details>
+## API at a glance
 
-**What's extensible (SDK):** Code injectors, init function, lifecycle hooks (OnStart/OnShutdown).
+| Group | Base | Auth | Notes |
+| --- | --- | --- | --- |
+| Health | `/health`, `/healthz`, `/metrics` | None / token | Liveness, readiness, Prometheus |
+| Data plane | `/api/v1/send`, `/api/v1/emails` | API key | Environment selected by `senda_prod_...` / `senda_test_...` |
+| Management (shared) | `/api/v1/manage/tenants/.../workspaces/...` | OIDC | Logical workspace CRUD |
+| Management (env) | `/api/v1/manage/environments/:environment/...` | OIDC | Environment-specific workspace runtime/resources |
+| External | `/api/v1/external/:profile_slug/...` | Custom | Embeddable builder/editor surface |
+| Global | `/api/v1/manage/global/...` | OIDC | Superadmin-only global resources |
+| Webhooks | `/api/v1/webhooks/ses/inbound` | SNS sig | Provider event ingestion |
 
-**What's internal (config):** Email senders (SES/Gmail/SMTP), cache, crypto, queue, rate limiter, auth, middleware, resolution engine. All managed via YAML config.
+## MCP integration
 
-Update Senda independently — `go get -u github.com/rendis/senda@latest` — your extensions keep working.
+Senda ships a dedicated MCP skill and OpenAPI-backed MCP server configuration.
 
----
+- Skill bundle: `skills/senda/`
+- Setup guide: `docs/mcp_setup.md`
+- OpenAPI-backed server name: `senda`
 
-## Architecture
-
-Hexagonal (Ports & Adapters). Domain logic has zero infrastructure dependencies.
-
-```mermaid
-graph TB
-    subgraph HTTP["HTTP Layer"]
-        H[Handlers]
-        MW[Middleware<br/>Auth · RBAC · Scope · Metrics · Logger]
-    end
-
-    subgraph Services["Service Layer"]
-        SS[SendService]
-        TS[TemplateService]
-        EP[EventProcessor]
-        WS[WebhookService]
-        AK[APIKeyService]
-        IS[IdentityService]
-    end
-
-    subgraph Resolution["Resolution Engine"]
-        CR[ChainResolver]
-        TR[TemplateResolver]
-        IM[InjectorMerger]
-        AR[AdapterResolver]
-    end
-
-    subgraph Ports["Port Interfaces"]
-        ST[(Stores)]
-        ES[EmailSender]
-        JQ[JobQueue]
-        CA[Cache]
-        CY[Crypto]
-        RL[RateLimiter]
-    end
-
-    subgraph Adapters["Adapter Implementations"]
-        PG[(PostgreSQL)]
-        SES[AWS SES]
-        GM[Gmail]
-        SMTP[SMTP]
-        RV[River Workers]
-        PGC[PG Cache]
-        AES[AES-256-GCM]
-        MJ[MJML Compiler]
-    end
-
-    HTTP --> Services
-    Services --> Resolution
-    Services --> Ports
-    Resolution --> Ports
-    Ports --> Adapters
-```
-
----
-
-## How Sending Works
-
-```mermaid
-sequenceDiagram
-    participant C as Client
-    participant S as SendService
-    participant R as Resolution Engine
-    participant DB as PostgreSQL
-    participant Q as River Queue
-    participant W as SendWorker
-    participant P as Email Provider
-
-    C->>S: POST /api/v1/send
-    S->>R: Resolve chain + template + injectors + adapter
-    R->>DB: Cached lookups (PGCache + LRU)
-    S->>DB: Create email + enqueue job (atomic tx)
-    S-->>C: 202 { tracking_id }
-
-    Q->>W: Poll job
-    W->>W: Rate limit + render MJML + inject tracking
-    W->>P: Send email (cached sender)
-    P-->>W: Provider message ID
-    W->>DB: CAS status update (processing > sent)
-    Note over P,DB: Provider events arrive via webhooks
-```
-
----
-
-## Tech Stack
-
-<table>
-<tr><td>
-
-**Backend**
-
-| Component  | Technology              |
-| ---------- | ----------------------- |
-| Language   | Go 1.25+                |
-| Database   | PostgreSQL 16 + pg_cron |
-| HTTP       | Echo v5                 |
-| Job Queue  | River (PG-native)       |
-| Templates  | gomjml (MJML)           |
-| Encryption | AES-256-GCM (HKDF)      |
-| Cache      | PG UNLOGGED tables      |
-| Rate Limit | PL/pgSQL token bucket   |
-
-</td><td>
-
-**Frontend**
-
-| Component | Technology                      |
-| --------- | ------------------------------- |
-| Framework | Next.js 16                      |
-| UI        | React 19 + shadcn/ui            |
-| Styling   | Tailwind CSS v4                 |
-| State     | TanStack Query 5                |
-| Forms     | React Hook Form + Zod 4         |
-| Auth      | Auth.js v5 (OIDC)               |
-| Theme     | next-themes (light/dark/system) |
-| Editor    | Monaco Editor                   |
-
-</td></tr>
-</table>
-
----
-
-## API at a Glance
-
-| Group      | Endpoint                                    | Auth         | Description                     |
-| ---------- | ------------------------------------------- | ------------ | ------------------------------- |
-| Health     | `/health`, `/healthz`, `/metrics`           | None / Token | Liveness, readiness, Prometheus |
-| Data Plane | `/api/v1/send`, `/api/v1/emails`            | API Key      | Send emails, query status       |
-| Management | `/api/v1/manage/tenants/.../workspaces/...` | OIDC         | CRUD for all resources          |
-| Global     | `/api/v1/manage/global/...`                 | OIDC         | Global-scope management         |
-| Webhooks   | `/api/v1/webhooks/ses/inbound`              | SNS sig      | Provider event ingestion        |
-| Tracking   | `/t/o/:tracking_id`                         | None         | Open-tracking pixel             |
-
-> Full reference: [docs/API.md](docs/API.md) | Postman: [docs/postman/](docs/postman/)
-
----
-
-<details>
-<summary><strong>Hierarchy & Resolution</strong></summary>
-
-Senda uses a 3-level scope hierarchy. Resources at lower scopes override those at higher scopes:
-
-```mermaid
-graph TD
-    G["Global Scope<br/>(defaults for everything)"]
-    T["Tenant Scope<br/>(organization-level overrides)"]
-    SYS["_system Workspace<br/>(tenant-wide defaults)"]
-    W["Workspace Scope<br/>(project-level overrides)"]
-
-    G --> T
-    T --> SYS
-    SYS --> W
-
-    style W fill:#2563eb,color:#fff
-    style SYS fill:#7c3aed,color:#fff
-    style T fill:#059669,color:#fff
-    style G fill:#6b7280,color:#fff
-```
-
-**Resolution order:** Workspace > \_system workspace > Global. First match wins. Injectors merge field-by-field across all scopes.
-
-</details>
-
-<details>
-<summary><strong>Authentication & RBAC</strong></summary>
-
-```mermaid
-flowchart LR
-    REQ[Request] --> CHECK{Auth Header?}
-
-    CHECK -->|"Bearer senda_live_..."| AK[Workspace API Key Auth]
-    CHECK -->|"Bearer eyJ..."| OIDC[OIDC Auth]
-
-    AK --> WS[Workspace-scoped]
-    WS --> DP[Data Plane<br/>send · query emails]
-
-    OIDC --> RBAC[RBAC Check]
-    RBAC --> MP[Management Plane<br/>CRUD · config · admin]
-```
-
-| Role            | Scope     | Permissions                              |
-| --------------- | --------- | ---------------------------------------- |
-| Superadmin      | Global    | Everything                               |
-| TenantAdmin     | Tenant    | Manage workspaces, members within tenant |
-| WorkspaceAdmin  | Workspace | Full workspace management                |
-| WorkspaceEditor | Workspace | Edit template versions/locales, injector values, field runtime policy, test-send, bulk-send |
-| WorkspaceViewer | Workspace | Read-only access                         |
-
-</details>
-
-<details>
-<summary><strong>Configuration</strong></summary>
-
-YAML config with environment variable overrides (`SENDA_` prefix). Priority: env vars > YAML > defaults.
-
-```bash
-cp config/config.example.yaml config/config.yaml
-```
-
-| Variable                   | Default   | Description                           |
-| -------------------------- | --------- | ------------------------------------- |
-| `SENDA_DATABASE_URL`       | --        | PostgreSQL connection URL (required)  |
-| `SENDA_MASTER_KEY`         | --        | AES-256-GCM key, 32+ chars (required) |
-| `SENDA_OIDC_DISCOVERY_URL` | --        | OIDC .well-known URL (required)       |
-| `SENDA_OIDC_CLIENT_ID`     | --        | OIDC client ID (required)             |
-| `SENDA_HOST`               | `0.0.0.0` | Bind address                          |
-| `SENDA_PORT`               | `8080`    | HTTP port                             |
-| `SENDA_LOG_LEVEL`          | `info`    | debug, info, warn, error              |
-| `SENDA_TRACKING_BASE_URL`  | --        | Public base URL for email tracking (open pixels, SES event auto-provisioning, SNS webhook). Unset = tracking disabled, auto-provisioning returns 501 |
-
-See [`config/config.example.yaml`](config/config.example.yaml) for all options.
-
-</details>
-
-<details>
-<summary><strong>MCP Integration (AI Agents)</strong></summary>
-
-Senda ships a single MCP server definition named `senda`, backed by
-[`mcp-openapi-proxy`](https://github.com/rendis/mcp-openapi-proxy) and the committed
-OpenAPI 3 spec at [`cmd/senda/docs/openapi.yaml`](cmd/senda/docs/openapi.yaml).
-
-**Install:**
-
-```bash
-go install github.com/rendis/mcp-openapi-proxy/cmd/mcp-openapi-proxy@latest
-```
-
-**Regenerate spec:**
-
-```bash
-make swagger
-```
-
-The repo includes `.mcp.json` with the server config. It exposes three tools:
-
-- `senda_list_endpoints` — discover operations
-- `senda_describe_endpoint` — inspect params and body
-- `senda_call_endpoint` — execute an endpoint
-
-**Authentication:**
-
-- Data plane: `export MCP_AUTH_WORKSPACEAPIKEYBEARER_TOKEN="senda_live_..."`
-- Management plane: `mcp-openapi-proxy login --mcp-config ./.mcp.json --server senda`
-
-**Supported clients:** Claude Code (auto-detects `.mcp.json`), Codex, Gemini CLI.
-
-> Full MCP setup guide with examples for each client: see the `.mcp.json` file and `AGENTS.md`.
-
-</details>
-
-<details>
-<summary><strong>Docker Services</strong></summary>
-
-**Dev stack** (`make dev`):
-
-| Service  | Port      | Purpose                     |
-| -------- | --------- | --------------------------- |
-| senda    | 8081      | Backend (Air hot-reload)    |
-| postgres | 5435      | PostgreSQL 16 + pg_cron     |
-| keycloak | 9090      | OIDC provider (admin/admin) |
-| mailpit  | 1026/8026 | SMTP capture + Web UI       |
-| caddy    | 443       | HTTPS proxy (optional)      |
-
-**Test users:**
-
-| Email                      | Password         | Role            |
-| -------------------------- | ---------------- | --------------- |
-| admin@senda.dev            | admin            | Superadmin      |
-| tenant-admin@senda.dev     | tenant-admin     | TenantAdmin     |
-| workspace-admin@senda.dev  | workspace-admin  | WorkspaceAdmin  |
-| workspace-editor@senda.dev | workspace-editor | WorkspaceEditor |
-| workspace-viewer@senda.dev | workspace-viewer | WorkspaceViewer |
-
-</details>
-
----
+For data-plane MCP usage, authenticate with a raw workspace API key such as `senda_prod_...` or `senda_test_...`.
 
 ## Development
 
-| Command                 | Description                        |
-| ----------------------- | ---------------------------------- |
-| `make dev`              | Start full Docker stack            |
-| `make build`            | Build Go binary                    |
-| `make test`             | Unit tests (race detector)         |
-| `make test-integration` | Integration tests (TestContainers) |
-| `make test-e2e`         | E2E deterministic gate             |
-| `make lint`             | golangci-lint                      |
-| `make swagger`          | Regenerate OpenAPI spec            |
-| `make system-pr`        | PR gate (functional + UI)          |
+| Command | Description |
+| --- | --- |
+| `make dev` | Start the Docker development stack |
+| `make test` | Unit tests with race detector |
+| `make test-integration` | Integration tests |
+| `make test-e2e` | Deterministic E2E gate |
+| `make test-e2e-chaos` | Chaos/resilience E2E gate |
+| `make system-pr` | System browser/API gate |
+| `make lint` | Go linting |
+| `pnpm --dir web typecheck` | Frontend typecheck |
+| `pnpm --dir web lint` | Frontend lint |
 
-Frontend: `pnpm --dir web dev` | `pnpm --dir web typecheck` | `pnpm --dir web lint`
+## Project structure
 
-> Full guide: [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)
-
----
-
-## Project Structure
-
-```
+```text
 senda/
-├── sdk/                    Public SDK (Engine, Injector, InjectorContext)
-├── cmd/senda/              Entry point (uses sdk.Engine)
+├── sdk/                    Public SDK
+├── cmd/senda/              Server entry point
 ├── internal/
-│   ├── domain/             Entities, value objects, domain errors
-│   ├── port/               Interface contracts (incl. CodeInjector)
+│   ├── domain/             Domain model and environment types
+│   ├── port/               Public extension and internal contracts
 │   ├── service/            Business logic
-│   ├── resolution/         Hierarchy chain resolution engine
-│   ├── adapter/            PostgreSQL, SES, Gmail, SMTP, River, MJML, Crypto
-│   ├── http/               Handlers + middleware
-│   └── app/                Bootstrap + DI wiring
-├── pkg/                    Shared utilities
-├── migrations/             37 migration versions (74 SQL files: up + down)
-├── config/                 YAML configuration
-├── docker/                 Dockerfiles + Compose
-├── test/                   E2E + system tests
-└── web/                    Next.js 16 frontend
+│   ├── resolution/         Scope and injector resolution
+│   ├── adapter/            Postgres, River, SES, Gmail, SMTP, MJML, crypto
+│   ├── http/               Handlers and middleware
+│   └── app/                Bootstrap and extension bridge
+├── migrations/             SQL migrations
+├── docs/                   Human-facing docs
+├── skills/senda/           Self-contained skill bundle for agents
+└── web/                    Next.js frontend
 ```
-
----
-
-## Documentation
-
-|                      | Document                                                           | Description                                    |
-| -------------------- | ------------------------------------------------------------------ | ---------------------------------------------- |
-| **Email Flows**      | [docs/EMAIL_FLOWS.md](docs/EMAIL_FLOWS.md)                         | Per-provider email lifecycle, status machine, tracking |
-| **Extensibility**    | [docs/extensibility-guide.md](docs/extensibility-guide.md)         | SDK guide: injectors, init, hooks, examples    |
-| **Architecture**     | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)                       | Hexagonal layers, resolution engine, ADRs      |
-| **API**              | [docs/API.md](docs/API.md)                                        | All endpoints, auth schemes, error codes       |
-| **Development**      | [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)                        | Setup, Docker, testing, troubleshooting        |
-| **Deployment**       | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)                          | Production Dockerfile, env vars, health checks |
-| **Postman**          | [docs/postman/](docs/postman/)                                    | Collection + environments                      |
-| **Tech Spec**        | [docs/specs/TECH_SPEC_v1.md](docs/specs/TECH_SPEC_v1.md)          | Complete technical specification               |
-
----
-
-## Contributing
-
-We welcome focused, well-validated contributions.
-
-Start with [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow, validation rules, commit conventions, and PR expectations. Please also read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) and [SECURITY.md](SECURITY.md) before opening issues or pull requests.
-
-The short version: fork the repo, create a focused branch, write or update tests first when behavior changes, run the fast local gates (`make ci-backend-pr`, `make ci-frontend`, `make ci-pr`, `make ci-main` as needed), and then run deeper suites like `make test-integration` and `make test-e2e` for systemic changes before opening a small PR with clear context.
-
-For larger changes, open an issue before implementation so maintainers can align on scope and fit. Repository-specific development and planning details remain documented in [AGENTS.md](AGENTS.md) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
-
----
-
-<div align="center">
-  <sub>Built with Go, PostgreSQL, and Next.js. No Redis required.</sub>
-  <br/>
-  <a href="LICENSE">MIT License</a>
-</div>

--- a/cmd/senda/docs/docs.go
+++ b/cmd/senda/docs/docs.go
@@ -315,6 +315,2057 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/external/{profile_slug}/bootstrap": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/bootstrap",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationBootstrapResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/environments/{environment}/bootstrap": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/environments/{environment}/bootstrap",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationBootstrapResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.InjectorListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name path parameter",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.InjectorDetailResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/policies": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/policies",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/session": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationSessionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateTypeListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "slug path parameter",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateTypeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "slug path parameter",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml": {
+            "post": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.MJMLPreviewRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.MJMLPreviewResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send": {
+            "post": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "PUT /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.CreateVersionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}": {
+            "get": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "locale path parameter",
+                        "name": "locale",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "PUT /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "locale path parameter",
+                        "name": "locale",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.SetLocaleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "locale path parameter",
+                        "name": "locale",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.SetLocaleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "DELETE /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "locale path parameter",
+                        "name": "locale",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish": {
+            "post": {
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "external"
+                ],
+                "summary": "POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "profile_slug path parameter",
+                        "name": "profile_slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "External integration environment selector (` + "`" + `prod` + "`" + ` or ` + "`" + `test` + "`" + `)",
+                        "name": "X-Senda-Environment",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/manage/config": {
             "get": {
                 "security": [
@@ -414,6 +2465,8232 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.ConfigResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.CreateAdapterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/validate-ses": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/validate-ses",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.UpdateAdapterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/auto-provision-tracking": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/auto-provision-tracking",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapter-identities"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapter-identities"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.CreateManualIdentityRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterIdentityResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/sync": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapter-identities"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/sync",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapter-identities"
+                ],
+                "summary": "DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "identity_id path parameter",
+                        "name": "identity_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/set-default": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapter-identities"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/set-default",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "identity_id path parameter",
+                        "name": "identity_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapter-identities"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "identity_id path parameter",
+                        "name": "identity_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapter-identities"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "identity_id path parameter",
+                        "name": "identity_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.UpdateAdapterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/provisioning-status": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/provisioning-status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/setup-guide": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/setup-guide",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/test": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/test",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "adapters"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.UpdateAdapterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "api-keys"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.APIKeyListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "api-keys"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.CreateAPIKeyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.APIKeyCreatedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "api-keys"
+                ],
+                "summary": "DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys/{id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/audit-log": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "audit"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/audit-log",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.AuditLogListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/dashboard-stats": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "dashboard"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/dashboard-stats",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.DashboardStatsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.EmailListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tracking_id path parameter",
+                        "name": "tracking_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.EmailDetailResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}/events": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}/events",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tracking_id path parameter",
+                        "name": "tracking_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.EmailEventResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "injectors"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.InjectorListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "injectors"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.CreateInjectorRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.InjectorDetailResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "injectors"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name path parameter",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.InjectorDetailResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "injectors"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name path parameter",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "injectors"
+                ],
+                "summary": "DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name path parameter",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/fields/{field_name}": {
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "injectors"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/fields/{field_name}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name path parameter",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "field_name path parameter",
+                        "name": "field_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.UpdateInjectorFieldRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.InjectorFieldResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/values": {
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "injectors"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/values",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name path parameter",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.SetInjectorValuesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "member_id path parameter",
+                        "name": "member_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "member_id path parameter",
+                        "name": "member_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles/{role_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles/{role_id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "member_id path parameter",
+                        "name": "member_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "role_id path parameter",
+                        "name": "role_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocWorkspacePolicyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.UpdateWorkspacePolicyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocWorkspacePolicyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/runtime/reset": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/runtime/reset",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "suppression"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.AddSuppressionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.SuppressionWorkspaceResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email}": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "suppression"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "email path parameter",
+                        "name": "email",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.SuppressionCheckResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "suppression"
+                ],
+                "summary": "DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "email path parameter",
+                        "name": "email",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "template-types"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateTypeListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "template-types"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.CreateTemplateTypeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateTypeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "template-types"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "slug path parameter",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateTypeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "template-types"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "slug path parameter",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "template-types"
+                ],
+                "summary": "DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "slug path parameter",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "template-types"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "slug path parameter",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.CreateTemplateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send-config": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/disable": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/disable",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/enable": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/enable",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.MJMLPreviewRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.MJMLPreviewResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.CreateVersionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.CreateVersionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "locale path parameter",
+                        "name": "locale",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "locale path parameter",
+                        "name": "locale",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.SetLocaleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "locale path parameter",
+                        "name": "locale",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.SetLocaleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "locale path parameter",
+                        "name": "locale",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "template_id path parameter",
+                        "name": "template_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "version_id path parameter",
+                        "name": "version_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "webhooks"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.WebhookListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "webhooks"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.CreateWebhookRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.WebhookCreatedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "webhooks"
+                ],
+                "summary": "GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.WebhookResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "webhooks"
+                ],
+                "summary": "PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.UpdateWebhookRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.WebhookResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "webhooks"
+                ],
+                "summary": "DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocGenericObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}/test": {
+            "post": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "webhooks"
+                ],
+                "summary": "POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}/test",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "environment path parameter",
+                        "name": "environment",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id path parameter",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocStatusResponse"
                         }
                     },
                     "400": {
@@ -9607,6 +19884,182 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies": {
+            "get": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "GET /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocWorkspacePolicyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ManagementBearer": []
+                    }
+                ],
+                "description": "Auto-generated route stub for OpenAPI + MCP discovery.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "PUT /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "tenant_code path parameter",
+                        "name": "tenant_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "workspace_code path parameter",
+                        "name": "workspace_code",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rendis_senda_internal_http_request.UpdateWorkspacePolicyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocWorkspacePolicyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/cmd_senda.DocErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/suppression": {
             "post": {
                 "security": [
@@ -13871,6 +24324,20 @@ const docTemplate = `{
                 }
             }
         },
+        "cmd_senda.DocWorkspacePolicyResponse": {
+            "type": "object",
+            "properties": {
+                "allow_workspace_inherited_template_forks": {
+                    "type": "boolean"
+                },
+                "allow_workspace_local_injectors": {
+                    "type": "boolean"
+                },
+                "allow_workspace_local_templates": {
+                    "type": "boolean"
+                }
+            }
+        },
         "github_com_rendis_senda_internal_http_request.AddRoleRequest": {
             "type": "object",
             "properties": {
@@ -14031,6 +24498,15 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "slug": {
+                    "type": "string"
+                },
+                "test_recipient_addresses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "test_recipient_mode": {
                     "type": "string"
                 },
                 "variable_schema": {
@@ -14462,9 +24938,26 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_rendis_senda_internal_http_request.UpdateWorkspacePolicyRequest": {
+            "type": "object",
+            "properties": {
+                "allow_workspace_inherited_template_forks": {
+                    "type": "boolean"
+                },
+                "allow_workspace_local_injectors": {
+                    "type": "boolean"
+                },
+                "allow_workspace_local_templates": {
+                    "type": "boolean"
+                }
+            }
+        },
         "github_com_rendis_senda_internal_http_request.UpdateWorkspaceRequest": {
             "type": "object",
             "properties": {
+                "code": {
+                    "type": "string"
+                },
                 "default_locale": {
                     "type": "string"
                 },
@@ -14476,6 +24969,15 @@ const docTemplate = `{
                 },
                 "open_tracking_enabled": {
                     "type": "boolean"
+                },
+                "test_recipient_addresses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "test_recipient_mode": {
+                    "type": "string"
                 }
             }
         },
@@ -15140,6 +25642,17 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_rendis_senda_internal_http_response.ExternalIntegrationBootstrapResponse": {
+            "type": "object",
+            "properties": {
+                "frame_ancestors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse": {
             "type": "object",
             "properties": {
@@ -15210,6 +25723,20 @@ const docTemplate = `{
                 },
                 "slug": {
                     "type": "string"
+                }
+            }
+        },
+        "github_com_rendis_senda_internal_http_response.ExternalIntegrationSessionResponse": {
+            "type": "object",
+            "properties": {
+                "effective_workspace_code": {
+                    "type": "string"
+                },
+                "permissions": {
+                    "$ref": "#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse"
+                },
+                "read_only": {
+                    "type": "boolean"
                 }
             }
         },
@@ -15723,6 +26250,15 @@ const docTemplate = `{
                 "slug": {
                     "type": "string"
                 },
+                "test_recipient_addresses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "test_recipient_mode": {
+                    "type": "string"
+                },
                 "updated_at": {
                     "type": "string"
                 },
@@ -16006,6 +26542,9 @@ const docTemplate = `{
                 "default_locale": {
                     "type": "string"
                 },
+                "environment": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -16015,6 +26554,9 @@ const docTemplate = `{
                 "is_system": {
                     "type": "boolean"
                 },
+                "logical_workspace_id": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -16022,6 +26564,15 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "tenant_id": {
+                    "type": "string"
+                },
+                "test_recipient_addresses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "test_recipient_mode": {
                     "type": "string"
                 },
                 "updated_at": {
@@ -16038,7 +26589,7 @@ const docTemplate = `{
             "in": "header"
         },
         "WorkspaceAPIKeyBearer": {
-            "description": "Workspace API key sent as ` + "`" + `Authorization: Bearer senda_live_...` + "`" + `.",
+            "description": "Workspace API key sent as ` + "`" + `Authorization: Bearer senda_prod_...` + "`" + ` or ` + "`" + `Authorization: Bearer senda_test_...` + "`" + `.",
             "type": "apiKey",
             "name": "Authorization",
             "in": "header"

--- a/cmd/senda/docs/openapi.yaml
+++ b/cmd/senda/docs/openapi.yaml
@@ -30,6 +30,15 @@ components:
                 status:
                     type: string
             type: object
+        cmd_senda.DocWorkspacePolicyResponse:
+            properties:
+                allow_workspace_inherited_template_forks:
+                    type: boolean
+                allow_workspace_local_injectors:
+                    type: boolean
+                allow_workspace_local_templates:
+                    type: boolean
+            type: object
         github_com_rendis_senda_internal_http_request.AddRoleRequest:
             properties:
                 role:
@@ -134,6 +143,12 @@ components:
                 sender_identity_id:
                     type: string
                 slug:
+                    type: string
+                test_recipient_addresses:
+                    items:
+                        type: string
+                    type: array
+                test_recipient_mode:
                     type: string
                 variable_schema:
                     items:
@@ -415,8 +430,19 @@ components:
                 url:
                     type: string
             type: object
+        github_com_rendis_senda_internal_http_request.UpdateWorkspacePolicyRequest:
+            properties:
+                allow_workspace_inherited_template_forks:
+                    type: boolean
+                allow_workspace_local_injectors:
+                    type: boolean
+                allow_workspace_local_templates:
+                    type: boolean
+            type: object
         github_com_rendis_senda_internal_http_request.UpdateWorkspaceRequest:
             properties:
+                code:
+                    type: string
                 default_locale:
                     type: string
                 is_active:
@@ -425,6 +451,12 @@ components:
                     type: string
                 open_tracking_enabled:
                     type: boolean
+                test_recipient_addresses:
+                    items:
+                        type: string
+                    type: array
+                test_recipient_mode:
+                    type: string
             type: object
         github_com_rendis_senda_internal_http_response.APIKeyCreatedResponse:
             properties:
@@ -860,6 +892,13 @@ components:
                 workspace_id:
                     type: string
             type: object
+        github_com_rendis_senda_internal_http_response.ExternalIntegrationBootstrapResponse:
+            properties:
+                frame_ancestors:
+                    items:
+                        type: string
+                    type: array
+            type: object
         github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse:
             properties:
                 builder_access:
@@ -907,6 +946,15 @@ components:
                     type: string
                 slug:
                     type: string
+            type: object
+        github_com_rendis_senda_internal_http_response.ExternalIntegrationSessionResponse:
+            properties:
+                effective_workspace_code:
+                    type: string
+                permissions:
+                    $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse'
+                read_only:
+                    type: boolean
             type: object
         github_com_rendis_senda_internal_http_response.ExternalIntegrationsConfigResponse:
             properties:
@@ -1240,6 +1288,12 @@ components:
                     type: string
                 slug:
                     type: string
+                test_recipient_addresses:
+                    items:
+                        type: string
+                    type: array
+                test_recipient_mode:
+                    type: string
                 updated_at:
                     type: string
                 variable_schema:
@@ -1425,17 +1479,27 @@ components:
                     type: string
                 default_locale:
                     type: string
+                environment:
+                    type: string
                 id:
                     type: string
                 is_active:
                     type: boolean
                 is_system:
                     type: boolean
+                logical_workspace_id:
+                    type: string
                 name:
                     type: string
                 open_tracking_enabled:
                     type: boolean
                 tenant_id:
+                    type: string
+                test_recipient_addresses:
+                    items:
+                        type: string
+                    type: array
+                test_recipient_mode:
                     type: string
                 updated_at:
                     type: string
@@ -1447,8 +1511,8 @@ components:
             scheme: bearer
             type: http
         WorkspaceAPIKeyBearer:
-            bearerFormat: senda_live
-            description: 'Workspace-scoped API key sent as Authorization: Bearer senda_live_...'
+            bearerFormat: senda_prod|senda_test
+            description: 'Workspace-scoped API key sent as Authorization: Bearer senda_prod_... or senda_test_....'
             scheme: bearer
             type: http
 info:
@@ -1711,6 +1775,1780 @@ paths:
             summary: GET /api/v1/emails/export
             tags:
                 - emails
+    /api/v1/external/{profile_slug}/bootstrap:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.ExternalIntegrationBootstrapResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/bootstrap
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/environments/{environment}/bootstrap:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.ExternalIntegrationBootstrapResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/environments/{environment}/bootstrap
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.InjectorListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: name path parameter
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.InjectorDetailResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/policies:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/session:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.ExternalIntegrationSessionResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/session
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: Pagination cursor
+                  in: query
+                  name: cursor
+                  schema:
+                    type: string
+                - description: Page size
+                  in: query
+                  name: limit
+                  schema:
+                    type: integer
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateTypeListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: slug path parameter
+                  in: path
+                  name: slug
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateTypeResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: slug path parameter
+                  in: path
+                  name: slug
+                  required: true
+                  schema:
+                    type: string
+                - description: Pagination cursor
+                  in: query
+                  name: cursor
+                  schema:
+                    type: string
+                - description: Page size
+                  in: query
+                  name: limit
+                  schema:
+                    type: integer
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.MJMLPreviewRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.MJMLPreviewResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions
+            tags:
+                - external
+    /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+            tags:
+                - external
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.CreateVersionRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: PUT /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+            tags:
+                - external
+    ? /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales
+    :   get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales
+            tags:
+                - external
+    ? /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+    :   delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: locale path parameter
+                  in: path
+                  name: locale
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: DELETE /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+            tags:
+                - external
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: locale path parameter
+                  in: path
+                  name: locale
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+            tags:
+                - external
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: locale path parameter
+                  in: path
+                  name: locale
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.SetLocaleRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+            tags:
+                - external
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: locale path parameter
+                  in: path
+                  name: locale
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.SetLocaleRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: PUT /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+            tags:
+                - external
+    ? /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish
+    :   post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: profile_slug path parameter
+                  in: path
+                  name: profile_slug
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: External integration environment selector (`prod` or `test`)
+                  in: header
+                  name: X-Senda-Environment
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            summary: POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish
+            tags:
+                - external
     /api/v1/manage/config:
         get:
             description: Auto-generated route stub for OpenAPI + MCP discovery.
@@ -1832,6 +3670,6914 @@ paths:
             summary: PUT /api/v1/manage/config
             tags:
                 - config
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: Pagination cursor
+                  in: query
+                  name: cursor
+                  schema:
+                    type: string
+                - description: Page size
+                  in: query
+                  name: limit
+                  schema:
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces
+            tags:
+                - workspaces
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}
+            tags:
+                - workspaces
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/cmd_senda.DocGenericBody'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}
+            tags:
+                - workspaces
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: Pagination cursor
+                  in: query
+                  name: cursor
+                  schema:
+                    type: string
+                - description: Page size
+                  in: query
+                  name: limit
+                  schema:
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters
+            tags:
+                - adapters
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.CreateAdapterRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters
+            tags:
+                - adapters
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}:
+        delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}
+            tags:
+                - adapters
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}
+            tags:
+                - adapters
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.UpdateAdapterRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}
+            tags:
+                - adapters
+    ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/auto-provision-tracking
+    :   post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/auto-provision-tracking
+            tags:
+                - adapters
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities
+            tags:
+                - adapter-identities
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.CreateManualIdentityRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterIdentityResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities
+            tags:
+                - adapter-identities
+    ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}
+    :   delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: identity_id path parameter
+                  in: path
+                  name: identity_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}
+            tags:
+                - adapter-identities
+    ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/set-default
+    :   post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: identity_id path parameter
+                  in: path
+                  name: identity_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/set-default
+            tags:
+                - adapter-identities
+    ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access
+    :   get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: identity_id path parameter
+                  in: path
+                  name: identity_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access
+            tags:
+                - adapter-identities
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: identity_id path parameter
+                  in: path
+                  name: identity_id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.UpdateAdapterRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access
+            tags:
+                - adapter-identities
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/sync:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/sync
+            tags:
+                - adapter-identities
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/provisioning-status:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/provisioning-status
+            tags:
+                - adapters
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/setup-guide:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/setup-guide
+            tags:
+                - adapters
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/test:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/test
+            tags:
+                - adapters
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access
+            tags:
+                - adapters
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.UpdateAdapterRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AdapterResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access
+            tags:
+                - adapters
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/validate-ses:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/cmd_senda.DocGenericBody'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/validate-ses
+            tags:
+                - adapters
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: Pagination cursor
+                  in: query
+                  name: cursor
+                  schema:
+                    type: string
+                - description: Page size
+                  in: query
+                  name: limit
+                  schema:
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.APIKeyListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys
+            tags:
+                - api-keys
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.CreateAPIKeyRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.APIKeyCreatedResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys
+            tags:
+                - api-keys
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys/{id}:
+        delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys/{id}
+            tags:
+                - api-keys
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/audit-log:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: Pagination cursor
+                  in: query
+                  name: cursor
+                  schema:
+                    type: string
+                - description: Page size
+                  in: query
+                  name: limit
+                  schema:
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.AuditLogListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/audit-log
+            tags:
+                - audit
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/dashboard-stats:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.DashboardStatsResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/dashboard-stats
+            tags:
+                - dashboard
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: Pagination cursor
+                  in: query
+                  name: cursor
+                  schema:
+                    type: string
+                - description: Page size
+                  in: query
+                  name: limit
+                  schema:
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.EmailListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails
+            tags:
+                - workspaces
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: tracking_id path parameter
+                  in: path
+                  name: tracking_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.EmailDetailResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}
+            tags:
+                - workspaces
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}/events:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: tracking_id path parameter
+                  in: path
+                  name: tracking_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.EmailEventResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}/events
+            tags:
+                - workspaces
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.InjectorListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors
+            tags:
+                - injectors
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.CreateInjectorRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.InjectorDetailResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors
+            tags:
+                - injectors
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}:
+        delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: name path parameter
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+            tags:
+                - injectors
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: name path parameter
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.InjectorDetailResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+            tags:
+                - injectors
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: name path parameter
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/cmd_senda.DocGenericBody'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+            tags:
+                - injectors
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/fields/{field_name}:
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: name path parameter
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: field_name path parameter
+                  in: path
+                  name: field_name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.UpdateInjectorFieldRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.InjectorFieldResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/fields/{field_name}
+            tags:
+                - injectors
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/values:
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: name path parameter
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.SetInjectorValuesRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/values
+            tags:
+                - injectors
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: Pagination cursor
+                  in: query
+                  name: cursor
+                  schema:
+                    type: string
+                - description: Page size
+                  in: query
+                  name: limit
+                  schema:
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members
+            tags:
+                - workspaces
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/cmd_senda.DocGenericBody'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members
+            tags:
+                - workspaces
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: member_id path parameter
+                  in: path
+                  name: member_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}
+            tags:
+                - workspaces
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: member_id path parameter
+                  in: path
+                  name: member_id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/cmd_senda.DocGenericBody'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles
+            tags:
+                - workspaces
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles/{role_id}:
+        delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: member_id path parameter
+                  in: path
+                  name: member_id
+                  required: true
+                  schema:
+                    type: string
+                - description: role_id path parameter
+                  in: path
+                  name: role_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles/{role_id}
+            tags:
+                - workspaces
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocWorkspacePolicyResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+            tags:
+                - workspaces
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.UpdateWorkspacePolicyRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocWorkspacePolicyResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+            tags:
+                - workspaces
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/runtime/reset:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/cmd_senda.DocGenericBody'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/runtime/reset
+            tags:
+                - workspaces
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.AddSuppressionRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.SuppressionWorkspaceResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression
+            tags:
+                - suppression
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email}:
+        delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: email path parameter
+                  in: path
+                  name: email
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email}
+            tags:
+                - suppression
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: email path parameter
+                  in: path
+                  name: email
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.SuppressionCheckResponse'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email}
+            tags:
+                - suppression
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: Pagination cursor
+                  in: query
+                  name: cursor
+                  schema:
+                    type: string
+                - description: Page size
+                  in: query
+                  name: limit
+                  schema:
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateTypeListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types
+            tags:
+                - template-types
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.CreateTemplateTypeRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateTypeResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types
+            tags:
+                - template-types
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}:
+        delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: slug path parameter
+                  in: path
+                  name: slug
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+            tags:
+                - template-types
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: slug path parameter
+                  in: path
+                  name: slug
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateTypeResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+            tags:
+                - template-types
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: slug path parameter
+                  in: path
+                  name: slug
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/cmd_senda.DocGenericBody'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+            tags:
+                - template-types
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: slug path parameter
+                  in: path
+                  name: slug
+                  required: true
+                  schema:
+                    type: string
+                - description: Pagination cursor
+                  in: query
+                  name: cursor
+                  schema:
+                    type: string
+                - description: Page size
+                  in: query
+                  name: limit
+                  schema:
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates
+            tags:
+                - template-types
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.CreateTemplateRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates
+            tags:
+                - templates
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}:
+        delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}
+            tags:
+                - templates
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/cmd_senda.DocGenericBody'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send
+            tags:
+                - templates
+    ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send-config
+    :   get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send-config
+            tags:
+                - templates
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/disable:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/disable
+            tags:
+                - templates
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/enable:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/enable
+            tags:
+                - templates
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/cmd_senda.DocGenericBody'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork
+            tags:
+                - templates
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.MJMLPreviewRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.MJMLPreviewResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml
+            tags:
+                - templates
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send
+            tags:
+                - templates
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions
+            tags:
+                - templates
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.CreateVersionRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions
+            tags:
+                - templates
+    ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+    :   delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+            tags:
+                - templates
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+            tags:
+                - templates
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.CreateVersionRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+            tags:
+                - templates
+    ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone
+    :   post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone
+            tags:
+                - templates
+    ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales
+    :   get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales
+            tags:
+                - templates
+    ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+    :   delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: locale path parameter
+                  in: path
+                  name: locale
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+            tags:
+                - templates
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: locale path parameter
+                  in: path
+                  name: locale
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+            tags:
+                - templates
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: locale path parameter
+                  in: path
+                  name: locale
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.SetLocaleRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+            tags:
+                - templates
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+                - description: locale path parameter
+                  in: path
+                  name: locale
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.SetLocaleRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+            tags:
+                - templates
+    ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish
+    :   post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: template_id path parameter
+                  in: path
+                  name: template_id
+                  required: true
+                  schema:
+                    type: string
+                - description: version_id path parameter
+                  in: path
+                  name: version_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish
+            tags:
+                - templates
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: Pagination cursor
+                  in: query
+                  name: cursor
+                  schema:
+                    type: string
+                - description: Page size
+                  in: query
+                  name: limit
+                  schema:
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.WebhookListResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks
+            tags:
+                - webhooks
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.CreateWebhookRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.WebhookCreatedResponse'
+                    description: Created
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks
+            tags:
+                - webhooks
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}:
+        delete:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocGenericObject'
+                    description: No Content
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}
+            tags:
+                - webhooks
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.WebhookResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}
+            tags:
+                - webhooks
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.UpdateWebhookRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github_com_rendis_senda_internal_http_response.WebhookResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}
+            tags:
+                - webhooks
+    /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}/test:
+        post:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: environment path parameter
+                  in: path
+                  name: environment
+                  required: true
+                  schema:
+                    type: string
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+                - description: id path parameter
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocStatusResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}/test
+            tags:
+                - webhooks
     /api/v1/manage/global/adapters:
         get:
             description: Auto-generated route stub for OpenAPI + MCP discovery.
@@ -9485,6 +18231,153 @@ paths:
             security:
                 - ManagementBearer: []
             summary: DELETE /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles/{role_id}
+            tags:
+                - workspaces
+    /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies:
+        get:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocWorkspacePolicyResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: GET /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+            tags:
+                - workspaces
+        put:
+            description: Auto-generated route stub for OpenAPI + MCP discovery.
+            parameters:
+                - description: tenant_code path parameter
+                  in: path
+                  name: tenant_code
+                  required: true
+                  schema:
+                    type: string
+                - description: workspace_code path parameter
+                  in: path
+                  name: workspace_code
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/github_com_rendis_senda_internal_http_request.UpdateWorkspacePolicyRequest'
+                description: Request body
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocWorkspacePolicyResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Bad Request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Forbidden
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Not Found
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Conflict
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Unprocessable Entity
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/cmd_senda.DocErrorResponse'
+                    description: Internal Server Error
+            security:
+                - ManagementBearer: []
+            summary: PUT /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies
             tags:
                 - workspaces
     /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/suppression:

--- a/cmd/senda/docs/swagger.yaml
+++ b/cmd/senda/docs/swagger.yaml
@@ -30,6 +30,15 @@ definitions:
       status:
         type: string
     type: object
+  cmd_senda.DocWorkspacePolicyResponse:
+    properties:
+      allow_workspace_inherited_template_forks:
+        type: boolean
+      allow_workspace_local_injectors:
+        type: boolean
+      allow_workspace_local_templates:
+        type: boolean
+    type: object
   github_com_rendis_senda_internal_http_request.AddRoleRequest:
     properties:
       role:
@@ -134,6 +143,12 @@ definitions:
       sender_identity_id:
         type: string
       slug:
+        type: string
+      test_recipient_addresses:
+        items:
+          type: string
+        type: array
+      test_recipient_mode:
         type: string
       variable_schema:
         items:
@@ -415,8 +430,19 @@ definitions:
       url:
         type: string
     type: object
+  github_com_rendis_senda_internal_http_request.UpdateWorkspacePolicyRequest:
+    properties:
+      allow_workspace_inherited_template_forks:
+        type: boolean
+      allow_workspace_local_injectors:
+        type: boolean
+      allow_workspace_local_templates:
+        type: boolean
+    type: object
   github_com_rendis_senda_internal_http_request.UpdateWorkspaceRequest:
     properties:
+      code:
+        type: string
       default_locale:
         type: string
       is_active:
@@ -425,6 +451,12 @@ definitions:
         type: string
       open_tracking_enabled:
         type: boolean
+      test_recipient_addresses:
+        items:
+          type: string
+        type: array
+      test_recipient_mode:
+        type: string
     type: object
   github_com_rendis_senda_internal_http_response.APIKeyCreatedResponse:
     properties:
@@ -860,6 +892,13 @@ definitions:
       workspace_id:
         type: string
     type: object
+  github_com_rendis_senda_internal_http_response.ExternalIntegrationBootstrapResponse:
+    properties:
+      frame_ancestors:
+        items:
+          type: string
+        type: array
+    type: object
   github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse:
     properties:
       builder_access:
@@ -907,6 +946,15 @@ definitions:
         type: string
       slug:
         type: string
+    type: object
+  github_com_rendis_senda_internal_http_response.ExternalIntegrationSessionResponse:
+    properties:
+      effective_workspace_code:
+        type: string
+      permissions:
+        $ref: '#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationCapabilitiesResponse'
+      read_only:
+        type: boolean
     type: object
   github_com_rendis_senda_internal_http_response.ExternalIntegrationsConfigResponse:
     properties:
@@ -1240,6 +1288,12 @@ definitions:
         type: string
       slug:
         type: string
+      test_recipient_addresses:
+        items:
+          type: string
+        type: array
+      test_recipient_mode:
+        type: string
       updated_at:
         type: string
       variable_schema:
@@ -1425,17 +1479,27 @@ definitions:
         type: string
       default_locale:
         type: string
+      environment:
+        type: string
       id:
         type: string
       is_active:
         type: boolean
       is_system:
         type: boolean
+      logical_workspace_id:
+        type: string
       name:
         type: string
       open_tracking_enabled:
         type: boolean
       tenant_id:
+        type: string
+      test_recipient_addresses:
+        items:
+          type: string
+        type: array
+      test_recipient_mode:
         type: string
       updated_at:
         type: string
@@ -1639,6 +1703,1395 @@ paths:
       summary: GET /api/v1/emails/export
       tags:
       - emails
+  /api/v1/external/{profile_slug}/bootstrap:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationBootstrapResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/bootstrap
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/environments/{environment}/bootstrap:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationBootstrapResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/environments/{environment}/bootstrap
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.InjectorListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: name path parameter
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.InjectorDetailResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/policies:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/session:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.ExternalIntegrationSessionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/session
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Page size
+        in: query
+        name: limit
+        type: integer
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateTypeListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: slug path parameter
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateTypeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: slug path parameter
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Page size
+        in: query
+        name: limit
+        type: integer
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml:
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.MJMLPreviewRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.MJMLPreviewResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send:
+    post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions
+      tags:
+      - external
+  /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+      tags:
+      - external
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.CreateVersionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: PUT /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+      tags:
+      - external
+  ? /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales
+  : get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales
+      tags:
+      - external
+  ? /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+  : delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: locale path parameter
+        in: path
+        name: locale
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: DELETE /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+      tags:
+      - external
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: locale path parameter
+        in: path
+        name: locale
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+      tags:
+      - external
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: locale path parameter
+        in: path
+        name: locale
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.SetLocaleRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+      tags:
+      - external
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: locale path parameter
+        in: path
+        name: locale
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.SetLocaleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: PUT /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+      tags:
+      - external
+  ? /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish
+  : post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: profile_slug path parameter
+        in: path
+        name: profile_slug
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: External integration environment selector (`prod` or `test`)
+        in: header
+        name: X-Senda-Environment
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      summary: POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish
+      tags:
+      - external
   /api/v1/manage/config:
     get:
       description: Auto-generated route stub for OpenAPI + MCP discovery.
@@ -1733,6 +3186,5443 @@ paths:
       summary: PUT /api/v1/manage/config
       tags:
       - config
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Page size
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces
+      tags:
+      - workspaces
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}
+      tags:
+      - workspaces
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/cmd_senda.DocGenericBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}
+      tags:
+      - workspaces
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Page size
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters
+      tags:
+      - adapters
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.CreateAdapterRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters
+      tags:
+      - adapters
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}:
+    delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}
+      tags:
+      - adapters
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}
+      tags:
+      - adapters
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.UpdateAdapterRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}
+      tags:
+      - adapters
+  ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/auto-provision-tracking
+  : post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/auto-provision-tracking
+      tags:
+      - adapters
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities
+      tags:
+      - adapter-identities
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.CreateManualIdentityRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterIdentityResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities
+      tags:
+      - adapter-identities
+  ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}
+  : delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: identity_id path parameter
+        in: path
+        name: identity_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}
+      tags:
+      - adapter-identities
+  ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/set-default
+  : post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: identity_id path parameter
+        in: path
+        name: identity_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/set-default
+      tags:
+      - adapter-identities
+  ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access
+  : get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: identity_id path parameter
+        in: path
+        name: identity_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access
+      tags:
+      - adapter-identities
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: identity_id path parameter
+        in: path
+        name: identity_id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.UpdateAdapterRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access
+      tags:
+      - adapter-identities
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/sync:
+    post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/sync
+      tags:
+      - adapter-identities
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/provisioning-status:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/provisioning-status
+      tags:
+      - adapters
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/setup-guide:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/setup-guide
+      tags:
+      - adapters
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/test:
+    post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/test
+      tags:
+      - adapters
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access
+      tags:
+      - adapters
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.UpdateAdapterRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AdapterResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access
+      tags:
+      - adapters
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/validate-ses:
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/cmd_senda.DocGenericBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/validate-ses
+      tags:
+      - adapters
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Page size
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.APIKeyListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys
+      tags:
+      - api-keys
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.CreateAPIKeyRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.APIKeyCreatedResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys
+      tags:
+      - api-keys
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys/{id}:
+    delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys/{id}
+      tags:
+      - api-keys
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/audit-log:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Page size
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.AuditLogListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/audit-log
+      tags:
+      - audit
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/dashboard-stats:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.DashboardStatsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/dashboard-stats
+      tags:
+      - dashboard
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Page size
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.EmailListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails
+      tags:
+      - workspaces
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: tracking_id path parameter
+        in: path
+        name: tracking_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.EmailDetailResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}
+      tags:
+      - workspaces
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}/events:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: tracking_id path parameter
+        in: path
+        name: tracking_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.EmailEventResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}/events
+      tags:
+      - workspaces
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.InjectorListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors
+      tags:
+      - injectors
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.CreateInjectorRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.InjectorDetailResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors
+      tags:
+      - injectors
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}:
+    delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: name path parameter
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+      tags:
+      - injectors
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: name path parameter
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.InjectorDetailResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+      tags:
+      - injectors
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: name path parameter
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/cmd_senda.DocGenericBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+      tags:
+      - injectors
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/fields/{field_name}:
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: name path parameter
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: field_name path parameter
+        in: path
+        name: field_name
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.UpdateInjectorFieldRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.InjectorFieldResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/fields/{field_name}
+      tags:
+      - injectors
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/values:
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: name path parameter
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.SetInjectorValuesRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/values
+      tags:
+      - injectors
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Page size
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members
+      tags:
+      - workspaces
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/cmd_senda.DocGenericBody'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members
+      tags:
+      - workspaces
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: member_id path parameter
+        in: path
+        name: member_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}
+      tags:
+      - workspaces
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles:
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: member_id path parameter
+        in: path
+        name: member_id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/cmd_senda.DocGenericBody'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles
+      tags:
+      - workspaces
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles/{role_id}:
+    delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: member_id path parameter
+        in: path
+        name: member_id
+        required: true
+        type: string
+      - description: role_id path parameter
+        in: path
+        name: role_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles/{role_id}
+      tags:
+      - workspaces
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocWorkspacePolicyResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+      tags:
+      - workspaces
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.UpdateWorkspacePolicyRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocWorkspacePolicyResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+      tags:
+      - workspaces
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/runtime/reset:
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/cmd_senda.DocGenericBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/runtime/reset
+      tags:
+      - workspaces
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression:
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.AddSuppressionRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.SuppressionWorkspaceResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression
+      tags:
+      - suppression
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email}:
+    delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: email path parameter
+        in: path
+        name: email
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email}
+      tags:
+      - suppression
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: email path parameter
+        in: path
+        name: email
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.SuppressionCheckResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email}
+      tags:
+      - suppression
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Page size
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateTypeListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types
+      tags:
+      - template-types
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.CreateTemplateTypeRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateTypeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types
+      tags:
+      - template-types
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}:
+    delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: slug path parameter
+        in: path
+        name: slug
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+      tags:
+      - template-types
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: slug path parameter
+        in: path
+        name: slug
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateTypeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+      tags:
+      - template-types
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: slug path parameter
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/cmd_senda.DocGenericBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+      tags:
+      - template-types
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: slug path parameter
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Page size
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates
+      tags:
+      - template-types
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates:
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.CreateTemplateRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates
+      tags:
+      - templates
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}:
+    delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}
+      tags:
+      - templates
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send:
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/cmd_senda.DocGenericBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send
+      tags:
+      - templates
+  ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send-config
+  : get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send-config
+      tags:
+      - templates
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/disable:
+    post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/disable
+      tags:
+      - templates
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/enable:
+    post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/enable
+      tags:
+      - templates
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork:
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/cmd_senda.DocGenericBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork
+      tags:
+      - templates
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml:
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.MJMLPreviewRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.MJMLPreviewResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml
+      tags:
+      - templates
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send:
+    post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send
+      tags:
+      - templates
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions
+      tags:
+      - templates
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.CreateVersionRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions
+      tags:
+      - templates
+  ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+  : delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+      tags:
+      - templates
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+      tags:
+      - templates
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.CreateVersionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+      tags:
+      - templates
+  ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone
+  : post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone
+      tags:
+      - templates
+  ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales
+  : get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales
+      tags:
+      - templates
+  ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+  : delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: locale path parameter
+        in: path
+        name: locale
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+      tags:
+      - templates
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: locale path parameter
+        in: path
+        name: locale
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+      tags:
+      - templates
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: locale path parameter
+        in: path
+        name: locale
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.SetLocaleRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+      tags:
+      - templates
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      - description: locale path parameter
+        in: path
+        name: locale
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.SetLocaleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.TemplateVersionLocaleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+      tags:
+      - templates
+  ? /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish
+  : post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: template_id path parameter
+        in: path
+        name: template_id
+        required: true
+        type: string
+      - description: version_id path parameter
+        in: path
+        name: version_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish
+      tags:
+      - templates
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Page size
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.WebhookListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks
+      tags:
+      - webhooks
+    post:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.CreateWebhookRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.WebhookCreatedResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks
+      tags:
+      - webhooks
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}:
+    delete:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/cmd_senda.DocGenericObject'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}
+      tags:
+      - webhooks
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.WebhookResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}
+      tags:
+      - webhooks
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.UpdateWebhookRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_rendis_senda_internal_http_response.WebhookResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}
+      tags:
+      - webhooks
+  /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}/test:
+    post:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: environment path parameter
+        in: path
+        name: environment
+        required: true
+        type: string
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: id path parameter
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}/test
+      tags:
+      - webhooks
   /api/v1/manage/global/adapters:
     get:
       description: Auto-generated route stub for OpenAPI + MCP discovery.
@@ -7694,6 +14584,121 @@ paths:
       summary: DELETE /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles/{role_id}
       tags:
       - workspaces
+  /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies:
+    get:
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocWorkspacePolicyResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: GET /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+      tags:
+      - workspaces
+    put:
+      consumes:
+      - application/json
+      description: Auto-generated route stub for OpenAPI + MCP discovery.
+      parameters:
+      - description: tenant_code path parameter
+        in: path
+        name: tenant_code
+        required: true
+        type: string
+      - description: workspace_code path parameter
+        in: path
+        name: workspace_code
+        required: true
+        type: string
+      - description: Request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_rendis_senda_internal_http_request.UpdateWorkspacePolicyRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/cmd_senda.DocWorkspacePolicyResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/cmd_senda.DocErrorResponse'
+      security:
+      - ManagementBearer: []
+      summary: PUT /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+      tags:
+      - workspaces
   /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/suppression:
     post:
       consumes:
@@ -10472,7 +17477,8 @@ securityDefinitions:
     name: Authorization
     type: apiKey
   WorkspaceAPIKeyBearer:
-    description: 'Workspace API key sent as `Authorization: Bearer senda_live_...`.'
+    description: 'Workspace API key sent as `Authorization: Bearer senda_prod_...`
+      or `Authorization: Bearer senda_test_...`.'
     in: header
     name: Authorization
     type: apiKey

--- a/cmd/senda/main.go
+++ b/cmd/senda/main.go
@@ -18,7 +18,7 @@ import (
 // @securityDefinitions.apikey WorkspaceAPIKeyBearer
 // @in              header
 // @name            Authorization
-// @description     Workspace API key sent as `Authorization: Bearer senda_live_...`.
+// @description     Workspace API key sent as `Authorization: Bearer senda_prod_...` or `Authorization: Bearer senda_test_...`.
 func main() {
 	cfgPath := os.Getenv("SENDA_CONFIG")
 	if cfgPath == "" {

--- a/cmd/senda/openapi_generated.go
+++ b/cmd/senda/openapi_generated.go
@@ -38,6 +38,12 @@ type DocTemplateLocaleListResponse struct {
 	Items []response.TemplateVersionLocaleResponse `json:"items"`
 }
 
+type DocWorkspacePolicyResponse struct {
+	AllowWorkspaceLocalTemplates bool `json:"allow_workspace_local_templates"`
+	AllowWorkspaceInheritedTemplateForks bool `json:"allow_workspace_inherited_template_forks"`
+	AllowWorkspaceLocalInjectors bool `json:"allow_workspace_local_injectors"`
+}
+
 // doc_get_api_v1_emails auto-generated route documentation.
 // @Summary      GET /api/v1/emails
 // @Description  Auto-generated route stub for OpenAPI + MCP discovery.
@@ -110,6 +116,439 @@ func doc_get_api_v1_emails_tracking_id_events() {}
 // @Router       /api/v1/emails/export [get]
 func doc_get_api_v1_emails_export() {}
 
+// doc_get_api_v1_external_profile_slug_bootstrap auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/bootstrap
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Success      200  {object}  response.ExternalIntegrationBootstrapResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/bootstrap [get]
+func doc_get_api_v1_external_profile_slug_bootstrap() {}
+
+// doc_get_api_v1_external_profile_slug_environments_environment_bootstrap auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/environments/{environment}/bootstrap
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        environment  path  string  true  "environment path parameter"
+// @Success      200  {object}  response.ExternalIntegrationBootstrapResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/environments/{environment}/bootstrap [get]
+func doc_get_api_v1_external_profile_slug_environments_environment_bootstrap() {}
+
+// doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_injectors auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  response.InjectorListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors [get]
+func doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_injectors() {}
+
+// doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_injectors_name auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        name  path  string  true  "name path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  response.InjectorDetailResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name} [get]
+func doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_injectors_name() {}
+
+// doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_policies auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/policies [get]
+func doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_policies() {}
+
+// doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_session auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/session
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  response.ExternalIntegrationSessionResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/session [get]
+func doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_session() {}
+
+// doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_template_types auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        cursor  query  string  false  "Pagination cursor"
+// @Param        limit  query  integer  false  "Page size"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  response.TemplateTypeListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types [get]
+func doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_template_types() {}
+
+// doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_template_types_slug auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        slug  path  string  true  "slug path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  response.TemplateTypeResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug} [get]
+func doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_template_types_slug() {}
+
+// doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_template_types_slug_templates auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        slug  path  string  true  "slug path parameter"
+// @Param        cursor  query  string  false  "Pagination cursor"
+// @Param        limit  query  integer  false  "Page size"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  response.TemplateListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates [get]
+func doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_template_types_slug_templates() {}
+
+// doc_post_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_preview_mjml auto-generated route documentation.
+// @Summary      POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Accept       json
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Param        body  body  request.MJMLPreviewRequest  true  "Request body"
+// @Success      200  {object}  response.MJMLPreviewResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml [post]
+func doc_post_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_preview_mjml() {}
+
+// doc_post_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_test_send auto-generated route documentation.
+// @Summary      POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send [post]
+func doc_post_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_test_send() {}
+
+// doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  response.TemplateVersionListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions [get]
+func doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions() {}
+
+// doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  response.TemplateVersionResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id} [get]
+func doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id() {}
+
+// doc_put_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id auto-generated route documentation.
+// @Summary      PUT /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Accept       json
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Param        body  body  request.CreateVersionRequest  true  "Request body"
+// @Success      200  {object}  response.TemplateVersionResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id} [put]
+func doc_put_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id() {}
+
+// doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  response.TemplateVersionResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales [get]
+func doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales() {}
+
+// doc_delete_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale auto-generated route documentation.
+// @Summary      DELETE /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        locale  path  string  true  "locale path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale} [delete]
+func doc_delete_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale() {}
+
+// doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale auto-generated route documentation.
+// @Summary      GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        locale  path  string  true  "locale path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      200  {object}  response.TemplateVersionLocaleResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale} [get]
+func doc_get_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale() {}
+
+// doc_post_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale auto-generated route documentation.
+// @Summary      POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Accept       json
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        locale  path  string  true  "locale path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Param        body  body  request.SetLocaleRequest  true  "Request body"
+// @Success      201  {object}  response.TemplateVersionLocaleResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale} [post]
+func doc_post_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale() {}
+
+// doc_put_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale auto-generated route documentation.
+// @Summary      PUT /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Accept       json
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        locale  path  string  true  "locale path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Param        body  body  request.SetLocaleRequest  true  "Request body"
+// @Success      200  {object}  response.TemplateVersionLocaleResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale} [put]
+func doc_put_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale() {}
+
+// doc_post_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_publish auto-generated route documentation.
+// @Summary      POST /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         external
+// @Produce      json
+// @Param        profile_slug  path  string  true  "profile_slug path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        X-Senda-Environment  header  string  true  "External integration environment selector (`prod` or `test`)"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish [post]
+func doc_post_api_v1_external_profile_slug_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_publish() {}
+
 // doc_get_api_v1_manage_config auto-generated route documentation.
 // @Summary      GET /api/v1/manage/config
 // @Description  Auto-generated route stub for OpenAPI + MCP discovery.
@@ -145,6 +584,1778 @@ func doc_get_api_v1_manage_config() {}
 // @Failure      500  {object}  DocErrorResponse
 // @Router       /api/v1/manage/config [put]
 func doc_put_api_v1_manage_config() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        cursor  query  string  false  "Pagination cursor"
+// @Param        limit  query  integer  false  "Page size"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code} [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  DocGenericBody  true  "Request body"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code} [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        cursor  query  string  false  "Pagination cursor"
+// @Param        limit  query  integer  false  "Page size"
+// @Success      200  {object}  response.AdapterListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  request.CreateAdapterRequest  true  "Request body"
+// @Success      201  {object}  response.AdapterResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters() {}
+
+// doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id auto-generated route documentation.
+// @Summary      DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id} [delete]
+func doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      200  {object}  response.AdapterResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id} [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Param        body  body  request.UpdateAdapterRequest  true  "Request body"
+// @Success      200  {object}  response.AdapterResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id} [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_auto_provision_tracking auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/auto-provision-tracking
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/auto-provision-tracking [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_auto_provision_tracking() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapter-identities
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      200  {object}  response.AdapterResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapter-identities
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Param        body  body  request.CreateManualIdentityRequest  true  "Request body"
+// @Success      201  {object}  response.AdapterIdentityResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities() {}
+
+// doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities_identity_id auto-generated route documentation.
+// @Summary      DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapter-identities
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Param        identity_id  path  string  true  "identity_id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id} [delete]
+func doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities_identity_id() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities_identity_id_set_default auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/set-default
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapter-identities
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Param        identity_id  path  string  true  "identity_id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/set-default [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities_identity_id_set_default() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities_identity_id_workspace_access auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapter-identities
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Param        identity_id  path  string  true  "identity_id path parameter"
+// @Success      200  {object}  response.AdapterResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities_identity_id_workspace_access() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities_identity_id_workspace_access auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapter-identities
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Param        identity_id  path  string  true  "identity_id path parameter"
+// @Param        body  body  request.UpdateAdapterRequest  true  "Request body"
+// @Success      200  {object}  response.AdapterResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/{identity_id}/workspace-access [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities_identity_id_workspace_access() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities_sync auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/sync
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapter-identities
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/identities/sync [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_identities_sync() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_provisioning_status auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/provisioning-status
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      200  {object}  response.AdapterResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/provisioning-status [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_provisioning_status() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_setup_guide auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/setup-guide
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      200  {object}  response.AdapterResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/setup-guide [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_setup_guide() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_test auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/test
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/test [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_test() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_workspace_access auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      200  {object}  response.AdapterResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_workspace_access() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_workspace_access auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Param        body  body  request.UpdateAdapterRequest  true  "Request body"
+// @Success      200  {object}  response.AdapterResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/{id}/workspace-access [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_id_workspace_access() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_validate_ses auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/validate-ses
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         adapters
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  DocGenericBody  true  "Request body"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/adapters/validate-ses [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_adapters_validate_ses() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_api_keys auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         api-keys
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        cursor  query  string  false  "Pagination cursor"
+// @Param        limit  query  integer  false  "Page size"
+// @Success      200  {object}  response.APIKeyListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_api_keys() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_api_keys auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         api-keys
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  request.CreateAPIKeyRequest  true  "Request body"
+// @Success      201  {object}  response.APIKeyCreatedResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_api_keys() {}
+
+// doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_api_keys_id auto-generated route documentation.
+// @Summary      DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys/{id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         api-keys
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/api-keys/{id} [delete]
+func doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_api_keys_id() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_audit_log auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/audit-log
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         audit
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        cursor  query  string  false  "Pagination cursor"
+// @Param        limit  query  integer  false  "Page size"
+// @Success      200  {object}  response.AuditLogListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/audit-log [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_audit_log() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_dashboard_stats auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/dashboard-stats
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         dashboard
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Success      200  {object}  response.DashboardStatsResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/dashboard-stats [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_dashboard_stats() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_emails auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        cursor  query  string  false  "Pagination cursor"
+// @Param        limit  query  integer  false  "Page size"
+// @Success      200  {object}  response.EmailListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_emails() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_emails_tracking_id auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        tracking_id  path  string  true  "tracking_id path parameter"
+// @Success      200  {object}  response.EmailDetailResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id} [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_emails_tracking_id() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_emails_tracking_id_events auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}/events
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        tracking_id  path  string  true  "tracking_id path parameter"
+// @Success      200  {object}  response.EmailEventResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/emails/{tracking_id}/events [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_emails_tracking_id_events() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         injectors
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Success      200  {object}  response.InjectorListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         injectors
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  request.CreateInjectorRequest  true  "Request body"
+// @Success      201  {object}  response.InjectorDetailResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors() {}
+
+// doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors_name auto-generated route documentation.
+// @Summary      DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         injectors
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        name  path  string  true  "name path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name} [delete]
+func doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors_name() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors_name auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         injectors
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        name  path  string  true  "name path parameter"
+// @Success      200  {object}  response.InjectorDetailResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name} [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors_name() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors_name auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         injectors
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        name  path  string  true  "name path parameter"
+// @Param        body  body  DocGenericBody  true  "Request body"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name} [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors_name() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors_name_fields_field_name auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/fields/{field_name}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         injectors
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        name  path  string  true  "name path parameter"
+// @Param        field_name  path  string  true  "field_name path parameter"
+// @Param        body  body  request.UpdateInjectorFieldRequest  true  "Request body"
+// @Success      200  {object}  response.InjectorFieldResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/fields/{field_name} [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors_name_fields_field_name() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors_name_values auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/values
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         injectors
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        name  path  string  true  "name path parameter"
+// @Param        body  body  request.SetInjectorValuesRequest  true  "Request body"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/injectors/{name}/values [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_injectors_name_values() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_members auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        cursor  query  string  false  "Pagination cursor"
+// @Param        limit  query  integer  false  "Page size"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_members() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_members auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  DocGenericBody  true  "Request body"
+// @Success      201  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_members() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_members_member_id auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        member_id  path  string  true  "member_id path parameter"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id} [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_members_member_id() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_members_member_id_roles auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        member_id  path  string  true  "member_id path parameter"
+// @Param        body  body  DocGenericBody  true  "Request body"
+// @Success      201  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_members_member_id_roles() {}
+
+// doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_members_member_id_roles_role_id auto-generated route documentation.
+// @Summary      DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles/{role_id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        member_id  path  string  true  "member_id path parameter"
+// @Param        role_id  path  string  true  "role_id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles/{role_id} [delete]
+func doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_members_member_id_roles_role_id() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_policies auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Success      200  {object}  DocWorkspacePolicyResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_policies() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_policies auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  request.UpdateWorkspacePolicyRequest  true  "Request body"
+// @Success      200  {object}  DocWorkspacePolicyResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_policies() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_runtime_reset auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/runtime/reset
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  DocGenericBody  true  "Request body"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/runtime/reset [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_runtime_reset() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_suppression auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         suppression
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  request.AddSuppressionRequest  true  "Request body"
+// @Success      201  {object}  response.SuppressionWorkspaceResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_suppression() {}
+
+// doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_suppression_email auto-generated route documentation.
+// @Summary      DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         suppression
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        email  path  string  true  "email path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email} [delete]
+func doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_suppression_email() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_suppression_email auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         suppression
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        email  path  string  true  "email path parameter"
+// @Success      204  {object}  response.SuppressionCheckResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/suppression/{email} [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_suppression_email() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         template-types
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        cursor  query  string  false  "Pagination cursor"
+// @Param        limit  query  integer  false  "Page size"
+// @Success      200  {object}  response.TemplateTypeListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         template-types
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  request.CreateTemplateTypeRequest  true  "Request body"
+// @Success      201  {object}  response.TemplateTypeResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types() {}
+
+// doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types_slug auto-generated route documentation.
+// @Summary      DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         template-types
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        slug  path  string  true  "slug path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug} [delete]
+func doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types_slug() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types_slug auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         template-types
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        slug  path  string  true  "slug path parameter"
+// @Success      200  {object}  response.TemplateTypeResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug} [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types_slug() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types_slug auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         template-types
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        slug  path  string  true  "slug path parameter"
+// @Param        body  body  DocGenericBody  true  "Request body"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug} [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types_slug() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types_slug_templates auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         template-types
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        slug  path  string  true  "slug path parameter"
+// @Param        cursor  query  string  false  "Pagination cursor"
+// @Param        limit  query  integer  false  "Page size"
+// @Success      200  {object}  response.TemplateListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/template-types/{slug}/templates [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_template_types_slug_templates() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  request.CreateTemplateRequest  true  "Request body"
+// @Success      201  {object}  response.TemplateResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates() {}
+
+// doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id auto-generated route documentation.
+// @Summary      DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id} [delete]
+func doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_bulk_send auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        body  body  DocGenericBody  true  "Request body"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_bulk_send() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_bulk_send_config auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send-config
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/bulk-send-config [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_bulk_send_config() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_disable auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/disable
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/disable [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_disable() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_enable auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/enable
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/enable [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_enable() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_fork auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        body  body  DocGenericBody  true  "Request body"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/fork [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_fork() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_preview_mjml auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        body  body  request.MJMLPreviewRequest  true  "Request body"
+// @Success      200  {object}  response.MJMLPreviewResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/preview-mjml [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_preview_mjml() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_test_send auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Success      200  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/test-send [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_test_send() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Success      200  {object}  response.TemplateVersionListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        body  body  request.CreateVersionRequest  true  "Request body"
+// @Success      201  {object}  response.TemplateVersionResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions() {}
+
+// doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id auto-generated route documentation.
+// @Summary      DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id} [delete]
+func doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Success      200  {object}  response.TemplateVersionResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id} [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        body  body  request.CreateVersionRequest  true  "Request body"
+// @Success      200  {object}  response.TemplateVersionResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id} [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_clone auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Success      201  {object}  response.TemplateVersionResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/clone [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_clone() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Success      200  {object}  response.TemplateVersionResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales() {}
+
+// doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale auto-generated route documentation.
+// @Summary      DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        locale  path  string  true  "locale path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale} [delete]
+func doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        locale  path  string  true  "locale path parameter"
+// @Success      200  {object}  response.TemplateVersionLocaleResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale} [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        locale  path  string  true  "locale path parameter"
+// @Param        body  body  request.SetLocaleRequest  true  "Request body"
+// @Success      201  {object}  response.TemplateVersionLocaleResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale} [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Param        locale  path  string  true  "locale path parameter"
+// @Param        body  body  request.SetLocaleRequest  true  "Request body"
+// @Success      200  {object}  response.TemplateVersionLocaleResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/locales/{locale} [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_locales_locale() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_publish auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         templates
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        template_id  path  string  true  "template_id path parameter"
+// @Param        version_id  path  string  true  "version_id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/templates/{template_id}/versions/{version_id}/publish [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_templates_template_id_versions_version_id_publish() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         webhooks
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        cursor  query  string  false  "Pagination cursor"
+// @Param        limit  query  integer  false  "Page size"
+// @Success      200  {object}  response.WebhookListResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         webhooks
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  request.CreateWebhookRequest  true  "Request body"
+// @Success      201  {object}  response.WebhookCreatedResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks() {}
+
+// doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks_id auto-generated route documentation.
+// @Summary      DELETE /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         webhooks
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      204  {object}  DocGenericObject
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id} [delete]
+func doc_delete_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks_id() {}
+
+// doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks_id auto-generated route documentation.
+// @Summary      GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         webhooks
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      200  {object}  response.WebhookResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id} [get]
+func doc_get_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks_id() {}
+
+// doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks_id auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         webhooks
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Param        body  body  request.UpdateWebhookRequest  true  "Request body"
+// @Success      200  {object}  response.WebhookResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id} [put]
+func doc_put_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks_id() {}
+
+// doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks_id_test auto-generated route documentation.
+// @Summary      POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}/test
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         webhooks
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        environment  path  string  true  "environment path parameter"
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        id  path  string  true  "id path parameter"
+// @Success      200  {object}  DocStatusResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/webhooks/{id}/test [post]
+func doc_post_api_v1_manage_environments_environment_tenants_tenant_code_workspaces_workspace_code_webhooks_id_test() {}
 
 // doc_get_api_v1_manage_global_adapters auto-generated route documentation.
 // @Summary      GET /api/v1/manage/global/adapters
@@ -2233,6 +4444,46 @@ func doc_post_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_member
 // @Failure      500  {object}  DocErrorResponse
 // @Router       /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/members/{member_id}/roles/{role_id} [delete]
 func doc_delete_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_members_member_id_roles_role_id() {}
+
+// doc_get_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_policies auto-generated route documentation.
+// @Summary      GET /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Success      200  {object}  DocWorkspacePolicyResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies [get]
+func doc_get_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_policies() {}
+
+// doc_put_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_policies auto-generated route documentation.
+// @Summary      PUT /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies
+// @Description  Auto-generated route stub for OpenAPI + MCP discovery.
+// @Tags         workspaces
+// @Accept       json
+// @Produce      json
+// @Security     ManagementBearer
+// @Param        tenant_code  path  string  true  "tenant_code path parameter"
+// @Param        workspace_code  path  string  true  "workspace_code path parameter"
+// @Param        body  body  request.UpdateWorkspacePolicyRequest  true  "Request body"
+// @Success      200  {object}  DocWorkspacePolicyResponse
+// @Failure      400  {object}  DocErrorResponse
+// @Failure      401  {object}  DocErrorResponse
+// @Failure      403  {object}  DocErrorResponse
+// @Failure      404  {object}  DocErrorResponse
+// @Failure      409  {object}  DocErrorResponse
+// @Failure      422  {object}  DocErrorResponse
+// @Failure      500  {object}  DocErrorResponse
+// @Router       /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies [put]
+func doc_put_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_policies() {}
 
 // doc_post_api_v1_manage_tenants_tenant_code_workspaces_workspace_code_suppression auto-generated route documentation.
 // @Summary      POST /api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/suppression

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,539 +1,349 @@
+
 # Senda API Reference
 
-Complete API reference for Senda v1. All endpoints under `/api/v1/` unless noted. Request and response bodies use `application/json`. For an interactive collection, see [docs/postman/](postman/).
-
----
+Complete API reference for Senda v1. All JSON endpoints live under `/api/v1/` unless noted.
 
 ## Authentication
 
-| Scheme     | Header                                 | Plane      | Scope                                      |
-| ---------- | -------------------------------------- | ---------- | ------------------------------------------ |
-| OIDC / JWT | `Authorization: Bearer <oidc_token>`   | Management | User identity, RBAC role determines access |
-| API Key    | `Authorization: Bearer senda_live_xxx` | Data       | Workspace-scoped, used by applications     |
+| Scheme | Header | Plane | Notes |
+| --- | --- | --- | --- |
+| OIDC / JWT | `Authorization: Bearer <oidc_token>` | Management | Human/member identity with RBAC |
+| Workspace API key | `Authorization: Bearer senda_prod_...` or `senda_test_...` | Data plane | Raw key selects workspace environment |
+| External integration | Custom per profile + `X-Senda-Environment` | External surface | Uses registered auth method + workspace resolver |
 
-API keys are scoped to a single workspace. Management tokens carry the member's RBAC role evaluated against the resource hierarchy.
+Important rules:
 
-### RBAC Roles (highest to lowest)
+- Use the environment-aware workspace API key prefixes documented here.
+- Environment is **not** part of the send `ref`.
+- External integration requests must include `X-Senda-Environment: prod|test`.
 
-| Role            | Description                                                       |
-| --------------- | ----------------------------------------------------------------- |
-| Superadmin      | Full platform access. Manages tenants, global resources, members. |
-| TenantAdmin     | Manages a tenant and all its workspaces.                          |
-| WorkspaceAdmin  | Full control over a single workspace.                             |
-| WorkspaceEditor | Create and modify resources within a workspace.                   |
-| WorkspaceViewer | Read-only access to workspace resources.                          |
+## Error format
 
----
-
-## Error Format
-
-All errors use a consistent JSON structure via `pkg/apperr`:
+Most endpoints use:
 
 ```json
-{ "code": 422, "message": "ref is required" }
+{ "code": 422, "message": "validation failed" }
 ```
 
-### Error Codes
-
-| Status | Meaning               | Common Causes                                                 |
-| ------ | --------------------- | ------------------------------------------------------------- |
-| 400    | Bad Request           | Malformed JSON, missing required fields, invalid query params |
-| 401    | Unauthorized          | Missing/expired token, invalid API key                        |
-| 403    | Forbidden             | Insufficient RBAC role                                        |
-| 404    | Not Found             | Resource does not exist or is soft-deleted                    |
-| 409    | Conflict              | Duplicate resource (unique code collision)                    |
-| 422    | Unprocessable Entity  | Validation failure on semantically invalid input              |
-| 429    | Too Many Requests     | Rate limit exceeded (token-bucket, per workspace)             |
-| 500    | Internal Server Error | Unexpected server-side failure                                |
-
----
+Validation errors can include field details.
 
 ## Pagination
 
-All list endpoints use cursor-based pagination. Cursors are opaque UUIDv7 strings.
+List endpoints use cursor-based pagination with `cursor` and `limit`. When present, `next_cursor` can be supplied to fetch the next page.
 
-| Parameter | Type    | Default  | Description                                     |
-| --------- | ------- | -------- | ----------------------------------------------- |
-| `cursor`  | string  | _(none)_ | Cursor from a previous response's `next_cursor` |
-| `limit`   | integer | 20       | Items per page (max varies by endpoint)         |
+## Public / unauthenticated endpoints
 
-```json
-{ "items": [ ... ], "next_cursor": "019012ab-..." }
-```
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/health` | Basic health |
+| GET | `/healthz` | Readiness / deeper health |
+| GET | `/metrics` | Prometheus metrics |
+| GET | `/t/o/:tracking_id` | Open-tracking pixel |
+| GET | `/public/video-thumbnail` | Video thumbnail composite |
+| GET | `/api/v1/onboarding/status` | Onboarding status |
+| POST | `/api/v1/webhooks/ses/inbound` | SNS-signed SES event ingestion |
 
-When `next_cursor` is `null` or absent, there are no more pages.
+## Data plane
 
----
+Data-plane requests require a raw workspace API key.
 
-## Infrastructure Endpoints (No Auth)
+Environment comes from the key prefix:
 
-| Method | Path       | Description                        |
-| ------ | ---------- | ---------------------------------- |
-| GET    | `/health`  | Basic application status           |
-| GET    | `/healthz` | Database connectivity check        |
-| GET    | `/metrics` | Prometheus metrics scrape endpoint |
+- `senda_prod_...`
+- `senda_test_...`
 
----
+The send ref format stays:
 
-## Public Endpoints (No Auth)
+`tenant_code:workspace_code:template_type_slug`
 
-| Method | Path                           | Description                                      |
-| ------ | ------------------------------ | ------------------------------------------------ |
-| GET    | `/t/o/:tracking_id`            | Open-tracking pixel (1x1 transparent GIF)        |
-| GET    | `/public/video-thumbnail`      | Video thumbnail composite image                  |
-| POST   | `/api/v1/webhooks/ses/inbound` | AWS SES inbound webhook (SNS signature verified) |
+### Send
 
----
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/api/v1/send` | Queue one logical send request |
+| POST | `/api/v1/send/batch` | Queue multiple same-template items with independent variables/injectors |
 
-## Onboarding
+### Email query
 
-| Method | Path                        | Auth | Description                         |
-| ------ | --------------------------- | ---- | ----------------------------------- |
-| GET    | `/api/v1/onboarding/status` | None | Current onboarding state            |
-| POST   | `/api/v1/onboarding/setup`  | OIDC | Initialize the platform (first-run) |
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/v1/emails` | List workspace emails |
+| GET | `/api/v1/emails/export` | Export emails |
+| GET | `/api/v1/emails/:tracking_id` | Get one email |
+| GET | `/api/v1/emails/:tracking_id/events` | Get lifecycle events |
 
----
+## Member profile
 
-## Data Plane (Workspace API Key Auth)
+| Method | Path | Auth |
+| --- | --- | --- |
+| GET | `/api/v1/members/me` | OIDC |
 
-All requests require `Authorization: Bearer senda_live_xxx`. The raw key implicitly scopes operations
-to its workspace. Management OIDC tokens are not accepted on these endpoints because the handlers
-require workspace context derived from the API key.
+## Management API
 
-### POST /api/v1/send
+Management requests require OIDC and RBAC. There are two workspace route families:
 
-| Field         | Type     | Required | Description                                                  |
-| ------------- | -------- | -------- | ------------------------------------------------------------ |
-| `ref`         | string   | yes      | Template ref in `tenant:workspace:template_type_slug` format |
-| `to`          | string[] | yes      | One or more recipient email addresses (max 50)               |
-| `variables`   | object   | no       | Key-value pairs for template interpolation                   |
-| `locale`      | string   | no       | BCP-47 locale (e.g., `en`, `es-419`). Falls back to default. |
-| `cc`          | string[] | no       | CC recipients                                                |
-| `bcc`         | string[] | no       | BCC recipients                                               |
-| `external_id` | string   | no       | Caller-provided idempotency/correlation ID                   |
+1. **shared logical workspace routes** — identity and logical CRUD
+2. **environment-scoped workspace routes** — environment-specific runtime/resources
 
-**Response (202):**
-
-```json
-{
-  "status": "accepted",
-  "tracking_ids": [
-    {
-      "to": "user@example.com",
-      "tracking_id": "trk_019012ab7c3d7def8abc1234567890ab",
-      "status": "accepted"
-    }
-  ],
-  "external_id": "signup-jane-20260226",
-  "template_resolved": "acme:production:welcome-email",
-  "template_version": 3
-}
-```
-
-**Full curl example:**
-
-```bash
-curl -X POST https://senda.example.com/api/v1/send \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer senda_live_sk_abc123def456" \
-  -d '{
-    "ref": "acme:production:welcome-email",
-    "to": ["user@example.com"],
-    "variables": {
-      "first_name": "Jane",
-      "activation_url": "https://app.example.com/activate?token=xyz"
-    },
-    "locale": "en",
-    "external_id": "signup-jane-20260226"
-  }'
-```
-
-### POST /api/v1/send/batch
-
-Use this endpoint when every logical message uses the **same template ref** but needs its **own variables/injector context**.
-
-**Limits:**
-
-- `items` must contain at least 1 item
-- default max: **100 items** per request
-- configurable via `send.batch_max_items` or `SENDA_SEND_BATCH_MAX_ITEMS`
-- each item has exactly **one** primary recipient in `to`
-
-| Field | Type | Required | Description |
-| ----- | ---- | -------- | ----------- |
-| `ref` | string | yes | Shared template ref in `tenant:workspace:template_type_slug` format |
-| `items` | object[] | yes | One logical message per item |
-| `items[].to` | string | yes | Primary recipient email |
-| `items[].variables` | object | no | Variables used for that item's template rendering and injector resolution |
-| `items[].locale` | string | no | Locale override for that item |
-| `items[].cc` | string[] | no | CC recipients for that item |
-| `items[].bcc` | string[] | no | BCC recipients for that item |
-| `items[].external_id` | string | no | Per-item correlation/idempotency ID |
-
-**Response (202):**
-
-```json
-{
-  "status": "partial",
-  "template_resolved": "acme:production:welcome-email",
-  "items": [
-    {
-      "index": 0,
-      "to": "ana@example.com",
-      "tracking_id": "trk_111",
-      "status": "accepted",
-      "external_id": "msg-1"
-    },
-    {
-      "index": 1,
-      "to": "blocked@example.com",
-      "tracking_id": "trk_222",
-      "status": "suppressed",
-      "external_id": "msg-2"
-    },
-    {
-      "index": 2,
-      "to": "broken@example.com",
-      "status": "failed",
-      "external_id": "msg-3",
-      "error": "all recipients failed: create email: db down"
-    }
-  ],
-  "accepted_count": 1,
-  "suppressed_count": 1,
-  "failed_count": 1
-}
-```
-
-**Full curl example:**
-
-```bash
-curl -X POST https://senda.example.com/api/v1/send/batch \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer senda_live_sk_abc123def456" \
-  -d '{
-    "ref": "acme:production:welcome-email",
-    "items": [
-      {
-        "to": "ana@example.com",
-        "variables": {
-          "first_name": "Ana",
-          "activation_url": "https://app.example.com/activate?token=ana"
-        },
-        "external_id": "signup-ana-1",
-        "locale": "es"
-      },
-      {
-        "to": "bob@example.com",
-        "variables": {
-          "first_name": "Bob",
-          "activation_url": "https://app.example.com/activate?token=bob"
-        },
-        "external_id": "signup-bob-2",
-        "locale": "en"
-      }
-    ]
-  }'
-```
-
-### Query Emails
-
-| Method | Path                                 | Description                               |
-| ------ | ------------------------------------ | ----------------------------------------- |
-| GET    | `/api/v1/emails`                     | List emails (paginated, workspace-scoped) |
-| GET    | `/api/v1/emails/export`              | Export emails                             |
-| GET    | `/api/v1/emails/:tracking_id`        | Get email by tracking ID                  |
-| GET    | `/api/v1/emails/:tracking_id/events` | Get delivery events                       |
-
----
-
-## Member Profile (OIDC Auth)
-
-| Method | Path                 | Description            |
-| ------ | -------------------- | ---------------------- |
-| GET    | `/api/v1/members/me` | Current member profile |
-
----
-
-## Management API (OIDC Auth, RBAC Enforced)
-
-All management endpoints live under `/api/v1/manage/`. The path hierarchy mirrors the resource hierarchy: global, tenant, workspace.
-
-### Tenants (Superadmin)
+### Tenants
 
 Base: `/api/v1/manage/tenants`
 
-| Method | Path                    | Description        |
-| ------ | ----------------------- | ------------------ |
-| POST   | `/tenants`              | Create tenant      |
-| GET    | `/tenants`              | List tenants       |
-| GET    | `/tenants/:tenant_code` | Get tenant         |
-| PUT    | `/tenants/:tenant_code` | Update tenant      |
-| DELETE | `/tenants/:tenant_code` | Soft-delete tenant |
+| Method | Path |
+| --- | --- |
+| POST | `/tenants` |
+| GET | `/tenants` |
+| GET | `/tenants/:tenant_code` |
+| PUT | `/tenants/:tenant_code` |
+| DELETE | `/tenants/:tenant_code` |
 
-### Workspaces (TenantAdmin+)
+### Workspaces (logical/shared)
 
 Base: `/api/v1/manage/tenants/:tenant_code/workspaces`
 
-| Method | Path                          | Description           |
-| ------ | ----------------------------- | --------------------- |
-| POST   | `/workspaces`                 | Create workspace      |
-| GET    | `/workspaces`                 | List workspaces       |
-| GET    | `/workspaces/:workspace_code` | Get workspace         |
-| PUT    | `/workspaces/:workspace_code` | Update workspace      |
-| DELETE | `/workspaces/:workspace_code` | Soft-delete workspace |
+| Method | Path | Purpose |
+| --- | --- | --- |
+| POST | `/workspaces` | Create logical workspace pair (`prod` + `test`) |
+| GET | `/workspaces` | List logical workspaces |
+| GET | `/workspaces/:workspace_code` | Get shared workspace identity |
+| PUT | `/workspaces/:workspace_code` | Update shared logical fields |
+| DELETE | `/workspaces/:workspace_code` | Soft-delete logical pair |
 
-### Members (Superadmin)
+### Workspaces (environment-scoped)
 
-Base: `/api/v1/manage/members`
+Base: `/api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code`
 
-| Method | Path                          | Description   |
-| ------ | ----------------------------- | ------------- |
-| POST   | `/members`                    | Create member |
-| GET    | `/members`                    | List members  |
-| GET    | `/members/:id`                | Get member    |
-| POST   | `/members/:id/roles`          | Assign role   |
-| DELETE | `/members/:id/roles/:role_id` | Remove role   |
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `` | Get environment-specific workspace state |
+| PUT | `` | Update environment-specific workspace state |
+| POST | `/runtime/reset` | Test-only runtime reset |
+| GET | `/policies` | Get workspace policies |
+| PUT | `/policies` | Update workspace policies |
 
-### Platform Config (Superadmin)
+Runtime reset is only valid for `environment=test`.
 
-| Method | Path                    | Description            |
-| ------ | ----------------------- | ---------------------- |
-| GET    | `/api/v1/manage/config` | Get platform config    |
-| PUT    | `/api/v1/manage/config` | Update platform config |
+### Members
 
----
+| Method | Path |
+| --- | --- |
+| GET | `/api/v1/manage/members` |
+| POST | `/api/v1/manage/members` |
+| GET | `/api/v1/manage/members/:member_id` |
+| POST | `/api/v1/manage/members/:member_id/roles` |
+| DELETE | `/api/v1/manage/members/:member_id/roles/:role_id` |
 
-### Workspace-Scoped Resources
+Tenant and workspace member routes also exist under the respective tenant/workspace paths.
 
-Base: `/api/v1/manage/tenants/:tc/workspaces/:wc`
+### Config
 
-Required role varies by operation (typically WorkspaceEditor+ for writes, WorkspaceViewer+ for reads).
+| Method | Path |
+| --- | --- |
+| GET | `/api/v1/manage/config` |
+| PUT | `/api/v1/manage/config` |
 
-#### Injectors
+Global config includes external integration profiles.
 
-| Method | Path                    | Description            |
-| ------ | ----------------------- | ---------------------- |
-| POST   | `/injectors`            | Create injector        |
-| GET    | `/injectors`            | List injectors         |
-| GET    | `/injectors/:id`        | Get injector           |
-| PUT    | `/injectors/:id/values` | Update injector values |
+## Workspace-scoped resources
 
-#### Adapters
+The same resource families are available under both:
 
-| Method | Path                                    | Description                    |
-| ------ | --------------------------------------- | ------------------------------ |
-| POST   | `/adapters`                             | Create adapter                 |
-| GET    | `/adapters`                             | List adapters                  |
-| GET    | `/adapters/:id`                         | Get adapter                    |
-| PUT    | `/adapters/:id`                         | Update adapter                 |
-| DELETE | `/adapters/:id`                         | Soft-delete adapter            |
-| POST   | `/adapters/:id/test`                    | Test connectivity              |
-| GET    | `/adapters/:id/setup-guide`             | Provider setup instructions    |
-| POST   | `/adapters/:id/auto-provision-tracking` | Auto-provision tracking domain |
-| GET    | `/adapters/:id/workspace-access`        | List workspace grants (Gmail, `_system` only) |
-| PUT    | `/adapters/:id/workspace-access`        | Replace workspace grants (Gmail, `_system` only) |
+- shared workspace base: `/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code`
+- environment workspace base: `/api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code`
 
-#### Adapter Identities
+For runtime resources, use the environment-scoped base.
 
-| Method | Path                                        | Description        |
-| ------ | ------------------------------------------- | ------------------ |
-| GET    | `/adapters/:id/identities`                  | List identities    |
-| POST   | `/adapters/:id/identities`                  | Create identity    |
-| POST   | `/adapters/:id/identities/sync`             | Sync from provider |
-| DELETE | `/adapters/:id/identities/:iid`             | Delete identity    |
-| POST   | `/adapters/:id/identities/:iid/set-default` | Set as default     |
-| GET    | `/adapters/:id/identities/:iid/workspace-access` | List workspace grants (SES email identities, `_system` only) |
-| PUT    | `/adapters/:id/identities/:iid/workspace-access` | Replace workspace grants (SES email identities, `_system` only) |
+### Injectors
 
-**Sharing rules**
+| Method | Path |
+| --- | --- |
+| POST | `/injectors` |
+| GET | `/injectors` |
+| GET | `/injectors/:name` |
+| PUT | `/injectors/:name` |
+| PUT | `/injectors/:name/fields/:field_name` |
+| PUT | `/injectors/:name/values` |
+| DELETE | `/injectors/:name` |
 
-- Sharing is managed only from the tenant's **`_system`** workspace.
-- **Gmail** sharing happens at the **adapter** level.
-- **SES** sharing happens at the **email identity** level; identities of type `domain` are **not** shareable.
-- `GET /adapters` in a regular workspace returns both workspace-owned adapters and visible `_system` shared adapters.
-- Shared adapters are **read-only** from child workspaces: update/delete/test/sync/set-default/manual identity mutations return `403`.
-- `GET /adapters/:id/identities` in a regular workspace returns:
-  - all identities for owned adapters;
-  - all identities for shared Gmail adapters;
-  - only the **granted email identities** for shared SES adapters.
+### Adapters and identities
 
-#### Template Types
+| Method | Path |
+| --- | --- |
+| GET | `/adapters` |
+| POST | `/adapters` |
+| POST | `/adapters/validate-ses` |
+| GET | `/adapters/:id` |
+| PUT | `/adapters/:id` |
+| DELETE | `/adapters/:id` |
+| POST | `/adapters/:id/test` |
+| GET | `/adapters/:id/workspace-access` |
+| PUT | `/adapters/:id/workspace-access` |
+| GET | `/adapters/:id/identities` |
+| POST | `/adapters/:id/identities` |
+| POST | `/adapters/:id/identities/sync` |
+| DELETE | `/adapters/:id/identities/:identity_id` |
+| POST | `/adapters/:id/identities/:identity_id/set-default` |
+| GET | `/adapters/:id/identities/:identity_id/workspace-access` |
+| PUT | `/adapters/:id/identities/:identity_id/workspace-access` |
 
-| Method | Path                  | Description          |
-| ------ | --------------------- | -------------------- |
-| POST   | `/template-types`     | Create template type |
-| GET    | `/template-types`     | List template types  |
-| GET    | `/template-types/:id` | Get template type    |
+Sharing rules:
 
-**Template type rules with shared adapters**
+- manage sharing from tenant `_system`
+- Gmail sharing is adapter-level
+- SES sharing is email-identity-level
+- SES domain identities are not shareable
+- shared child-workspace entries are read-only
 
-- Workspace template types can reference:
-  - a workspace-owned adapter;
-  - a Gmail adapter shared from tenant `_system`;
-  - a SES adapter shared from tenant `_system` **only when** the selected `sender_identity_id` is a granted SES email identity for that workspace.
-- For shared SES adapters, `sender_identity_id` is **required**.
-- Revoking a shared adapter grant or SES identity grant returns **`409 CONFLICT`** when a workspace template type still depends on it.
+### Template types
 
-#### Templates
+| Method | Path |
+| --- | --- |
+| POST | `/template-types` |
+| GET | `/template-types` |
+| GET | `/template-types/:slug` |
+| PUT | `/template-types/:slug` |
+| DELETE | `/template-types/:slug` |
 
-| Method | Path                     | Description      |
-| ------ | ------------------------ | ---------------- |
-| POST   | `/templates`             | Create template  |
-| GET    | `/templates`             | List templates   |
-| GET    | `/templates/:id`         | Get template     |
-| POST   | `/templates/:id/disable` | Disable template |
-| POST   | `/templates/:id/enable`  | Enable template  |
+Test-only template-type controls:
 
-#### Template Versions
+- `test_recipient_mode`
+- `test_recipient_addresses`
 
-| Method | Path                                   | Description          |
-| ------ | -------------------------------------- | -------------------- |
-| POST   | `/templates/:id/versions`              | Create version       |
-| GET    | `/templates/:id/versions`              | List versions        |
-| GET    | `/templates/:id/versions/:vid`         | Get version          |
-| PUT    | `/templates/:id/versions/:vid`         | Update draft version |
-| POST   | `/templates/:id/versions/:vid/publish` | Publish version      |
+These are only valid in the `test` environment.
 
-#### Template Version Locales
+### Templates, versions, locales
 
-| Method | Path                                           | Description   |
-| ------ | ---------------------------------------------- | ------------- |
-| POST   | `/templates/:id/versions/:vid/locales`         | Add locale    |
-| GET    | `/templates/:id/versions/:vid/locales`         | List locales  |
-| PUT    | `/templates/:id/versions/:vid/locales/:locale` | Update locale |
-| DELETE | `/templates/:id/versions/:vid/locales/:locale` | Remove locale |
+| Method | Path |
+| --- | --- |
+| GET | `/template-types/:slug/templates` |
+| POST | `/templates` |
+| POST | `/templates/:template_id/fork` |
+| GET | `/templates/:template_id/versions` |
+| GET | `/templates/:template_id/versions/:version_id` |
+| POST | `/templates/:template_id/versions` |
+| PUT | `/templates/:template_id/versions/:version_id` |
+| POST | `/templates/:template_id/versions/:version_id/clone` |
+| POST | `/templates/:template_id/versions/:version_id/publish` |
+| GET | `/templates/:template_id/versions/:version_id/locales` |
+| GET | `/templates/:template_id/versions/:version_id/locales/:locale` |
+| POST | `/templates/:template_id/versions/:version_id/locales/:locale` |
+| PUT | `/templates/:template_id/versions/:version_id/locales/:locale` |
+| DELETE | `/templates/:template_id/versions/:version_id/locales/:locale` |
+| POST | `/templates/:template_id/preview-mjml` |
+| POST | `/templates/:template_id/test-send` |
+| GET | `/templates/:template_id/bulk-send-config` |
+| POST | `/templates/:template_id/bulk-send` |
+| POST | `/templates/:template_id/disable` |
+| POST | `/templates/:template_id/enable` |
+| DELETE | `/templates/:template_id` |
+| DELETE | `/templates/:template_id/versions/:version_id` |
 
-#### Template Preview & Test
+Notes:
 
-| Method | Path                       | Description                   |
-| ------ | -------------------------- | ----------------------------- |
-| POST   | `/templates/:id/preview`   | Render preview (returns HTML) |
-| POST   | `/templates/:id/test-send` | Send test email               |
+- `clone` creates an exact draft copy of one version and all its locales.
+- `fork` copies inherited template behavior into local workspace ownership.
 
-#### Template Bulk Send (workspace scope)
+### API keys
 
-| Method | Path                              | Description |
-| ------ | --------------------------------- | ----------- |
-| GET    | `/templates/:id/bulk-send-config` | Return UI bulk-send limits and behavior |
-| POST   | `/templates/:id/bulk-send`        | Queue a bulk send using the current published version |
+| Method | Path |
+| --- | --- |
+| POST | `/api-keys` |
+| GET | `/api-keys` |
+| DELETE | `/api-keys/:id` |
 
-**Notes**
+Created keys return the raw key only once and use the environment-aware prefix for that workspace environment.
 
-- Only available on **workspace-scoped** template editors.
-- Uses the **current published version** of the template.
-- Request body contains only `items[]`; the template comes from the current screen.
-- The POST endpoint reuses the same batch send engine as `/api/v1/send/batch`.
-- Every persisted email is tagged with provenance so you can distinguish API-key sends from UI bulk uploads.
+### Webhooks
 
-#### API Keys
+| Method | Path |
+| --- | --- |
+| POST | `/webhooks` |
+| GET | `/webhooks` |
+| GET | `/webhooks/:id` |
+| PUT | `/webhooks/:id` |
+| DELETE | `/webhooks/:id` |
+| POST | `/webhooks/:id/test` |
 
-| Method | Path                   | Description    |
-| ------ | ---------------------- | -------------- |
-| POST   | `/api-keys`            | Create API key |
-| GET    | `/api-keys`            | List API keys  |
-| DELETE | `/api-keys/:id/revoke` | Revoke API key |
+### Emails / suppression / audit / dashboard
 
-#### Webhooks
+| Method | Path |
+| --- | --- |
+| GET | `/emails` |
+| GET | `/emails/:tracking_id` |
+| GET | `/emails/:tracking_id/events` |
+| POST | `/suppression` |
+| GET | `/suppression/:email` |
+| DELETE | `/suppression/:email` |
+| GET | `/audit-log` |
+| GET | `/dashboard-stats` |
 
-| Method | Path                 | Description     |
-| ------ | -------------------- | --------------- |
-| POST   | `/webhooks`          | Create webhook  |
-| GET    | `/webhooks`          | List webhooks   |
-| GET    | `/webhooks/:id`      | Get webhook     |
-| PUT    | `/webhooks/:id`      | Update webhook  |
-| DELETE | `/webhooks/:id`      | Delete webhook  |
-| POST   | `/webhooks/:id/test` | Send test event |
+## External integration surface
 
-#### Emails (Management View)
+Base: `/api/v1/external/:profile_slug`
 
-| Method | Path                          | Description                      |
-| ------ | ----------------------------- | -------------------------------- |
-| GET    | `/emails`                     | List emails (management filters) |
-| GET    | `/emails/:tracking_id`        | Get email                        |
-| GET    | `/emails/:tracking_id/events` | Get delivery events              |
+### Public bootstrap
 
-#### Suppression List
+| Method | Path |
+| --- | --- |
+| GET | `/bootstrap` |
+| GET | `/environments/:environment/bootstrap` |
 
-| Method | Path                  | Description                          |
-| ------ | --------------------- | ------------------------------------ |
-| POST   | `/suppression/add`    | Add address to suppression list      |
-| POST   | `/suppression/check`  | Check if address is suppressed       |
-| POST   | `/suppression/remove` | Remove address from suppression list |
+### Authenticated external workspace surface
 
-#### Audit Log
+Base:
 
-| Method | Path         | Description                               |
-| ------ | ------------ | ----------------------------------------- |
-| GET    | `/audit-log` | Query audit entries (paginated, filtered) |
+`/api/v1/external/:profile_slug/tenants/:tenant_code/workspaces/:workspace_code`
 
-#### Dashboard
+Required request header:
 
-| Method | Path               | Description                            |
-| ------ | ------------------ | -------------------------------------- |
-| GET    | `/dashboard/stats` | Workspace email statistics and metrics |
+```http
+X-Senda-Environment: prod|test
+```
 
----
+Key endpoints:
 
-### Global-Scoped Resources (Superadmin)
+| Method | Path | Capability |
+| --- | --- | --- |
+| GET | `/session` | `builder_access` |
+| GET | `/template-types` | `list_templates` |
+| GET | `/template-types/:slug` | `list_templates` |
+| GET | `/template-types/:slug/templates` | `list_templates` |
+| GET | `/templates/:template_id/versions` | `view_versions` |
+| GET | `/templates/:template_id/versions/:version_id` | `view_versions` |
+| PUT | `/templates/:template_id/versions/:version_id` | `edit_versions` |
+| POST | `/templates/:template_id/versions/:version_id/publish` | `publish_versions` |
+| GET | `/templates/:template_id/versions/:version_id/locales` | `locale_access` |
+| GET | `/templates/:template_id/versions/:version_id/locales/:locale` | `locale_access` |
+| POST | `/templates/:template_id/versions/:version_id/locales/:locale` | `locale_access` |
+| PUT | `/templates/:template_id/versions/:version_id/locales/:locale` | `locale_access` |
+| DELETE | `/templates/:template_id/versions/:version_id/locales/:locale` | `locale_access` |
+| POST | `/templates/:template_id/preview-mjml` | `builder_access` |
+| POST | `/templates/:template_id/test-send` | `test_send` |
+| GET | `/injectors` | `builder_access` |
+| GET | `/injectors/:name` | `builder_access` |
+| GET | `/policies` | `builder_access` |
+
+The effective workspace may differ from the path workspace if the registered resolver returns a read-only fallback.
+
+## Global scope
 
 Base: `/api/v1/manage/global`
 
-Global resources mirror the workspace-scoped structure but apply at the platform level. Only Superadmins have access. Global resources participate in the resolution chain and can be inherited by tenants and workspaces.
+Global scope mirrors the workspace resource families for superadmin use.
 
-| Resource           | Endpoints                                       |
-| ------------------ | ----------------------------------------------- |
-| Injectors          | CRUD + values (same as workspace-scoped)        |
-| Adapters           | CRUD + test + setup-guide + auto-provision      |
-| Adapter Identities | List, create, sync, delete, set-default         |
-| Template Types     | CRUD                                            |
-| Templates          | CRUD + versions + locales + preview + test-send |
-| Audit Log          | GET with filters                                |
-| Dashboard          | GET stats                                       |
+## Webhook events
 
----
+Typical outbound events include:
 
-## Webhook Events
+- `email.queued`
+- `email.sent`
+- `email.delivered`
+- `email.bounced`
+- `email.complained`
+- `email.failed`
+- `email.opened`
+- `*`
 
-Senda delivers real-time event notifications to configured webhook URLs.
+## Postman
 
-| Event              | Description                                       |
-| ------------------ | ------------------------------------------------- |
-| `email.queued`     | Email accepted and placed in the send queue       |
-| `email.sent`       | Email handed off to the provider                  |
-| `email.delivered`  | Provider confirmed delivery to recipient MTA      |
-| `email.bounced`    | Email bounced (hard or soft)                      |
-| `email.complained` | Recipient marked the email as spam                |
-| `email.failed`     | Permanent send failure                            |
-| `email.opened`     | Recipient opened the email (tracking pixel fired) |
-| `*`                | Wildcard, subscribes to all events                |
-
-### Signature Verification
-
-Every webhook request includes an HMAC-SHA256 signature in `X-Senda-Signature`, computed over the raw request body using the webhook's secret key.
-
-```
-X-Senda-Signature: sha256=<hex_digest>
-```
-
-Verification example:
-
-```python
-import hmac, hashlib
-
-def verify(body: bytes, secret: str, signature: str) -> bool:
-    expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, signature)
-```
-
----
-
-## Rate Limiting
-
-The data plane enforces token-bucket rate limiting per workspace. When exceeded, the API returns `429 Too Many Requests`. Retry after the period indicated in the `Retry-After` response header.
-
----
-
-## Postman Collection
-
-An importable Postman collection covering all endpoints is available at `docs/postman/senda-api-v1.postman_collection.json`.
+A Postman collection is available in `docs/postman/`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,382 +1,141 @@
+
 # Senda Architecture
 
-> Email orchestration platform. Go + PostgreSQL. No Redis. Hexagonal architecture.
-
----
-
-## 1. System Overview
-
-Senda is a multi-tenant email orchestration platform built on a **3-level hierarchy**:
-
-```
-Global -> Tenant -> Workspace
-```
-
-Each level inherits configuration from its parent through a resolution chain. Templates, injectors, and adapters resolve upward until a match is found.
-
-**UI scope model:** The "Tenant" UI scope is the `_system` workspace (`/t/{code}/w/_system`). See `docs/specs/DESIGN_BRIEF.md` §3.2-3.4 for navigation flow and sidebar visibility matrix.
-
-**Stack:** Go 1.25+, PostgreSQL 16 + pg_cron, Echo v5, River (queue), pgx v5, gomjml, golang-migrate.
-
-On the web side, Senda uses Next.js 16 + React 19 with shared semantic theme tokens and a
-single branding asset (`web/public/senda-logo.svg`) applied consistently across public pages,
-dashboard chrome, and the editor shell.
-
----
-
-## 2. Hexagonal Architecture
-
-The codebase follows Ports & Adapters. The domain layer has **zero infrastructure dependencies**.
-
-```mermaid
-graph LR
-    subgraph Edge["Edge (HTTP)"]
-        H[Echo Handlers]
-        MW[Middleware Chain]
-    end
-
-    subgraph Adapters["Adapters (infra)"]
-        PG[PostgreSQL Stores]
-        RV[River Workers]
-        SES[SES Adapter]
-        GM[Gmail Adapter]
-        PGC[PG UNLOGGED Cache]
-        CR[AES-256-GCM Crypto]
-        RL[PL/pgSQL Rate Limiter]
-    end
-
-    subgraph Ports["Ports (interfaces)"]
-        ST[(Stores)]
-        JQ[JobQueue]
-        ES[EmailSender]
-        TC[TemplateCompiler]
-        OV[OIDCVerifier]
-        CA[Cache]
-        CY[Crypto]
-        RT[RateLimiter]
-    end
-
-    subgraph Domain["Domain (pure)"]
-        EN[Entities]
-        VO[Value Objects]
-        SV[Services]
-        RE[Resolution Engine]
-    end
-
-    H --> MW --> SV
-    SV --> ST & JQ & ES & TC & OV & CA & CY & RT
-    PG -.implements.-> ST
-    RV -.implements.-> JQ
-    SES -.implements.-> ES
-    GM -.implements.-> ES
-    PGC -.implements.-> CA
-    CR -.implements.-> CY
-    RL -.implements.-> RT
-```
-
-**Layer rules:**
-
-- `internal/domain/` -- entities and value objects. No imports from other internal packages.
-- `internal/port/` -- interfaces. Depends only on domain.
-- `internal/service/` -- orchestration. Depends on domain + ports.
-- `internal/resolution/` -- resolution engine. Depends on domain + ports.
-- `internal/adapter/` -- infrastructure implementations. Implements ports.
-- `internal/http/` -- HTTP handlers and middleware. Depends on services.
-
----
-
-## 3. Domain Entities
-
-### Hierarchy & Access
+Senda is a PostgreSQL-first email orchestration platform with hierarchical resolution, environment-aware workspaces, and a public embedding SDK.
 
-| Entity         | Description                                                                                 |
-| -------------- | ------------------------------------------------------------------------------------------- |
-| **Tenant**     | Top-level organization                                                                      |
-| **Workspace**  | Isolated environment within a tenant (+ a `_system` workspace per tenant for defaults)      |
-| **Member**     | Human user linked via OIDC                                                                  |
-| **MemberRole** | 5 roles:`Superadmin`, `TenantAdmin`, `WorkspaceAdmin`, `WorkspaceEditor`, `WorkspaceViewer` |
-| **APIKey**     | Machine credential. Prefix `senda_live_`, stored as SHA-256 hash                            |
+## Core topology
 
-### Email Infrastructure
+Senda has four surfaces:
 
-| Entity                    | Description                                                   |
-| ------------------------- | ------------------------------------------------------------- |
-| **Adapter**               | Provider connection (SES, Gmail)                              |
-| **AdapterIdentity**       | Email/domain identity. States:`verified`, `pending`, `failed` |
-| **TemplateType**          | Slug-addressable category with an assigned adapter            |
-| **Template**              | Belongs to a template type                                    |
-| **TemplateVersion**       | Lifecycle:`Draft` -> `Published` -> `Archived`                |
-| **TemplateVersionLocale** | Localized content for a version                               |
+1. **Management plane** — OIDC + RBAC for admin and content operations
+2. **Data plane** — workspace API keys for send/query
+3. **External integration surface** — embeddable builder/editor APIs with custom auth/resolver seams
+4. **SDK surface** — Go extension points for embedders
 
-### Operations
+## Layering
 
-| Entity                                       | Description                                                                                                                                |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **InjectorDefinition**                       | Scoped variable definition (workspace,\_system, or global)                                                                                 |
-| **InjectorField**                            | Individual field within a definition                                                                                                       |
-| **InjectorValue**                            | Field-level value; merged across scopes (highest priority wins)                                                                            |
-| **Email**                                    | Send record. States:`Queued` -> `Processing` -> `Sent` -> `Delivered` -> `Opened` -> `Bounced` -> `Complained` -> `Failed` -> `Suppressed` |
-| **EmailEvent**                               | State transition log                                                                                                                       |
-| **Webhook**                                  | Outbound webhook. HMAC-SHA256 signed, supports wildcard events                                                                             |
-| **SuppressionGlobal / SuppressionWorkspace** | Suppression entries. Reasons:`HardBounce`, `Complaint`, `Manual`                                                                           |
-| **AuditLog**                                 | Immutable record. Actions:`Create`, `Update`, `Delete`, `Publish`, `Archive`, `Disable`, `Enable`, `Revoke`, `Invite`, `RemoveRole`        |
-| **GlobalConfig**                             | System-wide configuration                                                                                                                  |
-| **ProviderEvent**                            | Raw inbound event from email providers                                                                                                     |
+- `internal/domain/` — pure domain model and environment/policy types
+- `internal/port/` — contracts for stores, senders, and public extension seams
+- `internal/service/` — business orchestration
+- `internal/resolution/` — scope, injector, and template resolution
+- `internal/adapter/` — Postgres, River, SES, Gmail, SMTP, MJML, crypto, cache
+- `internal/http/` — handlers and middleware
+- `sdk/` — public aliases and engine builder for embedders
 
----
+## Domain entities
 
-## 4. Port Interfaces
+### Hierarchy and auth
 
-All in `internal/port/`. Services depend only on these interfaces.
+| Entity | Purpose |
+| --- | --- |
+| `Tenant` | top-level organization |
+| `Workspace` | operational unit inside a tenant |
+| `_system` workspace | tenant-wide defaults and selective sharing control point |
+| `Member` / `MemberRole` | OIDC-backed human access and RBAC |
+| `APIKey` | machine credential for one workspace environment |
 
-**Storage ports:**
-`TenantStore`, `WorkspaceStore`, `InjectorStore`, `TemplateStore`, `EmailStore`, `MemberStore`, `SuppressionStore`, `AdapterStore`, `AdapterIdentityStore`, `WebhookStore`, `APIKeyStore`, `AuditLogStore`, `GlobalConfigStore`, `DashboardStore`
-
-**Infrastructure ports:**
-`JobQueue` (EnqueueSend, EnqueueWebhook), `EmailSender` (Send, Name, HealthCheck), `TemplateCompiler`, `VariableRenderer`, `OIDCVerifier`, `Cache`, `Crypto`, `RateLimiter`, `IdentityProvider`
-
----
-
-## 5. Services
-
-| Service               | Responsibility                                                                                                               |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| **SendService**       | Full send pipeline: validate -> resolve template -> resolve adapter -> check suppression -> compile -> rate limit -> enqueue |
-| **TemplateService**   | Template/version/locale CRUD with lifecycle transitions                                                                      |
-| **EventProcessor**    | Processes provider callbacks (bounces, complaints, deliveries, opens) and updates email state                                |
-| **WebhookService**    | Fire-and-forget webhook dispatch to registered endpoints                                                                     |
-| **APIKeyService**     | Generate, validate, revoke API keys                                                                                          |
-| **IdentityService**   | Sync provider identities, manage default sender addresses                                                                    |
-| **OnboardingService** | Guided tenant/workspace/adapter setup flow                                                                                   |
-
----
-
-## 6. Resolution Engine
-
-Located in `internal/resolution/`. Resolves configuration by walking the scope chain upward.
-
-```mermaid
-flowchart TD
-    REQ[Send Request with template_type slug + locale]
-    CR[ChainResolver]
-    TR[TemplateResolver]
-    IM[InjectorMerger]
-    AR[AdapterResolver]
-    OUT[Resolved: Template + Adapter + Injectors]
-
-    REQ --> CR
-    CR -->|"scope chain: workspace -> _system -> global"| TR
-    TR -->|"locale fallback: es-CO -> es -> default"| IM
-    IM -->|"field-level merge, highest priority wins"| AR
-    AR -->|"adapter assigned to template_type"| OUT
-
-    subgraph Cache TTLs
-        C1["ChainResolver: 5 min"]
-        C2["AdapterResolver: 10 min"]
-    end
-```
-
-### ChainResolver
-
-Builds the scope chain for a given workspace: `[workspace] -> [_system workspace] -> [global]`. Cached for 5 minutes.
-
-### TemplateResolver
-
-Walks the chain to find a published template matching the requested type slug. Applies locale fallback: specific locale (e.g., `es-CO`) -> language (e.g., `es`) -> default locale.
-
-### InjectorMerger
-
-Collects injector definitions from all scopes in the chain. Merges at field level -- values from the most specific scope (workspace) override less specific ones (global).
-
-### AdapterResolver
-
-Resolves which adapter handles the send. Adapters are assigned per **template type**, not per workspace or template. Cached for 10 minutes.
-
-Regular workspaces can use:
-
-- adapters they own directly;
-- Gmail adapters granted from the tenant `_system` workspace;
-- SES adapters granted from the tenant `_system` workspace **only** through explicitly shared email identities.
-
-When a workspace uses a shared SES adapter, the resolved template type must carry a `sender_identity_id` that was granted to that workspace. That keeps send attribution, logs, and dashboard breakdown tied to the effective workspace + sender identity, even when the underlying adapter is shared.
+### Messaging model
 
----
+| Entity | Purpose |
+| --- | --- |
+| `Adapter` | provider configuration |
+| `AdapterIdentity` | provider identity (email/domain) |
+| `TemplateType` | slug-addressable sending category |
+| `Template` | concrete content holder for a template type |
+| `TemplateVersion` | draft/published/archive version |
+| `TemplateVersionLocale` | locale-specific override |
+| `Email` / `EmailEvent` | send state and event history |
+| `Webhook` | outbound notification target |
 
-## 7. Send Pipeline
+## Environment model
 
-Full sequence from API call to delivery confirmation:
+Each logical workspace exists as two operational environments:
 
-```mermaid
-sequenceDiagram
-    participant Client
-    participant Handler as HTTP Handler
-    participant Send as SendService
-    participant Res as Resolution Engine
-    participant Sup as SuppressionStore
-    participant Comp as TemplateCompiler
-    participant RL as RateLimiter
-    participant JQ as JobQueue (River)
-    participant SW as SendWorker
-    participant Provider as Email Provider
-    participant EP as EventProcessor
-    participant WH as WebhookService
+- `prod`
+- `test`
 
-    Client->>Handler: POST /api/v1/emails/send
-    Handler->>Send: Send(ctx, request)
-    Send->>Res: Resolve template + adapter + injectors
-    Res-->>Send: ResolvedContext
-    Send->>Sup: Check suppression (global + workspace)
-    Sup-->>Send: Not suppressed
-    Send->>Comp: Compile MJML -> HTML with injectors
-    Comp-->>Send: Compiled HTML
-    Send->>RL: Check rate limit
-    RL-->>Send: Allowed
-    Send->>JQ: EnqueueSend(emailID, payload)
-    Send-->>Handler: Email{status: Queued}
-    Handler-->>Client: 202 Accepted
+Environment affects:
 
-    Note over SW: Async (River worker)
-    SW->>JQ: Poll for jobs
-    JQ-->>SW: SendJob
-    SW->>Provider: Send email via adapter
-    Provider-->>SW: MessageID
-    SW->>SW: Update email status -> Sent
+- API key generation (`senda_prod_...`, `senda_test_...`)
+- management routing (`/manage/environments/:environment/...`)
+- external integration requests (`X-Senda-Environment`)
+- runtime safety controls in test
+- runtime reset availability in test
 
-    Note over Provider: Later (webhook/SNS)
-    Provider->>EP: Delivery/bounce/complaint event
-    EP->>EP: Update email status
-    EP->>WH: Fire webhooks for event
-    WH->>Client: POST to registered webhook URL
-```
+## Resolution and inheritance
 
----
+Resolution is scope-aware:
 
-## 8. Background Workers
+`workspace -> tenant _system -> global`
 
-River-based, running inside the Go process with PostgreSQL as the backing store. No external broker.
+Three important states:
 
-```mermaid
-flowchart LR
-    subgraph Enqueue
-        S1[SendService] -->|EnqueueSend| Q[(river_job table)]
-        S2[WebhookService] -->|EnqueueWebhook| Q
-    end
+- **owned**
+- **inherited**
+- **shared**
 
-    subgraph Workers
-        Q -->|poll| SW[SendWorker<br/>max 50 concurrent]
-        Q -->|poll| WW[WebhookWorker<br/>max 20 concurrent]
-    end
+Selective sharing rules:
 
-    subgraph Execute
-        SW -->|Send via adapter| P[Email Provider]
-        WW -->|POST + HMAC-SHA256| WE[Webhook Endpoint]
-    end
+- Gmail sharing is adapter-level from `_system`
+- SES sharing is email-identity-level from `_system`
+- shared child-workspace resources are read-only
+- template forks create local ownership from inherited resources
+- exact version cloning copies a version and all locales into a new draft
 
-    subgraph Lifecycle
-        SW -->|success| ACK[Ack / Complete]
-        SW -->|failure| RETRY_S[Retry with backoff]
-        WW -->|success| ACK
-        WW -->|4xx/5xx| RETRY_W[Retry up to 6 attempts]
-    end
-```
-
-**SendWorker:** 50 max concurrent workers. Picks up enqueued email jobs, resolves the adapter, calls `EmailSender.Send()`, and updates email status.
-
-**WebhookWorker:** 20 max concurrent workers. Delivers webhook payloads to registered URLs with HMAC-SHA256 signatures. Retries up to 6 times on failure.
-
----
-
-## 9. Authentication
-
-Dual-auth model:
-
-| Channel         | Mechanism       | Usage                            |
-| --------------- | --------------- | -------------------------------- |
-| Human users     | OIDC (Keycloak) | Dashboard, admin operations      |
-| Machine clients | API Keys        | Programmatic sends, integrations |
-
-**API Keys** use the `senda_live_` prefix. The raw key is shown once at creation; only the SHA-256 hash is stored. Validation compares hashes.
-
-**RBAC** is enforced at the middleware layer based on `MemberRole`. Each endpoint declares its minimum required role.
-
----
-
-## 10. Infrastructure Decisions
-
-### PostgreSQL-Only Stack (No Redis)
-
-| Concern           | Solution                                                                                                                     |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| **Cache**         | PG UNLOGGED table (`internal/adapter/pgcache/`). Fast writes, acceptable durability tradeoff since cache is reconstructible. |
-| **Rate limiting** | PL/pgSQL token bucket function (`internal/adapter/postgres/rate_limiter.go`). Atomic operations within the database.         |
-| **Job queue**     | River. Go-native worker framework backed by PostgreSQL. Jobs are transactional with the rest of the application state.       |
-| **Partitioning**  | `emails` and `audit_logs` tables partitioned by month. Managed by pg_cron.                                                   |
-
-### Encryption
-
-AES-256-GCM with HKDF key derivation. Salt: `senda-v1`, info: `senda-aes-256-gcm`. Used for adapter credentials and sensitive configuration.
-
-### Data Patterns
-
-- **UUIDs v7** -- time-ordered, used as primary keys and cursor-based pagination tokens.
-- **Soft delete** -- `deleted_at` column on all mutable entities. No physical deletes.
-- **Cursor-based pagination** -- no OFFSET queries. UUIDv7 natural ordering serves as the cursor.
-- **24 SQL migrations** -- managed by golang-migrate, applied in order.
-
----
-
-## 11. ADR Log
-
-### ADR-0001: Provider-Managed Email Authentication
-
-**Decision:** SPF, DKIM, and DMARC configuration is handled by the email provider (SES, Gmail), not by Senda.
-
-**Rationale:** Senda orchestrates sends through provider adapters. DNS record management is provider-specific and outside the application's domain. Adapter identities track verification status (`verified`, `pending`, `failed`) but the actual DNS setup is the provider's responsibility.
-
----
-
-## 12. Non-Negotiable Decisions
-
-1. **No Redis** -- PG UNLOGGED for cache, PL/pgSQL for rate limiting.
-2. **Adapter per template_type** -- not per workspace or template.
-3. **Resolution chain** -- workspace -> \_system workspace -> global.
-4. **River for job queue** -- Go + PG native, no external broker.
-5. **OIDC for humans, API Keys for machines** -- dual auth.
-6. **Hexagonal architecture** -- ports define contracts, adapters implement.
-7. **UUIDs v7** -- time-ordered, non-sequential.
-8. **Partitioned tables** -- emails and audit_logs by month.
-9. **Soft delete** -- `deleted_at` column, never physical delete.
-10. **Cursor-based pagination** -- no offset, UUIDv7 as cursor.
-
----
-
-## 13. Directory Structure
-
-```
-senda/
-  cmd/
-    api/              # HTTP server entry point
-    systemtest/       # System test harness
-  internal/
-    domain/           # Entities, value objects (zero deps)
-    port/             # Interface definitions
-    service/          # Business orchestration
-    resolution/       # Chain, template, adapter, injector resolvers
-    adapter/
-      postgres/       # Store implementations + rate limiter
-      pgcache/        # PG UNLOGGED cache
-      ses/            # AWS SES email sender
-      gmail/          # Gmail email sender
-      river/          # SendWorker, WebhookWorker
-      crypto/         # AES-256-GCM encryption
-      keycloak/       # OIDC adapter
-    http/
-      handler/        # Echo route handlers
-      middleware/      # Auth, RBAC, rate limit, logging
-      server.go       # Echo setup and DI wiring
-  migrations/         # SQL migration files (001..024)
-  docker/             # Docker Compose + Keycloak config
-  docs/               # Specs, Postman collection, this file
-  stories/            # Implementation stories (HT-01..HT-37)
-  test/               # System and integration tests
-```
+## External integration architecture
+
+External builder/editor access is profile-driven.
+
+A global external integration profile binds:
+
+- auth method name
+- workspace resolver name
+- allowed origins
+- allowed/required headers
+- capability flags
+
+Runtime pipeline:
+
+1. load profile
+2. validate headers and environment
+3. authenticate with registered auth method
+4. resolve workspace with registered workspace resolver
+5. enforce effective permissions on external routes
+
+## Public SDK architecture
+
+The public SDK is intentionally narrow.
+
+Supported extension points:
+
+- code injectors
+- one per-request init function
+- external auth methods
+- external workspace resolvers
+- startup hooks
+- shutdown hooks
+
+Not exposed through the SDK:
+
+- provider adapter registration
+- internal stores
+- internal queue/cache/crypto wiring
+- internal HTTP middleware composition
+
+## Auth model
+
+| Plane | Auth |
+| --- | --- |
+| Management | OIDC bearer token |
+| Data plane | workspace API key |
+| External integration | custom profile-driven auth + `X-Senda-Environment` |
+
+RBAC applies to management routes. External integration permissions are profile/auth-result driven rather than normal RBAC roles.
+
+## Infrastructure decisions
+
+- PostgreSQL is the system-of-record and operational backbone.
+- River provides PG-backed background jobs.
+- Cache uses PostgreSQL-backed mechanisms rather than Redis.
+- Encryption uses AES-256-GCM with HKDF-derived keys.
+- Soft delete and cursor-based pagination are standard patterns across the app.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -121,7 +121,7 @@ Configure the adapter with the SMTP relay host and port. This is the most flexib
 
 ### Provider Selection
 
-Each adapter is assigned to a template type. When sending an email, Senda resolves the adapter through the 3-level hierarchy (Global, Tenant, Workspace) and uses the configured provider for that template type.
+Each adapter is assigned to a template type. When sending an email, Senda resolves the adapter through the hierarchical scope model (Global, Tenant, `_system`, Workspace) and uses the configured provider for that template type.
 
 ## Health Checks
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,318 +1,155 @@
+
 # Senda Development Guide
 
 ## Prerequisites
 
-| Tool                    | Version | Required                                          |
-| ----------------------- | ------- | ------------------------------------------------- |
-| Docker + Docker Compose | Latest  | Yes                                               |
-| Go                      | 1.25+   | Yes                                               |
-| Node.js                 | 25.x    | Yes (frontend, aligned with `web/.nvmrc`)         |
-| Make                    | Any     | Yes                                               |
-| golang-migrate CLI      | Latest  | Optional (migrations run on app start by default) |
+- Docker
+- Go 1.25+
+- Node 25.x (aligned with `web/.nvmrc`)
+- Make
+- Corepack (recommended for `pnpm`)
 
-## First-Time Setup
+## First-time setup
 
 ```bash
 git clone https://github.com/rendis/senda.git
 cd senda
-make dev          # starts senda + postgres + keycloak + mailpit
-# wait ~30s for keycloak health check
-curl localhost:8081/health  # verify backend
+make dev
+curl http://localhost:8081/health
 ```
 
-`make dev` brings up the full development stack via Docker Compose: the Senda API server with hot reload, PostgreSQL 16 with pg_cron, Keycloak as the OIDC provider, and Mailpit as the local email sink.
+`make dev` starts the local stack: Senda API, PostgreSQL, Keycloak, and Mailpit.
 
-## Backend Development
+## Frontend development
 
-- **Module:** `github.com/rendis/senda`
-- **Go version:** 1.25.1
-- **Hot reload:** Provided by [Air](https://github.com/air-verse/air) via `docker/Dockerfile.dev`
-- **Auto-rebuild:** Code changes under `internal/` trigger automatic rebuild inside the container
-
-The dev container mounts the project root as a volume, so any file change in `internal/`, `cmd/`, or `pkg/` is picked up by Air and triggers a rebuild + restart of the server process.
-
-No local Go installation is strictly required for backend work (everything runs inside Docker), but having Go installed locally is recommended for IDE support, running tests outside Docker, and using `go vet`/`golangci-lint`.
-
-## Frontend Development
+Use `pnpm` only.
 
 ```bash
 corepack enable
 (cd web && corepack install)
 pnpm --dir web install
-pnpm --dir web dev          # starts on localhost:3000
+pnpm --dir web dev
 ```
 
-- **Framework:** Next.js 16
-- **UI:** React 19, TypeScript 5, Tailwind v4
-- **API proxy:** All `/api/v1/*` requests are proxied to the backend (configured in `next.config.ts` rewrites)
-- **Environment:** Copy `web/.env.local.example` to `web/.env.local` and configure:
+Useful frontend checks:
 
-| Variable                  | Description                                            |
-| ------------------------- | ------------------------------------------------------ |
-| `NEXT_PUBLIC_API_URL`     | Backend API base URL (default:`http://localhost:8081`) |
-| `AUTH_SECRET`             | Auth.js session encryption secret                      |
-| `AUTH_OIDC_ISSUER`        | OIDC issuer URL (Keycloak)                             |
-| `AUTH_OIDC_CLIENT_ID`     | OIDC client ID                                         |
-| `AUTH_OIDC_CLIENT_SECRET` | OIDC client secret                                     |
+```bash
+pnpm --dir web typecheck
+pnpm --dir web lint -- --max-warnings=0
+```
 
-### Frontend UX, theme, and branding
+The standard local validation flow does **not** require a local `next build`.
 
-- **Theme modes:** `light`, `dark`, `system`
-- **Default:** `system` (follows browser / OS preference)
-- **Persistence:** local browser storage via `next-themes`
-- **Controls available in:** public pages (`/login`, `/access-denied`, `/onboarding`), dashboard user menu, and `/global/settings`
-- **Editor:** Monaco follows the resolved light/dark theme automatically
-- **Brand asset:** `web/public/senda-logo.svg` is the current canonical logo and favicon source
+## Backend development
 
-If you add a new public asset that must load before authentication, make sure it is exempted
-in `web/src/proxy.ts`; otherwise Auth.js middleware can redirect the request before the asset
-is served.
+Senda is a Go monorepo with the public module:
 
-## Database
+`github.com/rendis/senda`
 
-- **Engine:** PostgreSQL 16 + pg_cron extension
-- **Auto-migrate:** Migrations run automatically on application start (config: `migrate_on_start: true`)
-- **Manual migration:**
-  ```bash
-  make migrate-up     # apply all pending migrations
-  make migrate-down   # rollback last migration
-  ```
-- **Direct connection:**
-  ```bash
-  psql postgres://senda:senda@localhost:5435/senda
-  ```
-- **Migrations directory:** `/migrations/` (37 migration versions / 74 SQL files including `up` + `down`)
-- **Migration tool:** [golang-migrate](https://github.com/golang-migrate/migrate)
+Useful areas:
 
-## Docker Compose Stacks
+- `sdk/` — public SDK
+- `internal/domain/` — domain model
+- `internal/port/` — contracts and extension seams
+- `internal/service/` — business logic
+- `internal/resolution/` — inheritance and injector resolution
+- `internal/http/` — routes, handlers, middleware
 
-The project provides two Docker Compose configurations for different purposes:
+## Dev services
 
-| Aspect       | Dev (`docker-compose.yml`) | E2E (`docker-compose.e2e.yml`) |
-| ------------ | -------------------------- | ------------------------------ |
-| Senda port   | 8081                       | 8090                           |
-| PG port      | 5435                       | 5436                           |
-| Mailpit SMTP | 1026                       | 2025                           |
-| Mailpit UI   | 8026                       | 9025                           |
-| OIDC mode    | `oidc`                     | `dual` (OIDC + test JWT)       |
-| Hot reload   | Yes (Air)                  | No (compiled binary)           |
+| Service | URL / Port |
+| --- | --- |
+| API | `http://localhost:8081` |
+| Keycloak | `http://localhost:9090` |
+| Mailpit UI | `http://localhost:8026` |
+| PostgreSQL | `localhost:5435` |
+| Frontend | `http://localhost:3000` |
 
-The E2E stack uses `dual` auth mode so tests can authenticate with both real OIDC tokens and lightweight test JWTs for speed and determinism.
+## Keycloak test users
 
-## Makefile Reference
-
-All 27 available targets:
-
-### Development
-
-| Target           | Description                                                              |
-| ---------------- | ------------------------------------------------------------------------ |
-| `make dev`       | Start the full development stack (senda + postgres + keycloak + mailpit) |
-| `make dev-down`  | Stop the development stack                                               |
-| `make dev-clean` | Stop and remove all dev containers, volumes, and networks                |
-
-### Build
-
-| Target       | Description            |
-| ------------ | ---------------------- |
-| `make build` | Build the Senda binary |
-
-### Testing
-
-| Target                    | Description                                             |
-| ------------------------- | ------------------------------------------------------- |
-| `make ci-backend-pr`      | Run the fast Docker-free GitHub PR backend gate locally |
-| `make ci-backend-main`    | Run the fast Docker-free main backend gate locally      |
-| `make ci-frontend`        | Run the GitHub frontend gate locally                    |
-| `make ci-pr`              | Run the combined PR gate (backend + frontend)           |
-| `make ci-main`            | Run the combined main/systemic fast gate (no Docker)    |
-| `make test`               | Run unit tests with race detector                       |
-| `make test-integration`   | Run integration tests (TestContainers)                  |
-| `make test-e2e`           | Start E2E stack, run deterministic gate, stop stack     |
-| `make test-e2e-run`       | Run E2E tests (assumes stack is already up)             |
-| `make test-e2e-full`      | Start E2E stack, run full E2E suite, stop stack         |
-| `make test-e2e-full-run`  | Run full E2E suite (assumes stack is already up)        |
-| `make test-e2e-core`      | Start E2E stack, run core E2E tests, stop stack         |
-| `make test-e2e-core-run`  | Run core E2E tests (assumes stack is already up)        |
-| `make test-e2e-chaos`     | Start E2E stack, run chaos/resilience tests, stop stack |
-| `make test-e2e-chaos-run` | Run chaos tests (assumes stack is already up)           |
-| `make test-e2e-ses`       | Run only the SES lifecycle + signed SNS replay suite    |
-| `make test-e2e-up`        | No-op (E2E harness is self-managed by Testcontainers)  |
-| `make test-e2e-down`      | No-op (E2E harness is self-managed by Testcontainers)  |
-
-### System Tests
-
-| Target                          | Description                                                 |
-| ------------------------------- | ----------------------------------------------------------- |
-| `make system-validate-manifest` | Validate the system test manifest                           |
-| `make system-matrix`            | Run the system test matrix                                  |
-| `make system-pr`                | Run PR-level system tests (API contract + UI flow; visual opt-in) |
-| `make system-nightly`           | Run full nightly system test suite (visual opt-in)         |
-| `make system-down`              | Stop system test infrastructure                             |
-
-GitHub runs the lightweight backend/frontend gates automatically on pull requests. Heavy workflows such as `system-pr`, `system-nightly`, and `chaos-e2e` are manual in GitHub (`workflow_dispatch`) and should be triggered intentionally when you need deeper coverage.
-
-### Database
-
-| Target              | Description                           |
-| ------------------- | ------------------------------------- |
-| `make migrate-up`   | Apply all pending database migrations |
-| `make migrate-down` | Rollback the last database migration  |
-
-### Quality
-
-| Target                  | Description                                       |
-| ----------------------- | ------------------------------------------------- |
-| `make lint`             | Run golangci-lint                                 |
-| `make install-githooks` | Configure the versioned pre-push gate enforcement |
-
-`make install-githooks` installs a pre-push hook that runs `make ci-pr` only. Required validation gates are Docker-free; if you want deeper local coverage, run `make test-integration` and/or `make test-e2e` explicitly.
-
-### Cleanup
-
-| Target       | Description                                |
-| ------------ | ------------------------------------------ |
-| `make clean` | Remove build artifacts and temporary files |
-
-### Help
-
-| Target      | Description                                  |
-| ----------- | -------------------------------------------- |
-| `make help` | Show all available targets with descriptions |
-
-## Dev Services Access
-
-| Service                | URL                   | Credentials       |
-| ---------------------- | --------------------- | ----------------- |
-| Senda API              | http://localhost:8081 | --                |
-| Keycloak Admin Console | http://localhost:9090 | `admin` / `admin` |
-| Mailpit UI             | http://localhost:8026 | --                |
-| PostgreSQL             | `localhost:5435`      | `senda` / `senda` |
-
-## Keycloak Test Users
-
-The development Keycloak realm (`senda`) is pre-configured with the following test users:
-
-| Email                      | Password           | Role            |
-| -------------------------- | ------------------ | --------------- |
-| admin@senda.dev            | `admin`            | Superadmin      |
-| tenant-admin@senda.dev     | `tenant-admin`     | TenantAdmin     |
-| workspace-admin@senda.dev  | `workspace-admin`  | WorkspaceAdmin  |
+| Email | Password | Role |
+| --- | --- | --- |
+| admin@senda.dev | `admin` | Superadmin |
+| tenant-admin@senda.dev | `tenant-admin` | TenantAdmin |
+| workspace-admin@senda.dev | `workspace-admin` | WorkspaceAdmin |
 | workspace-editor@senda.dev | `workspace-editor` | WorkspaceEditor |
 | workspace-viewer@senda.dev | `workspace-viewer` | WorkspaceViewer |
 
-These users cover all RBAC roles in the system. The Keycloak realm configuration lives in `docker/keycloak/realm-senda.json`.
+## Make targets
 
-## Testing Guide
+### Development
 
-### Unit Tests
+- `make dev`
+- `make dev-down`
+- `make dev-clean`
 
-```bash
-make test
-```
+### Validation
 
-Runs `go test -race ./...`. Tests use manual mocks (no mock frameworks). All unit tests live alongside the code they test (e.g., `handler_test.go` next to `handler.go`).
+- `make test`
+- `make test-integration`
+- `make test-e2e`
+- `make test-e2e-full`
+- `make test-e2e-core`
+- `make test-e2e-chaos`
+- `make test-e2e-ses`
+- `make ci-backend-pr`
+- `make ci-frontend`
+- `make ci-pr`
+- `make ci-main`
+- `make lint`
+- `make vet`
 
-### Integration Tests
+### System tests
 
-```bash
-make test-integration
-```
+- `make system-validate-manifest`
+- `make system-matrix`
+- `make system-pr`
+- `make system-nightly`
+- `make system-down`
 
-Uses [TestContainers](https://golang.testcontainers.org/) to spin up real PostgreSQL instances. Integration test files are tagged with `//go:build integration` so they do not run during `make test`.
+### Database and helpers
 
-### E2E Tests
+- `make migrate-up`
+- `make migrate-down`
+- `make install-githooks`
+- `make clean`
+- `make help`
+
+## Environment-aware testing
+
+Senda now includes environment-aware runtime flows. When validating changes that touch workspace environment behavior, cover at least one of these:
+
+- `make test-e2e`
+- `make test-e2e-chaos` for crash/recovery or cross-layer runtime behavior
+- `make system-pr` for browser/API validation
+
+The system harness includes a dedicated environment-mode stage:
+
+- `test/system/subagents/ui-environment-mode-tester.sh`
+
+## E2E notes
+
+The deterministic and chaos E2E suites use self-managed Testcontainers harnesses. Prefer the Make targets over manual stack management.
+
+Useful suites:
 
 ```bash
 make test-e2e
-```
-
-Runs the deterministic E2E gate on a self-managed Testcontainers harness. Use `make test-e2e-run` if you already have an external stack running and exported via the harness env report.
-
-### SES-specific E2E coverage
-
-If you want to validate only the SES lifecycle flows, run:
-
-```bash
+make test-e2e-chaos
 make test-e2e-ses
 ```
 
-This suite is clone-friendly and self-contained. It bootstraps:
+## SDK / external integration development
 
-- PostgreSQL
-- Senda app
-- MiniStack
-- the `aws-sim` bridge
+When working on embedding or external integrations, verify against these source-of-truth files:
 
-And it verifies:
+- `sdk/engine.go`
+- `sdk/interfaces.go`
+- `internal/port/code_injector.go`
+- `internal/port/external_integration.go`
+- `internal/http/server.go`
+- `internal/http/middleware/external_integration.go`
 
-- SES auto-provisioning
-- sender identity sync + default identity setup
-- real send through the SES adapter path
-- SES/SNS delivery, bounce, and complaint events
-- deprovision when deleting the adapter
-- a separate signed SNS replay path for webhook signature verification
+## Migrations and data model
 
-### E2E Chaos Tests
-
-```bash
-make test-e2e-chaos
-```
-
-Non-blocking resilience and chaos tests. These exercise failure modes (network partitions, provider timeouts, concurrent mutations) and are not part of the main gate.
-
-### System Tests
-
-```bash
-make system-pr       # PR gate: API contract + UI flow + visual regression
-make system-nightly  # Full nightly suite
-```
-
-System tests cover end-to-end API contracts, UI flows, accessibility, and optional visual regression.
-The PR gate runs a subset for fast feedback; the nightly suite runs the complete matrix. Visual
-diff is opt-in:
-
-```bash
-SYSTEM_UI_VISUAL=1 make system-pr
-SYSTEM_UI_VISUAL=1 make system-nightly
-```
-
-## Troubleshooting
-
-### Port Conflicts
-
-If default ports collide with other services on your machine, override them with environment variables:
-
-```bash
-SENDA_PORT=8082 SENDA_PG_PORT=5437 KEYCLOAK_PORT=9091 make dev
-```
-
-### Keycloak Slow Start
-
-Keycloak has a 30-second health check start period configured in Docker Compose. This is normal. If `make dev` appears to hang, wait for the health check to pass. You can monitor progress with:
-
-```bash
-docker compose logs -f keycloak
-```
-
-### Migration Dirty State
-
-If a migration fails mid-way, the schema_migrations table may be left in a dirty state. Fix it by forcing the version:
-
-```bash
-migrate -database "postgres://senda:senda@localhost:5435/senda?sslmode=disable" \
-        -path migrations force <version>
-```
-
-Replace `<version>` with the last successfully applied migration version number.
-
-### PostgreSQL Not Ready
-
-If the application fails to connect to PostgreSQL on startup:
-
-```bash
-docker compose logs postgres    # check container health
-docker compose ps               # verify container is running
-```
-
-PostgreSQL has a health check configured. If the container shows as `unhealthy`, check disk space and available memory.
+Database migrations live in `migrations/`. Do not hardcode migration counts in docs or tooling; rely on the directory contents.

--- a/docs/extensibility-guide.md
+++ b/docs/extensibility-guide.md
@@ -1,661 +1,191 @@
+
 # Extensibility Guide
 
-Senda can be used as a Go library. Import `github.com/rendis/senda/sdk`, create an Engine, register your extensions, and call `Run()`. Update Senda independently — your extensions keep working.
+Senda can be embedded as a Go library via `github.com/rendis/senda/sdk`.
+
+This guide covers the public seams embedders can rely on without forking Senda.
 
 ```bash
 go get github.com/rendis/senda
 ```
 
----
+## Extension points summary
 
-## Table of Contents
+| Method | Purpose | Multiplicity | Runtime |
+| --- | --- | ---: | --- |
+| `RegisterInjector(...)` | Add a code injector | many | send flow |
+| `SetInitFunc(...)` | Add per-request init | one | send flow |
+| `RegisterExternalAuthMethod(...)` | Add external auth method | many | external surface |
+| `RegisterExternalWorkspaceResolver(...)` | Add external workspace resolver | many | external surface |
+| `OnStart(...)` | Startup hook | many | process lifecycle |
+| `OnShutdown(...)` | Shutdown hook | many | process lifecycle |
 
-1. [Engine](#1-engine)
-2. [Injectors](#2-injectors)
-3. [Init Function](#3-init-function)
-4. [Lifecycle Hooks](#4-lifecycle-hooks)
-5. [InjectorContext Reference](#5-injectorcontext-reference)
-6. [How Code Injectors Merge with DB Injectors](#6-how-code-injectors-merge-with-db-injectors)
-7. [Consumer Project Structure](#7-consumer-project-structure)
-8. [Complete Example](#8-complete-example)
-9. [Error Handling](#9-error-handling)
-10. [Troubleshooting](#10-troubleshooting)
-
----
-
-## 1. Engine
-
-The `sdk.Engine` is the entry point. It wraps Senda's internal bootstrap and lets you register extensions before starting.
-
-### Construction
+## Basic engine bootstrap
 
 ```go
-// Default config path ("config.yaml"):
-engine := sdk.New()
+engine := sdk.NewWithConfig("settings/config.yaml")
 
-// Custom config path:
-engine := sdk.NewWithConfig("settings/app.yaml")
+engine.SetInitFunc(MyInit())
+engine.RegisterInjector(&StudentInjector{})
+engine.RegisterExternalAuthMethod(&PortalAuthMethod{})
+engine.RegisterExternalWorkspaceResolver(&PortalWorkspaceResolver{})
+engine.OnStart(func(ctx context.Context) error { return connectMongo(ctx) })
+engine.OnShutdown(func(ctx context.Context) error { return closeMongo(ctx) })
+
+if err := engine.Run(); err != nil {
+    return err
+}
 ```
 
-The config path can be overridden at runtime with the `SENDA_CONFIG` environment variable.
+## Injectors
 
-### Fluent API
-
-All registration methods return `*Engine` for chaining:
-
-```go
-engine := sdk.NewWithConfig("config.yaml").
-    RegisterInjector(&StudentInjector{}).
-    RegisterInjector(&InstitutionInjector{}).
-    SetInitFunc(myInit()).
-    OnStart(connectMongo).
-    OnShutdown(closeMongo)
-```
-
-### Run
-
-`engine.Run()` performs the following sequence:
-
-1. Load configuration (YAML + `SENDA_*` env vars)
-2. Setup structured logging
-3. Bootstrap all internal components (DB, repositories, resolvers, HTTP server, River workers)
-4. Execute `OnStart` hooks (synchronously, in registration order)
-5. Start River workers (background goroutine)
-6. Start HTTP server (blocks until signal)
-7. On SIGINT/SIGTERM: stop server, execute `OnShutdown` hooks (reverse order), close resources
-
-### Extension Points Summary
-
-| Method | Purpose | Multiplicity |
-|--------|---------|-------------|
-| `RegisterInjector(inj)` | Add a code injector | Multiple allowed |
-| `SetInitFunc(fn)` | Per-request initialization | One (last wins) |
-| `OnStart(fn)` | Post-bootstrap hook | Multiple (FIFO) |
-| `OnShutdown(fn)` | Pre-exit hook | Multiple (LIFO) |
-
-### What the Engine Does NOT Expose
-
-Built-in components are managed by YAML configuration, not the SDK:
-
-- Email senders (SES, Gmail, SMTP)
-- PostgreSQL stores and connection pool
-- River job queue and workers
-- PG UNLOGGED cache
-- AES-256-GCM encryption
-- Rate limiter (PL/pgSQL token bucket)
-- OIDC / API Key authentication
-- HTTP middleware chain
-- Resolution engine (chain, template, adapter resolvers)
-
----
-
-## 2. Injectors
-
-Code injectors are the primary extension point. They resolve dynamic values at send time and merge with DB injectors into templates.
-
-### Interface
+Injectors provide code-defined template fields.
 
 ```go
 type Injector interface {
-    // Code returns the unique injector name.
-    // Maps to the template namespace: {{ injector.<Code()>.<field> }}
     Code() string
-
-    // Resolve returns the resolution function and optional dependency codes.
-    // Dependencies are names of other injectors (code or DB) that must resolve first.
-    Resolve() (ResolveFunc, []string)
-
-    // IsCritical returns true if a failure should abort the entire send.
-    // When false, the injector is silently skipped on error.
+    Resolve() (sdk.ResolveFunc, []string)
     IsCritical() bool
-
-    // Timeout returns the max duration for resolution.
-    // Zero means use the default (30 seconds).
     Timeout() time.Duration
 }
-
-// ResolveFunc executes the injector logic.
-// Returns field_name -> value pairs.
-type ResolveFunc func(ctx context.Context, injCtx *InjectorContext) (map[string]any, error)
 ```
 
-### Minimal Example
+### When injectors run
+
+Injectors run inside the send flow after workspace/template resolution and after the init function.
+
+### What they can read
+
+Use `*sdk.InjectorContext` to access:
+
+- request headers
+- send variables
+- request injector overrides
+- init data
+- tenant/workspace IDs
+- environment
+- already resolved injector values
+
+### Environment access
+
+Use:
 
 ```go
-type GreetingInjector struct{}
-
-func (i *GreetingInjector) Code() string { return "greeting" }
-
-func (i *GreetingInjector) Resolve() (sdk.ResolveFunc, []string) {
-    return func(ctx context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
-        name := injCtx.Variables()["name"]
-        return map[string]any{
-            "message": fmt.Sprintf("Hello, %v!", name),
-        }, nil
-    }, nil
-}
-
-func (i *GreetingInjector) IsCritical() bool      { return false }
-func (i *GreetingInjector) Timeout() time.Duration { return 0 }
+env := injCtx.Environment()
 ```
 
-In the MJML template:
-```
-<mj-text>{{ injector.greeting.message }}</mj-text>
-```
+Do not invent your own environment flag.
 
-### Reading Headers
+## Init function
 
-Injectors can read HTTP headers from the send request:
+Init runs once per send request.
 
 ```go
-func (i *CaseInjector) Resolve() (sdk.ResolveFunc, []string) {
-    return func(ctx context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
-        caseID := injCtx.Header("X-Case-Id")
-        caseData, err := fetchCase(ctx, caseID)
-        if err != nil {
-            return nil, err
-        }
-        return map[string]any{
-            "title":  caseData.Title,
-            "status": caseData.Status,
-        }, nil
-    }, nil
-}
+type InitFunc func(ctx context.Context, injCtx *sdk.InjectorContext) (any, error)
 ```
 
-### Using Init Data
+Use it when multiple injectors need the same request-scoped load.
 
-When an `InitFunc` is registered, its return value is available to all injectors:
+The result is available to injectors through `injCtx.InitData()`.
+
+## External auth methods
+
+External integrations use custom auth, not OIDC.
 
 ```go
-func (i *StudentInjector) Resolve() (sdk.ResolveFunc, []string) {
-    return func(ctx context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
-        // Type-assert the init data to your concrete type.
-        data := injCtx.InitData().(*MyInitData)
-        return map[string]any{
-            "full_name": data.Student.FullName,
-            "email":     data.Student.Email,
-        }, nil
-    }, nil
+type ExternalAuthMethod interface {
+    Name() string
+    Description() string
+    Authenticate(ctx context.Context, req *sdk.ExternalIntegrationRequest) (*sdk.ExternalAuthResult, error)
 }
 ```
 
-### Dependencies Between Injectors
+Use an external auth method to:
 
-Injectors can declare dependencies on other injectors (code or DB). The merger resolves them in topological order.
+- validate tokens or headers from an iframe/portal
+- normalize capability flags
+- attach caller context
+
+The auth method does **not** choose the final workspace.
+
+## External workspace resolvers
+
+Workspace mapping is a separate seam.
 
 ```go
-type SummaryInjector struct{}
-
-func (i *SummaryInjector) Code() string { return "summary" }
-
-func (i *SummaryInjector) Resolve() (sdk.ResolveFunc, []string) {
-    return func(ctx context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
-        // Read a DB injector's value.
-        company, _ := injCtx.GetResolved("company")
-        companyName := ""
-        if company != nil {
-            companyName, _ = company["name"].(string)
-        }
-
-        // Read another code injector's value.
-        student, _ := injCtx.GetResolved("student")
-        studentName := ""
-        if student != nil {
-            studentName, _ = student["full_name"].(string)
-        }
-
-        return map[string]any{
-            "text": fmt.Sprintf("%s enrolled at %s", studentName, companyName),
-        }, nil
-    }, []string{"company", "student"} // <-- declare dependencies
+type ExternalWorkspaceResolver interface {
+    Name() string
+    Description() string
+    ResolveWorkspace(ctx context.Context, req *sdk.ExternalIntegrationRequest, auth *sdk.ExternalAuthResult) (*sdk.ExternalWorkspaceResolution, error)
 }
 ```
 
-**Rules:**
-- Dependencies are resolved before the dependent injector runs
-- If a dependency is a DB injector, it's already resolved (seeded into context before code injectors run)
-- If a dependency code doesn't exist in either DB or code injectors, it's silently skipped
-- Circular dependencies are not detected — avoid them
+Use it to:
 
-### Critical vs Non-Critical
+- map an authenticated request to a workspace
+- force read-only fallback
+- centralize external workspace-routing logic
 
-| `IsCritical()` | On Error | Use When |
-|----------------|----------|----------|
-| `true` | Send is aborted, error returned to caller | Data is essential (e.g., student name in a certificate) |
-| `false` | Injector is skipped, warning logged, send continues | Data is supplementary (e.g., a logo URL) |
+## External request context
 
-### Timeout
+`ExternalIntegrationRequest` includes:
 
-Each injector can set a per-resolution timeout:
+- `ProfileSlug`
+- `Environment`
+- `TenantCode`
+- `WorkspaceCodes`
+- `Token`
+- `Headers`
+- `QueryParams`
+- `Path`
+- `Method`
 
-```go
-func (i *SlowInjector) Timeout() time.Duration {
-    return 10 * time.Second // max 10s for this injector
-}
-```
+The environment comes from the validated `X-Senda-Environment` header.
 
-Zero (default) uses the engine default of **30 seconds**.
+## Lifecycle hooks
 
-### Name Collisions
+### `OnStart(...)`
 
-If a code injector has the same `Code()` as a DB injector, the **code injector wins** and a warning is logged:
+Runs after bootstrap and before the server starts serving.
 
-```
-WARN code injector overrides DB injector code=brand
-```
+Use it for:
 
-If two code injectors have the same `Code()`, the **last registered wins** (map overwrite).
+- connecting external clients
+- warming resources needed by injectors/auth/resolvers
 
-### Registration
+### `OnShutdown(...)`
 
-```go
-engine.RegisterInjector(&StudentInjector{})
-engine.RegisterInjector(&InstitutionInjector{})
-engine.RegisterInjector(&SummaryInjector{})
-```
+Runs during shutdown in reverse registration order.
 
----
+Use it for:
 
-## 3. Init Function
+- closing external clients
+- flushing buffers
+- stopping long-lived resources
 
-The init function runs **once per send request**, before any code injectors execute. Use it to load shared data that multiple injectors need.
+## Send flow
 
-### Signature
+1. request enters the send pipeline
+2. tenant, workspace, and template type resolve
+3. `InjectorContext` is created
+4. DB injectors resolve and seed context
+5. `InitFunc` runs once
+6. code injectors run in dependency order
+7. values merge and render proceeds
+8. provider dispatch / queueing continues
 
-```go
-type InitFunc func(ctx context.Context, injCtx *InjectorContext) (any, error)
-```
+## External integration flow
 
-### Example
+1. profile loads by slug
+2. required headers and `X-Senda-Environment` validate
+3. selected auth method authenticates
+4. selected workspace resolver returns the effective workspace or read-only fallback
+5. capability guards apply per route
 
-```go
-type InitData struct {
-    Admission *Admission
-    Student   *Student
-}
+## Design guidance for embedders
 
-func MyInit() sdk.InitFunc {
-    return func(ctx context.Context, injCtx *sdk.InjectorContext) (any, error) {
-        caseID := injCtx.Header("X-Case-Id")
-        if caseID == "" {
-            return nil, nil // no case context, injectors handle gracefully
-        }
-
-        admission, err := admissionRepo.FindByID(ctx, caseID)
-        if err != nil {
-            return nil, fmt.Errorf("load admission: %w", err)
-        }
-
-        student, err := studentRepo.FindByID(ctx, admission.StudentID)
-        if err != nil {
-            return nil, fmt.Errorf("load student: %w", err)
-        }
-
-        return &InitData{
-            Admission: admission,
-            Student:   student,
-        }, nil
-    }
-}
-```
-
-### Behavior
-
-- Runs after DB injectors are resolved (so `injCtx.GetResolved("db_injector")` works)
-- If it returns an error, the **entire send is aborted**
-- The returned value is stored in `injCtx.InitData()` and accessible to all code injectors
-- Only one InitFunc is allowed; calling `SetInitFunc` again replaces the previous one
-
-### Registration
-
-```go
-engine.SetInitFunc(MyInit())
-```
-
----
-
-## 4. Lifecycle Hooks
-
-### OnStart
-
-Runs after Senda is fully bootstrapped (DB connected, migrations applied, River ready, HTTP server configured) but **before** the server accepts requests.
-
-```go
-engine.OnStart(func(ctx context.Context) error {
-    mongoClient, err = mongo.Connect(ctx, mongoURI)
-    if err != nil {
-        return fmt.Errorf("connect mongo: %w", err)
-    }
-    initRepositories(mongoClient)
-    return nil
-})
-```
-
-- Multiple hooks allowed, executed in **registration order** (FIFO)
-- If any hook returns an error, startup is aborted
-- Use for: connecting external databases, initializing HTTP clients, loading secrets
-
-### OnShutdown
-
-Runs after the HTTP server stops and before the process exits.
-
-```go
-engine.OnShutdown(func(ctx context.Context) error {
-    if mongoClient != nil {
-        return mongoClient.Disconnect(ctx)
-    }
-    return nil
-})
-```
-
-- Multiple hooks allowed, executed in **reverse order** (LIFO)
-- Errors are logged but don't prevent shutdown of subsequent hooks
-- Shutdown context has a 30-second timeout
-- Use for: closing database connections, flushing buffers, stopping background processes
-
----
-
-## 5. InjectorContext Reference
-
-The `InjectorContext` is passed to both the init function and all code injectors. It's **thread-safe** (uses `sync.RWMutex` internally).
-
-### Available Methods
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `Header(key)` | `string` | HTTP request header value. Empty if not found or headers are nil |
-| `Headers()` | `map[string]string` | Copy of all HTTP headers. Safe to modify |
-| `Ref()` | `string` | Send request addressing ref (e.g., `"tenant:workspace:templateType"`) |
-| `Variables()` | `map[string]any` | Caller-provided event variables from the send request |
-| `InitData()` | `any` | Value returned by `InitFunc`. Nil if no InitFunc set. Type-assert to your concrete type |
-| `TenantID()` | `uuid.UUID` | Resolved tenant UUID |
-| `WorkspaceID()` | `uuid.UUID` | Resolved workspace UUID |
-| `TemplateType()` | `string` | Resolved template type slug |
-| `GetResolved(code)` | `(map[string]any, bool)` | Get resolved fields for a named injector (DB or code). Returns false if not yet resolved |
-
-### Data Flow
-
-```
-HTTP Request arrives (POST /api/v1/send)
-    │
-    ├── Headers extracted → injCtx.Header("X-Case-Id")
-    ├── Body parsed → injCtx.Ref(), injCtx.Variables()
-    ├── Tenant/Workspace resolved → injCtx.TenantID(), injCtx.WorkspaceID()
-    │
-    ▼
-DB Injectors resolved → seeded into injCtx.GetResolved("db_name")
-    │
-    ▼
-InitFunc runs → result stored in injCtx.InitData()
-    │
-    ▼
-Code Injectors resolve (in dependency order)
-    ├── Each reads injCtx as needed
-    ├── Each result stored via injCtx.SetResolved(code, fields)
-    │
-    ▼
-All values merged → passed to VariableRenderer → MJML template compiled
-```
-
----
-
-## 6. How Code Injectors Merge with DB Injectors
-
-Senda has two types of injectors that coexist:
-
-| Type | Defined In | Managed By | Resolved At |
-|------|-----------|-----------|-------------|
-| **DB Injectors** | PostgreSQL tables (`injector_definitions`, `injector_fields`, `injector_values`) | Dashboard / Management API | Per-workspace, scope hierarchy (workspace > \_system > global) |
-| **Code Injectors** | Go code (`sdk.Injector` interface) | SDK registration (`engine.RegisterInjector`) | Per-request, by the resolution engine |
-
-### Merge Process
-
-1. **DB injectors resolve first** — the `InjectorMerger` resolves all DB injectors via the scope hierarchy chain (workspace > \_system > global), producing `map[string]map[string]any`
-2. **DB values seeded into context** — all DB injector values are available to code injectors via `injCtx.GetResolved("db_injector_name")`
-3. **InitFunc runs** — loads shared per-request data
-4. **Code injectors resolve** — in dependency order (topological sort). Each injector's result is immediately available to subsequent injectors
-5. **Merge** — code injector values are merged into the same map. On name collision, code injector wins
-
-### Template Access
-
-Both types use the same template syntax:
-
-```
-{{ injector.company.name }}       ← could be DB or code injector
-{{ injector.student.full_name }}  ← could be DB or code injector
-{{ event.name }}                  ← caller-provided variable (not an injector)
-```
-
-The template doesn't know or care whether a value came from DB or code.
-
----
-
-## 7. Consumer Project Structure
-
-Following the pattern from pdf-forge and doc-assembly SDKs:
-
-```
-my-senda-app/
-├── main.go                       Entry point
-├── extensions/
-│   ├── register.go               Single registration function
-│   ├── init.go                   InitFunc implementation
-│   └── injectors/
-│       ├── student.go            Code injector: student data
-│       ├── institution.go        Code injector: institution data
-│       └── summary.go            Code injector: derived summary
-├── internal/
-│   ├── datasource/
-│   │   ├── mongodb/              MongoDB repositories
-│   │   ├── api/                  External API clients
-│   │   └── factory/              Dev/prod factory pattern
-│   └── shared/                   JWT utilities, helpers
-├── settings/
-│   └── app.yaml                  Senda YAML configuration
-├── go.mod                        requires github.com/rendis/senda
-└── go.sum
-```
-
-### `main.go`
-
-```go
-package main
-
-import (
-    "log/slog"
-    "os"
-
-    "github.com/rendis/senda/sdk"
-    "my-senda-app/extensions"
-)
-
-func main() {
-    engine := sdk.NewWithConfig("settings/app.yaml")
-    extensions.Register(engine)
-
-    if err := engine.Run(); err != nil {
-        slog.Error("senda failed", "error", err)
-        os.Exit(1)
-    }
-}
-```
-
-### `extensions/register.go`
-
-```go
-package extensions
-
-import (
-    "context"
-    "my-senda-app/extensions/injectors"
-    "github.com/rendis/senda/sdk"
-)
-
-var mongoClient *mongo.Client
-
-func Register(engine *sdk.Engine) {
-    // Init function: load shared data per request.
-    engine.SetInitFunc(TetherInit())
-
-    // Code injectors.
-    engine.RegisterInjector(&injectors.StudentInjector{})
-    engine.RegisterInjector(&injectors.InstitutionInjector{})
-    engine.RegisterInjector(&injectors.SummaryInjector{})
-
-    // Lifecycle: connect/disconnect MongoDB.
-    engine.OnStart(func(ctx context.Context) error {
-        client, err := connectMongo(ctx)
-        if err != nil {
-            return err
-        }
-        mongoClient = client
-        injectors.SetMongoClient(client)
-        return nil
-    })
-
-    engine.OnShutdown(func(ctx context.Context) error {
-        if mongoClient != nil {
-            return mongoClient.Disconnect(ctx)
-        }
-        return nil
-    })
-}
-```
-
----
-
-## 8. Complete Example
-
-A full working injector that loads admission data from MongoDB:
-
-```go
-package injectors
-
-import (
-    "context"
-    "fmt"
-    "time"
-
-    "github.com/rendis/senda/sdk"
-)
-
-// AdmissionInjector provides admission-related fields to email templates.
-// Templates use: {{ injector.admission.student_name }}, {{ injector.admission.status }}, etc.
-type AdmissionInjector struct{}
-
-func (i *AdmissionInjector) Code() string { return "admission" }
-
-func (i *AdmissionInjector) Resolve() (sdk.ResolveFunc, []string) {
-    return func(ctx context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
-        // Read from init data (loaded once, shared across injectors).
-        initData := injCtx.InitData()
-        if initData == nil {
-            return map[string]any{}, nil // graceful: no admission context
-        }
-
-        data, ok := initData.(*InitData)
-        if !ok {
-            return nil, fmt.Errorf("unexpected init data type: %T", initData)
-        }
-
-        adm := data.Admission
-        return map[string]any{
-            "student_name": adm.Student.FullName,
-            "status":       string(adm.Status),
-            "created_at":   adm.CreatedAt.Format("02/01/2006"),
-            "campus_name":  adm.Campus.Name,
-            "program":      adm.Program.Name,
-        }, nil
-    }, nil // no dependencies
-}
-
-func (i *AdmissionInjector) IsCritical() bool      { return true }  // essential for the email
-func (i *AdmissionInjector) Timeout() time.Duration { return 0 }    // use default (30s)
-```
-
----
-
-## 9. Error Handling
-
-### InitFunc Errors
-
-If the init function returns an error, the entire send is aborted and the error propagates to the API caller as a 500 Internal Server Error.
-
-### Critical Injector Errors
-
-If a critical injector (`IsCritical() == true`) fails, the send is aborted:
-
-```
-critical code injector "admission" failed: db connection timeout
-```
-
-### Non-Critical Injector Errors
-
-If a non-critical injector fails, it's skipped and a warning is logged:
-
-```
-WARN non-critical code injector failed code=logo error="image service unavailable"
-```
-
-The email is still sent — the template fields for that injector resolve to empty values.
-
-### Timeout Errors
-
-If an injector exceeds its timeout, the context is cancelled and the injector fails with a context deadline exceeded error. Whether this aborts the send depends on `IsCritical()`.
-
-### OnStart Hook Errors
-
-If any OnStart hook returns an error, `engine.Run()` returns that error immediately without starting the server.
-
-### OnShutdown Hook Errors
-
-Errors are logged but don't prevent other shutdown hooks from executing.
-
----
-
-## 10. Troubleshooting
-
-### "code injector overrides DB injector"
-
-A code injector and a DB injector have the same name. The code injector wins. If this is unintentional, rename your code injector's `Code()` to something unique.
-
-### Injector values are empty in the template
-
-1. Verify the injector is registered: `engine.RegisterInjector(&MyInjector{})`
-2. Verify the `Code()` matches the template: `{{ injector.<Code()>.<field> }}`
-3. Check if `Resolve()` returns the correct field names
-4. If using `InitData()`, verify the init function is registered and returns non-nil
-5. If depending on other injectors, verify dependencies are spelled correctly
-
-### InitFunc panics
-
-Ensure you handle the case where `InitData()` returns nil (no init function set) or an unexpected type. Always use type assertions with the comma-ok pattern:
-
-```go
-data, ok := injCtx.InitData().(*MyType)
-if !ok {
-    return nil, fmt.Errorf("unexpected init data type")
-}
-```
-
-### Dependency order seems wrong
-
-Code injectors are resolved in dependency order (topological sort based on the `[]string` returned by `Resolve()`). If the order seems wrong:
-
-1. Check that dependency codes exactly match other injectors' `Code()` values
-2. DB injector dependencies are always available (resolved before code injectors)
-3. Unknown dependency codes are silently skipped — check for typos
-
-### Headers are empty in InjectorContext
-
-Headers are extracted from the HTTP request by the send handler. If you're testing directly via `SendService.Send()`, ensure you set `req.Headers`:
-
-```go
-req := &service.SendRequest{
-    Ref:     "tenant:ws:type",
-    To:      []string{"user@test.com"},
-    Headers: map[string]string{"X-Case-Id": "123"},
-}
-```
+- Centralize registration in `extensions.Register(engine)`.
+- Keep auth and workspace resolution separate.
+- Use `InitFunc` to avoid duplicated per-request loads.
+- Use `injCtx.Environment()` / `req.Environment` as the environment source of truth.
+- Do not try to replace Senda internals like providers, queue, crypto, or middleware through the SDK. Those remain configuration-driven internals.

--- a/docs/mcp_setup.md
+++ b/docs/mcp_setup.md
@@ -1,8 +1,9 @@
+
 # Senda MCP Setup
 
-Connect AI agents to the Senda email orchestration API using [mcp-openapi-proxy](https://github.com/rendis/mcp-openapi-proxy).
+Connect agents to Senda through the OpenAPI-backed `senda` MCP server.
 
-## Prerequisites
+## Prerequisite
 
 ```bash
 go install github.com/rendis/mcp-openapi-proxy/cmd/mcp-openapi-proxy@latest
@@ -10,16 +11,14 @@ go install github.com/rendis/mcp-openapi-proxy/cmd/mcp-openapi-proxy@latest
 
 ## Claude Code
 
-Auto-detected from `.mcp.json` in repo root. No manual setup needed.
+`.mcp.json` in the repo root is the source of truth.
 
 ```bash
-make dev                    # start senda (port 8081)
-claude mcp list             # verify "senda" connected
+make dev
+claude mcp list
 ```
 
 ## OpenAI Codex
-
-Edit `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.senda]
@@ -33,8 +32,6 @@ MCP_TOOL_PREFIX = "senda"
 ```
 
 ## Gemini CLI
-
-Edit `.gemini/settings.json` (project) or `~/.gemini/settings.json` (global):
 
 ```json
 {
@@ -52,32 +49,45 @@ Edit `.gemini/settings.json` (project) or `~/.gemini/settings.json` (global):
 }
 ```
 
-## Production (OIDC)
+## Authentication
 
-Add OIDC config to env:
+### Management plane
 
-```
-MCP_OIDC_ISSUER=https://auth.tether.education/auth/realms/tether-team
-MCP_OIDC_CLIENT_ID=senda-web
-MCP_AUTH_PROFILE=senda
-```
-
-Then authenticate:
+Use OIDC login for `/api/v1/manage/...` and member-profile operations.
 
 ```bash
-mcp-openapi-proxy login     # browser-based OIDC PKCE
-mcp-openapi-proxy status    # check token
-mcp-openapi-proxy logout    # clear tokens
+mcp-openapi-proxy login
+mcp-openapi-proxy status
 ```
 
-## Environment Variables
+### Data plane
 
-| Variable | Purpose | Default |
-|----------|---------|---------|
-| `MCP_SPEC` | OpenAPI spec URL or file path | (required) |
-| `MCP_BASE_URL` | API base URL | (required) |
-| `MCP_TOOL_PREFIX` | Tool name prefix | `senda` |
-| `MCP_AUTH_TOKEN` | Static bearer token (dev) | — |
-| `MCP_OIDC_ISSUER` | OIDC provider URL | — |
-| `MCP_OIDC_CLIENT_ID` | OIDC client ID | — |
-| `MCP_AUTH_PROFILE` | Token storage namespace | `senda` |
+Export a raw workspace API key, for example:
+
+```bash
+export MCP_AUTH_WORKSPACEAPIKEYBEARER_TOKEN="senda_prod_..."
+```
+
+or
+
+```bash
+export MCP_AUTH_WORKSPACEAPIKEYBEARER_TOKEN="senda_test_..."
+```
+
+### External integration surface
+
+When calling external integration endpoints, include:
+
+```http
+X-Senda-Environment: prod|test
+```
+
+and whatever token/headers the configured external auth method expects.
+
+## Recommended workflow
+
+1. discover endpoints with `senda_list_endpoints`
+2. inspect one endpoint with `senda_describe_endpoint`
+3. call it with `senda_call_endpoint`
+
+Use the bundled skill `skills/senda/` for operational guidance and workflows.

--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -1,166 +1,67 @@
+
 # Senda API - Postman Collection
 
-Comprehensive Postman collection for the Senda email orchestration platform API v1.
+Postman material for the Senda API.
 
 ## Files
 
-| File                                     | Description                                        |
-| ---------------------------------------- | -------------------------------------------------- |
-| `senda-api-v1.postman_collection.json`   | Full API collection (Postman v2.1 format)          |
-| `senda-local.postman_environment.json`   | Environment for local development (localhost:8081) |
-| `senda-staging.postman_environment.json` | Environment for staging (placeholder URL)          |
-
-## Quick Start
-
-1. **Import the collection** into Postman: File > Import > select `senda-api-v1.postman_collection.json`
-2. **Import the environment**: File > Import > select `senda-local.postman_environment.json`
-3. **Select the environment** from the environment dropdown (top-right)
-4. **Set your OIDC token** in the environment variables (`oidc_token`)
-5. **Start testing** with the Health folder to verify connectivity
+| File | Description |
+| --- | --- |
+| `senda-api-v1.postman_collection.json` | Full API collection |
+| `senda-local.postman_environment.json` | Local development environment |
+| `senda-staging.postman_environment.json` | Staging placeholder environment |
 
 ## Authentication
 
-### OIDC (Management API)
+### Management plane
 
-All management endpoints under `/api/v1/manage/` require an OIDC Bearer token. Set the `oidc_token` environment variable with a valid JWT.
+Use OIDC bearer auth for `/api/v1/manage/...` and member-profile requests.
 
-The collection uses Bearer token auth by default. Individual requests inherit this.
+### Data plane
 
-### API Key (Data Plane)
-
-The send and data-plane email query endpoints use Bearer auth with the raw workspace API key:
+Use a raw workspace API key:
 
 ```http
-Authorization: Bearer senda_live_...
+Authorization: Bearer senda_prod_...
 ```
 
-To get an API key:
+or
 
-1. Create one via `POST /api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code/api-keys`
-2. Save the `key` from the response (returned only once)
-3. Set the `api_key` environment variable
-
-Available data-plane endpoints for API key clients:
-
-- `POST /api/v1/send`
-- `POST /api/v1/send/batch`
-- `GET /api/v1/emails`
-- `GET /api/v1/emails/:tracking_id`
-- `GET /api/v1/emails/:tracking_id/events`
-- `GET /api/v1/emails/export`
-
-### No Auth
-
-- `GET /health`, `GET /healthz`, `GET /metrics` - public health checks
-- `GET /api/v1/onboarding/status` - public onboarding status
-- `POST /api/v1/webhooks/ses/inbound` - SNS signature verification (no app auth)
-
-## Collection Structure
-
-The collection is organized into folders matching the API structure:
-
-| Folder             | Endpoints | Auth                     | Description                                |
-| ------------------ | --------- | ------------------------ | ------------------------------------------ |
-| **Health**         | 3         | None                     | Health checks and Prometheus metrics       |
-| **Onboarding**     | 2         | Public / OIDC            | First-use setup                            |
-| **Tenants**        | 5         | OIDC (superadmin)        | Tenant CRUD                                |
-| **Workspaces**     | 5         | OIDC (tenant_admin+)     | Workspace CRUD                             |
-| **Members**        | 4         | OIDC (superadmin)        | Member and role management                 |
-| **Config**         | 2         | OIDC (superadmin)        | Global configuration                       |
-| **Injectors**      | 4         | OIDC (workspace roles)   | Injector definitions and values            |
-| **Adapters**       | 14        | OIDC (workspace roles)   | Email adapter CRUD, identities, and `_system` sharing controls |
-| **Domains**        | 5         | OIDC (workspace roles)   | Domain registration and DKIM verification  |
-| **Template Types** | 3         | OIDC (workspace roles)   | Template type CRUD                         |
-| **Templates**      | 9         | OIDC (workspace roles)   | Templates, versions, locales, MJML preview |
-| **Send**           | 1         | Bearer `senda_live_*`    | Send emails                                |
-| **Emails**         | 4         | Bearer `senda_live_*`    | Data-plane email query and event history   |
-| **Suppression**    | 3         | OIDC (workspace roles)   | Suppression list management                |
-| **Audit Log**      | 1         | OIDC (workspace_viewer+) | Workspace audit log                        |
-| **Webhooks**       | 6         | OIDC (workspace roles)   | Webhook CRUD and test                      |
-| **API Keys**       | 3         | OIDC (workspace_admin)   | API key management                         |
-| **SES Webhooks**   | 1         | None (SNS sig)           | Provider event ingestion                   |
-| **Global**         | 15        | OIDC (superadmin)        | Global-scoped resources                    |
-
-## Variables
-
-The collection uses these variables (auto-populated by test scripts):
-
-| Variable           | Source                      | Description                   |
-| ------------------ | --------------------------- | ----------------------------- |
-| `base_url`         | Environment                 | Server base URL               |
-| `oidc_token`       | Environment                 | OIDC Bearer token             |
-| `api_key`          | Auto (Create API Key)       | Workspace API key (`senda_live_*`) |
-| `tenant_code`      | Auto (Create Tenant)        | Current tenant code           |
-| `workspace_code`   | Auto (Create Workspace)     | Current workspace code        |
-| `system_workspace_code` | Default (`_system`)    | Tenant system workspace code  |
-| `member_id`        | Auto (Create Member)        | Last created member ID        |
-| `role_id`          | Auto (Add Role)             | Last created role ID          |
-| `adapter_id`       | Auto (Create Adapter)       | Last created adapter ID       |
-| `identity_id`      | Auto (List/Create Identity) | Last created or discovered adapter identity ID |
-| `domain_id`        | Auto (Register Domain)      | Last created domain ID        |
-| `template_type_id` | Auto (Create Template Type) | Last created template type ID |
-| `template_id`      | Auto (Create Template)      | Last created template ID      |
-| `version_id`       | Auto (Create Version)       | Last created version ID       |
-| `tracking_id`      | Auto (Send Email)           | Last tracking ID from send    |
-| `webhook_id`       | Auto (Create Webhook)       | Last created webhook ID       |
-| `api_key_id`       | Auto (Create API Key)       | Last created API key ID       |
-
-## Recommended Test Order
-
-For a full end-to-end flow, run requests in this order:
-
-1. Health > Simple Health
-2. Onboarding > Get Onboarding Status
-3. Onboarding > Run Onboarding Setup
-4. Workspaces > Create Workspace
-5. Adapters > Create Adapter
-6. Adapters > List Adapter Identities
-7. Adapters > Update Adapter Workspace Access (when managing Gmail sharing from `_system`)
-8. Adapters > Update Identity Workspace Access (when managing SES email sharing from `_system`)
-9. Domains > Register Domain
-10. Template Types > Create Template Type
-11. Templates > Create Template
-12. Templates > Create Version
-13. Templates > Publish Version
-14. API Keys > Create API Key
-15. Send > Send Email
-16. Emails > List Emails
-17. Emails > Get Email by Tracking ID
-18. Emails > Export Emails (optional)
-
-## Shared Adapter Notes
-
-- The workspace-access endpoints must be called against the tenant `_system` workspace. The collection exposes this through the `system_workspace_code` variable, which defaults to `_system`.
-- Gmail sharing is configured on the adapter itself.
-- SES sharing is configured on an **email identity**, not on the whole domain.
-- For a child workspace using a shared SES adapter, remember to send `sender_identity_id` on the template type payload.
-
-## Pagination
-
-All list endpoints use cursor-based pagination:
-
-- `limit` (query param): Number of items per page (default: 25, max: 100)
-- `cursor` (query param): Cursor from previous response's `next_cursor`
-- Response includes `next_cursor` and `has_more` fields
-
-## Error Format
-
-All errors follow the standard envelope:
-
-```json
-{
-  "error": {
-    "code": "VALIDATION_ERROR",
-    "message": "validation failed",
-    "details": [
-      {
-        "field": "name",
-        "message": "is required"
-      }
-    ],
-    "request_id": "abc-123"
-  }
-}
+```http
+Authorization: Bearer senda_test_...
 ```
 
-Error codes: `BAD_REQUEST`, `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `CONFLICT`, `VALIDATION_ERROR`, `RATE_LIMITED`, `INTERNAL_ERROR`
+The collection variable `api_key` should store the raw key returned when creating an API key.
+
+### External integration surface
+
+For external integration requests, include:
+
+```http
+X-Senda-Environment: prod|test
+```
+
+plus the profile-specific auth headers or token expected by the configured external auth method.
+
+## Recommended order
+
+1. onboarding status / setup
+2. create tenant
+3. create workspace
+4. create adapter
+5. create template type
+6. create template and version
+7. publish version
+8. create API key
+9. send email
+10. inspect email history
+
+For environment-specific operations, use the environment-scoped management routes.
+
+## Notes
+
+- `_system` is the tenant control workspace for sharing and defaults.
+- Gmail sharing is adapter-level.
+- SES sharing is email-identity-level.
+- Test recipient policies and runtime reset are test-only behaviors.
+- Exact version cloning uses `POST /templates/:template_id/versions/:version_id/clone`.

--- a/docs/postman/senda-api-v1.postman_collection.json
+++ b/docs/postman/senda-api-v1.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "_postman_id": "senda-api-v1-collection",
     "name": "Senda API v1",
-    "description": "Comprehensive Postman collection for the Senda email orchestration platform API.\n\n## Authentication\n\n**OIDC (Management API):** Bearer token in Authorization header.\n\n**API Key (Data Plane):** `Authorization: Bearer senda_live_...` with the full key returned at creation.\n\n## Hierarchy\n\nSenda uses a 3-level hierarchy: Global -> Tenant -> Workspace. Resources are scoped to a workspace (or global for superadmin operations).\n\n## Pagination\n\nAll list endpoints use cursor-based pagination with `cursor` and `limit` query parameters. Responses include `next_cursor` and `has_more` fields.",
+    "description": "Comprehensive Postman collection for the Senda email orchestration platform API.\n\n## Authentication\n\n**OIDC (Management API):** Bearer token in Authorization header.\n\n**API Key (Data Plane):** `Authorization: Bearer senda_prod_...` or `Authorization: Bearer senda_test_...` with the full key returned at creation.\n\n## Hierarchy\n\nSenda uses a hierarchical scope model: Global -> Tenant -> _system -> Workspace. Resources can be owned, inherited, or selectively shared depending on scope.\n\n## Pagination\n\nAll list endpoints use cursor-based pagination with `cursor` and `limit` query parameters. Responses include `next_cursor` and `has_more` fields.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -723,7 +723,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"Main Workspace (Updated)\",\n    \"open_tracking_enabled\": true,\n    \"default_locale\": \"en\"\n}"
+              "raw": "{\n    \"name\": \"Main Workspace (Updated)\"\n}"
             },
             "url": {
               "raw": "{{base_url}}/api/v1/manage/tenants/{{tenant_code}}/workspaces/{{workspace_code}}",
@@ -2537,7 +2537,7 @@
     },
     {
       "name": "Send",
-      "description": "Data-plane email sending. Requires a workspace API key in `Authorization: Bearer senda_live_...`.",
+      "description": "Data-plane email sending. Requires a workspace API key in `Authorization: Bearer senda_prod_...` or `Authorization: Bearer senda_test_...`.",
       "item": [
         {
           "name": "Send Email",
@@ -2574,7 +2574,7 @@
                 "send"
               ]
             },
-            "description": "Send an email using a template reference.\n\n**Auth:** `Authorization: Bearer senda_live_...`\n\n**Ref format:** `tenant_code:workspace_code:template_type_slug`\n\n**Response:** 202 Accepted with tracking IDs for each recipient."
+            "description": "Send an email using a template reference.\n\n**Auth:** `Authorization: Bearer senda_prod_...` or `Authorization: Bearer senda_test_...`\n\n**Ref format:** `tenant_code:workspace_code:template_type_slug`\n\n**Response:** 202 Accepted with tracking IDs for each recipient."
           },
           "response": [],
           "event": [
@@ -2639,7 +2639,7 @@
                 "batch"
               ]
             },
-            "description": "Send a same-template batch where each item has its own variables and injector context.\n\n**Auth:** `Authorization: Bearer senda_live_...`\n\n**Limits:** default max 100 items (configurable via `send.batch_max_items` / `SENDA_SEND_BATCH_MAX_ITEMS`).\n\n**Response:** 202 Accepted with per-item tracking IDs and statuses."
+            "description": "Send a same-template batch where each item has its own variables and injector context.\n\n**Auth:** `Authorization: Bearer senda_prod_...` or `Authorization: Bearer senda_test_...`\n\n**Limits:** default max 100 items (configurable via `send.batch_max_items` / `SENDA_SEND_BATCH_MAX_ITEMS`).\n\n**Response:** 202 Accepted with per-item tracking IDs and statuses."
           },
           "response": [],
           "event": [
@@ -2668,7 +2668,7 @@
     },
     {
       "name": "Emails",
-      "description": "Data-plane email query and event history. Requires a workspace API key in `Authorization: Bearer senda_live_...`.",
+      "description": "Data-plane email query and event history. Requires a workspace API key in `Authorization: Bearer senda_prod_...` or `Authorization: Bearer senda_test_...`.",
       "item": [
         {
           "name": "List Emails",
@@ -2749,7 +2749,7 @@
                 }
               ]
             },
-            "description": "List workspace emails with optional filters and cursor-based pagination.\n\n**Auth:** `Authorization: Bearer senda_live_...`"
+            "description": "List workspace emails with optional filters and cursor-based pagination.\n\n**Auth:** `Authorization: Bearer senda_prod_...` or `Authorization: Bearer senda_test_...`"
           },
           "response": [],
           "event": [
@@ -2797,7 +2797,7 @@
                 "{{tracking_id}}"
               ]
             },
-            "description": "Get a single workspace email with all its events.\n\n**Auth:** `Authorization: Bearer senda_live_...`"
+            "description": "Get a single workspace email with all its events.\n\n**Auth:** `Authorization: Bearer senda_prod_...` or `Authorization: Bearer senda_test_...`"
           },
           "response": [],
           "event": [
@@ -2847,7 +2847,7 @@
                 "events"
               ]
             },
-            "description": "Get lifecycle events for a workspace email.\n\n**Auth:** `Authorization: Bearer senda_live_...`"
+            "description": "Get lifecycle events for a workspace email.\n\n**Auth:** `Authorization: Bearer senda_prod_...` or `Authorization: Bearer senda_test_...`"
           },
           "response": []
         },
@@ -2931,7 +2931,7 @@
                 }
               ]
             },
-            "description": "Export workspace emails as CSV using the same filters as the list endpoint.\n\n**Auth:** `Authorization: Bearer senda_live_...`"
+            "description": "Export workspace emails as CSV using the same filters as the list endpoint.\n\n**Auth:** `Authorization: Bearer senda_prod_...` or `Authorization: Bearer senda_test_...`"
           },
           "response": []
         }

--- a/docs/specs/DESIGN_BRIEF.md
+++ b/docs/specs/DESIGN_BRIEF.md
@@ -14,7 +14,7 @@
 
 ## 1. Product Summary
 
-Senda is an open-source transactional email orchestration platform. The dashboard lets administrators manage a 3-level hierarchy (Global → Tenant → Workspace), configure email templates with inheritance, manage domains, email-sending adapters, and monitor the full lifecycle of every email.
+Senda is an open-source transactional email orchestration platform. The dashboard lets administrators manage a hierarchical scope model (Global → Tenant → `_system` → Workspace), configure email templates with inheritance, manage domains, email-sending adapters, and monitor the full lifecycle of every email.
 
 **Dashboard audience:** Technical and semi-technical administrators at companies that manage multiple brands/regions/customers. This is not a consumer product — it is an internal operations tool.
 
@@ -628,7 +628,7 @@ Field: logo (type: img)
 - [Generate]
 - Modal: "Your API Key has been generated. Copy it now — it will never be shown again."
   ```
-  senda_live_a3f8b9c2d4e5f6a7b8c9d0e1f2a3b4c5
+  senda_prod_a3f8b9c2d4e5f6a7b8c9d0e1f2a3b4c5
   ```
   [Copy] [Close]
 

--- a/docs/specs/PRD_v5.md
+++ b/docs/specs/PRD_v5.md
@@ -27,7 +27,7 @@ Connecting each application directly to a provider (SES, Gmail), scattering send
 **User Goals:**
 
 1. A centralized place where any application sends emails, with full lifecycle visibility.
-2. Hierarchical management at 3 levels (Global → Tenant → Workspace) with automatic inheritance and overrides where needed.
+2. Hierarchical management across Global → Tenant → `_system` → Workspace with automatic inheritance, selective sharing, and overrides where needed.
 3. Traceability for all emails in a business case via `external_id`, across workspaces and tenants.
 4. Reusable templates with a visual editor (drag-and-drop + inline) for non-technical users.
 5. Typed data injectors that automatically provide context according to the hierarchy.
@@ -58,9 +58,9 @@ Connecting each application directly to a provider (SES, Gmail), scattering send
 
 ## 4. Core Concepts
 
-### 4.1. Hierarchy: Global → Tenant → Workspace
+### 4.1. Hierarchy: Global → Tenant → `_system` → Workspace
 
-Senda operates with **three hierarchical levels**. The names are generic — each company decides what each level means.
+Senda operates with a hierarchical scope model composed of Global, Tenant, and Workspace, with a special tenant-owned `_system` workspace participating in resolution. The names are generic — each company decides what each level means.
 
 **Global** is the root layer. It is managed by superadmins. It defines defaults inherited across the platform: base templates, corporate injectors, default sending adapters, verified domains, and platform settings.
 
@@ -359,7 +359,7 @@ AI integration is assistance — the editor always retains control over the fina
 **Request:**
 ```json
 POST /api/v1/send
-Authorization: Bearer senda_live_abc123...
+Authorization: Bearer senda_prod_abc123...
 
 {
   "ref": "latam:acme:welcome",
@@ -512,7 +512,7 @@ This flow happens only once. If at least one member already exists, OIDC login i
 Access to the send and query API (data plane) does not use OIDC but long-lived **API Keys**:
 
 - Each API Key belongs to a specific workspace.
-- Identifiable prefix format: `senda_live_<random>` (production) and `senda_test_<random>` (sandbox).
+- Identifiable prefix format: `senda_prod_<random>` (production) and `senda_test_<random>` (test).
 - They are stored hashed in the database (never in plaintext).
 - A workspace can have multiple active API Keys.
 - API Keys can be revoked individually.
@@ -525,7 +525,7 @@ Access to the send and query API (data plane) does not use OIDC but long-lived *
 - Search emails by recipient/sender
 - Export records with filters
 
-**Test/sandbox mode:** Test and simulation functionality (sending a test email without actually delivering it) is performed from the **dashboard** authenticated via OIDC, not from the API. This lets editors and admins test templates without needing test API Keys.
+**Test mode:** Test and simulation functionality exists both through dashboard-driven test sends and through dedicated `senda_test_...` API keys. The environment controls recipient safety policies and runtime isolation.
 
 ### 4.12. Soft Delete and Dependency Management
 
@@ -713,8 +713,8 @@ The audit log is append-only (it cannot be modified or deleted). It is visible t
 
 ### Must-Have (P0)
 
-**R-01: 3-level hierarchy with inheritance and `_system`**
-Global → Tenant → Workspace. Each tenant has an auto-created `_system` workspace for inheritable configuration. Resolution: workspace → tenant `_system` → global.
+**R-01: Hierarchical scope model with inheritance and `_system`**
+Global → Tenant → `_system` → Workspace. Each tenant has an auto-created `_system` workspace for inheritable configuration. Resolution: workspace → tenant `_system` → global.
 - [x] Isolation: resources from workspace A are not visible from workspace B (except via `_system`/global inheritance).
 - [x] `_system` is created automatically when a tenant is created. It cannot be deleted or renamed.
 - [x] Emails cannot be sent from `_system`.
@@ -865,7 +865,7 @@ The first user automatically becomes superadmin.
 **R-20: API Keys for the data plane**
 Authentication for the send and query API uses long-lived API Keys.
 - [x] Each API Key belongs to a workspace.
-- [x] Format: `senda_live_<random>` (prod). It is only shown in full at creation time.
+- [x] Format: `senda_prod_<random>` or `senda_test_<random>` depending on the workspace environment. It is only shown in full at creation time.
 - [x] Stored hashed (never plaintext).
 - [x] A workspace can have multiple API Keys.
 - [x] Individual revocation.
@@ -1049,7 +1049,7 @@ Docker + Docker Compose. Caddy optional for HTTPS.
 ## 10. Phasing
 
 ### Phase 1 — Core
-3-level hierarchy + `_system`, slug codes, typed injectors (top-down schema), API with deterministic addressing (array `to`, `cc`, `bcc`, `locale`), code-based MJML templates (with subject, preview text, from address), versioning with states, kill switch, lifecycle tracking, optional `external_id`, SES/Gmail adapters, provider-managed email authentication (no in-app DKIM), members and roles (multiple superadmins), initial onboarding, API Keys (send + query), OIDC, suppression lists (global + workspace), soft delete + dependencies, audit logging, basic rate limiting (respect SES limits), basic i18n support (field `locale` in the API + template variant resolution).
+Hierarchical scope model + `_system`, slug codes, typed injectors (top-down schema), API with deterministic addressing (array `to`, `cc`, `bcc`, `locale`), code-based MJML templates (with subject, preview text, from address), versioning with states, kill switch, lifecycle tracking, optional `external_id`, SES/Gmail adapters, provider-managed email authentication (no in-app DKIM), members and roles (multiple superadmins), initial onboarding, environment-aware API Keys (send + query), OIDC, suppression lists (global + workspace), soft delete + dependencies, audit logging, basic rate limiting (respect SES limits), basic i18n support (field `locale` in the API + template variant resolution).
 
 ### Phase 2 — Observability
 Dashboard, metrics, advanced search, bulk export, bounce/complaint alerts, test emails from dashboard.

--- a/docs/specs/SECURITY_CHECKLIST.md
+++ b/docs/specs/SECURITY_CHECKLIST.md
@@ -22,7 +22,7 @@
 - [ ] Full key visible only once (in the creation response)
 - [ ] Immediate revocation (check revoked_at on every request)
 - [ ] Rate limit per API key (future, not P1 — but design it to be extensible)
-- [ ] Key prefix identifies the type: `senda_live_` (helps detect leaks)
+- [ ] Key prefix identifies the environment: `senda_prod_` / `senda_test_` (helps detect leaks and misuse)
 - [ ] Audit log on creation and revocation
 
 ### 1.3. RBAC

--- a/docs/specs/TECH_SPEC_v1.md
+++ b/docs/specs/TECH_SPEC_v1.md
@@ -576,7 +576,7 @@ CREATE TABLE api_keys (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     workspace_id    UUID NOT NULL REFERENCES workspaces(id),
 
-    -- senda_live_<random> — only live keys (test access is via dashboard/OIDC)
+    -- senda_prod_<random> / senda_test_<random> — environment-aware workspace API keys
     key_prefix      VARCHAR(20) NOT NULL DEFAULT 'senda_live',
     key_hash        VARCHAR(128) NOT NULL,  -- SHA-256 hex
     key_hint        VARCHAR(8) NOT NULL,    -- last 8 chars for identification
@@ -3468,7 +3468,7 @@ Request
 package middleware
 
 // AuthMiddleware supports two authentication modes:
-// 1. API Key (Bearer senda_live_*) → workspace-scoped
+// 1. API Key (Bearer senda_prod_* or senda_test_*) → workspace-environment scoped
 // 2. OIDC JWT (Bearer eyJ*) → member with roles
 func AuthMiddleware(apiKeyStore port.APIKeyStore, memberStore port.MemberStore, oidcVerifier OIDCVerifier) echo.MiddlewareFunc {
     return func(next echo.HandlerFunc) echo.HandlerFunc {
@@ -3478,7 +3478,7 @@ func AuthMiddleware(apiKeyStore port.APIKeyStore, memberStore port.MemberStore, 
                 return echo.NewHTTPError(401, "missing authorization")
             }
 
-            if strings.HasPrefix(token, "senda_live_") {
+            if strings.HasPrefix(token, "senda_prod_") || strings.HasPrefix(token, "senda_test_") {
                 // API Key auth
                 hash := sha256Hex(token)
                 apiKey, err := apiKeyStore.GetByHash(c.Request().Context(), hash)

--- a/docs/specs/TECH_STORIES.md
+++ b/docs/specs/TECH_STORIES.md
@@ -836,8 +836,8 @@
 
 **Deliverables:**
 - `internal/service/apikey.go` — `APIKeyService`
-  - `Generate(ctx, workspaceID, name, createdBy)` → `{key: "senda_live_xxx...", id, key_hint}` (key visible only once)
-  - Key format: `senda_live_` + 32 random hex chars
+  - `Generate(ctx, workspaceID, environment, name, createdBy)` → `{key: "senda_prod_xxx..." | "senda_test_xxx...", id, key_hint}` (key visible only once)
+  - Key format: `senda_prod_` or `senda_test_` + 32 random hex chars
   - Storage: SHA-256 hash of the key, last 8 chars as hint
   - `Validate(ctx, rawKey)` → `(APIKey, error)`
   - `Revoke(ctx, keyID)` → soft revoke (set `revoked_at`)

--- a/internal/adapter/postgres/email_repo.go
+++ b/internal/adapter/postgres/email_repo.go
@@ -182,6 +182,39 @@ func (r *EmailRepo) GetByProviderMessageID(ctx context.Context, providerMessageI
 	return scanEmail(row)
 }
 
+func (r *EmailRepo) PurgeWorkspaceRuntime(ctx context.Context, workspaceID uuid.UUID) error {
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("beginning purge workspace runtime tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM email_events
+		 WHERE email_id IN (
+		     SELECT id
+		     FROM emails
+		     WHERE workspace_id = @workspace_id
+		 )`,
+		pgx.NamedArgs{"workspace_id": workspaceID},
+	); err != nil {
+		return fmt.Errorf("deleting workspace email events: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM emails WHERE workspace_id = @workspace_id`,
+		pgx.NamedArgs{"workspace_id": workspaceID},
+	); err != nil {
+		return fmt.Errorf("deleting workspace emails: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("committing purge workspace runtime tx: %w", err)
+	}
+
+	return nil
+}
+
 func (r *EmailRepo) UpdateStatus(ctx context.Context, id uuid.UUID, newStatus, expectedStatus domain.EmailStatus) error {
 	result, err := r.pool.Exec(ctx,
 		`UPDATE emails SET status = @new_status, updated_at = now()

--- a/internal/adapter/postgres/template_repo.go
+++ b/internal/adapter/postgres/template_repo.go
@@ -28,18 +28,26 @@ func NewTemplateRepo(pool *pgxpool.Pool) *TemplateRepo {
 
 func (r *TemplateRepo) CreateType(ctx context.Context, tt *domain.TemplateType) error { //nolint:dupl // structurally similar to AdapterRepo.Create
 	row := r.pool.QueryRow(ctx,
-		`INSERT INTO template_types (id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema)
-		 VALUES (@id, @slug, @name, @description, @workspace_id, @adapter_id, @sender_identity_id, @variable_schema)
+		`INSERT INTO template_types (
+		    id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema,
+		    test_recipient_mode, test_recipient_addresses
+		)
+		 VALUES (
+		    @id, @slug, @name, @description, @workspace_id, @adapter_id, @sender_identity_id, @variable_schema,
+		    @test_recipient_mode, @test_recipient_addresses
+		)
 		 RETURNING created_at, updated_at`,
 		pgx.NamedArgs{
-			"id":                 tt.ID,
-			"slug":               tt.Slug,
-			"name":               tt.Name,
-			"description":        tt.Description,
-			"workspace_id":       tt.WorkspaceID,
-			"adapter_id":         tt.AdapterID,
-			"sender_identity_id": tt.SenderIdentityID,
-			"variable_schema":    coalesceJSON(tt.VariableSchema),
+			"id":                       tt.ID,
+			"slug":                     tt.Slug,
+			"name":                     tt.Name,
+			"description":              tt.Description,
+			"workspace_id":             tt.WorkspaceID,
+			"adapter_id":               tt.AdapterID,
+			"sender_identity_id":       tt.SenderIdentityID,
+			"variable_schema":          coalesceJSON(tt.VariableSchema),
+			"test_recipient_mode":      tt.TestRecipientMode,
+			"test_recipient_addresses": domain.NormalizeRecipientAddresses(tt.TestRecipientAddresses),
 		},
 	)
 
@@ -56,15 +64,19 @@ func (r *TemplateRepo) CreateType(ctx context.Context, tt *domain.TemplateType) 
 func (r *TemplateRepo) UpdateType(ctx context.Context, tt *domain.TemplateType) error {
 	row := r.pool.QueryRow(ctx,
 		`UPDATE template_types
-		 SET slug = @slug, name = @name, adapter_id = @adapter_id, sender_identity_id = @sender_identity_id, updated_at = now()
+		 SET slug = @slug, name = @name, adapter_id = @adapter_id, sender_identity_id = @sender_identity_id,
+		     test_recipient_mode = @test_recipient_mode, test_recipient_addresses = @test_recipient_addresses,
+		     updated_at = now()
 		 WHERE id = @id AND deleted_at IS NULL
 		 RETURNING updated_at`,
 		pgx.NamedArgs{
-			"id":                 tt.ID,
-			"slug":               tt.Slug,
-			"name":               tt.Name,
-			"adapter_id":         tt.AdapterID,
-			"sender_identity_id": tt.SenderIdentityID,
+			"id":                       tt.ID,
+			"slug":                     tt.Slug,
+			"name":                     tt.Name,
+			"adapter_id":               tt.AdapterID,
+			"sender_identity_id":       tt.SenderIdentityID,
+			"test_recipient_mode":      tt.TestRecipientMode,
+			"test_recipient_addresses": domain.NormalizeRecipientAddresses(tt.TestRecipientAddresses),
 		},
 	)
 
@@ -96,7 +108,7 @@ func (r *TemplateRepo) GetTypeBySlug(ctx context.Context, slug string, chain []u
 	scopes, includeGlobal := splitChain(chain)
 
 	row := r.pool.QueryRow(ctx,
-		`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema,
+		`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema, test_recipient_mode, test_recipient_addresses,
 		        created_at, updated_at, deleted_at
 		 FROM template_types
 		 WHERE slug = @slug
@@ -124,7 +136,7 @@ func (r *TemplateRepo) FindTypeBySlugInScope(ctx context.Context, slug string, w
 	var row pgx.Row
 	if wsID == nil {
 		row = r.pool.QueryRow(ctx,
-			`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema,
+			`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema, test_recipient_mode, test_recipient_addresses,
 			        created_at, updated_at, deleted_at
 			 FROM template_types
 			 WHERE slug = @slug AND workspace_id IS NULL AND deleted_at IS NULL`,
@@ -132,7 +144,7 @@ func (r *TemplateRepo) FindTypeBySlugInScope(ctx context.Context, slug string, w
 		)
 	} else {
 		row = r.pool.QueryRow(ctx,
-			`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema,
+			`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema, test_recipient_mode, test_recipient_addresses,
 			        created_at, updated_at, deleted_at
 			 FROM template_types
 			 WHERE slug = @slug AND workspace_id = @workspace_id AND deleted_at IS NULL`,
@@ -156,7 +168,7 @@ func (r *TemplateRepo) ListTypes(ctx context.Context, wsID *uuid.UUID, opts port
 		// Global scope: only global types.
 		if afterID != nil {
 			rows, err = r.pool.Query(ctx,
-				`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema,
+				`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema, test_recipient_mode, test_recipient_addresses,
 				        created_at, updated_at, deleted_at
 				 FROM template_types
 				 WHERE workspace_id IS NULL AND deleted_at IS NULL AND id < @after_id
@@ -166,7 +178,7 @@ func (r *TemplateRepo) ListTypes(ctx context.Context, wsID *uuid.UUID, opts port
 			)
 		} else {
 			rows, err = r.pool.Query(ctx,
-				`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema,
+				`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema, test_recipient_mode, test_recipient_addresses,
 				        created_at, updated_at, deleted_at
 				 FROM template_types
 				 WHERE workspace_id IS NULL AND deleted_at IS NULL
@@ -179,7 +191,7 @@ func (r *TemplateRepo) ListTypes(ctx context.Context, wsID *uuid.UUID, opts port
 		// Workspace scope: types in this workspace.
 		if afterID != nil {
 			rows, err = r.pool.Query(ctx,
-				`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema,
+				`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema, test_recipient_mode, test_recipient_addresses,
 				        created_at, updated_at, deleted_at
 				 FROM template_types
 				 WHERE workspace_id = @workspace_id AND deleted_at IS NULL AND id < @after_id
@@ -189,7 +201,7 @@ func (r *TemplateRepo) ListTypes(ctx context.Context, wsID *uuid.UUID, opts port
 			)
 		} else {
 			rows, err = r.pool.Query(ctx,
-				`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema,
+				`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema, test_recipient_mode, test_recipient_addresses,
 				        created_at, updated_at, deleted_at
 				 FROM template_types
 				 WHERE workspace_id = @workspace_id AND deleted_at IS NULL
@@ -359,7 +371,8 @@ func (r *TemplateRepo) GetTemplateByID(ctx context.Context, id uuid.UUID) (*doma
 
 func (r *TemplateRepo) GetTypeByID(ctx context.Context, id uuid.UUID) (*domain.TemplateType, error) {
 	row := r.pool.QueryRow(ctx,
-		`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema, created_at, updated_at, deleted_at
+		`SELECT id, slug, name, description, workspace_id, adapter_id, sender_identity_id, variable_schema, test_recipient_mode, test_recipient_addresses,
+		        created_at, updated_at, deleted_at
 		 FROM template_types
 		 WHERE id = @id AND deleted_at IS NULL`,
 		pgx.NamedArgs{"id": id},
@@ -1154,7 +1167,7 @@ func scanTemplateTypeRow(row pgx.CollectableRow) (*domain.TemplateType, error) {
 	var tt domain.TemplateType
 	err := row.Scan(
 		&tt.ID, &tt.Slug, &tt.Name, &tt.Description,
-		&tt.WorkspaceID, &tt.AdapterID, &tt.SenderIdentityID, &tt.VariableSchema,
+		&tt.WorkspaceID, &tt.AdapterID, &tt.SenderIdentityID, &tt.VariableSchema, &tt.TestRecipientMode, &tt.TestRecipientAddresses,
 		&tt.CreatedAt, &tt.UpdatedAt, &tt.DeletedAt,
 	)
 	if err != nil {
@@ -1167,7 +1180,7 @@ func scanTemplateType(row pgx.Row) (*domain.TemplateType, error) {
 	var tt domain.TemplateType
 	err := row.Scan(
 		&tt.ID, &tt.Slug, &tt.Name, &tt.Description,
-		&tt.WorkspaceID, &tt.AdapterID, &tt.SenderIdentityID, &tt.VariableSchema,
+		&tt.WorkspaceID, &tt.AdapterID, &tt.SenderIdentityID, &tt.VariableSchema, &tt.TestRecipientMode, &tt.TestRecipientAddresses,
 		&tt.CreatedAt, &tt.UpdatedAt, &tt.DeletedAt,
 	)
 	if err != nil {

--- a/internal/adapter/postgres/template_repo_test.go
+++ b/internal/adapter/postgres/template_repo_test.go
@@ -253,6 +253,39 @@ func TestTemplateRepo_GetTypeBySlug_NotFound(t *testing.T) {
 	}
 }
 
+func TestTemplateRepo_GetTypeByID_RoundTripsTestRecipientPolicy(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	repo := pgadapter.NewTemplateRepo(pool)
+
+	mode := domain.TestRecipientModeReplace
+	tt := &domain.TemplateType{
+		ID:                     uuid.New(),
+		Slug:                   "policy-roundtrip",
+		Name:                   "Policy Roundtrip",
+		VariableSchema:         map[string]any{"type": "object"},
+		TestRecipientMode:      &mode,
+		TestRecipientAddresses: []string{"qa@example.com", "qa@example.com", "ops@example.com"},
+	}
+	if err := repo.CreateType(ctx, tt); err != nil {
+		t.Fatalf("CreateType() error: %v", err)
+	}
+
+	got, err := repo.GetTypeByID(ctx, tt.ID)
+	if err != nil {
+		t.Fatalf("GetTypeByID() error: %v", err)
+	}
+	if got.TestRecipientMode == nil || *got.TestRecipientMode != mode {
+		t.Fatalf("expected test recipient mode %q, got %v", mode, got.TestRecipientMode)
+	}
+	if len(got.TestRecipientAddresses) != 2 {
+		t.Fatalf("expected normalized recipient addresses, got %v", got.TestRecipientAddresses)
+	}
+	if got.TestRecipientAddresses[0] != "qa@example.com" || got.TestRecipientAddresses[1] != "ops@example.com" {
+		t.Fatalf("unexpected recipient addresses: %v", got.TestRecipientAddresses)
+	}
+}
+
 func TestTemplateRepo_FindTypeBySlugInScope(t *testing.T) {
 	ctx := context.Background()
 	pool := setupTestDB(ctx, t)

--- a/internal/adapter/postgres/workspace_repo.go
+++ b/internal/adapter/postgres/workspace_repo.go
@@ -25,44 +25,32 @@ func NewWorkspaceRepo(pool *pgxpool.Pool) *WorkspaceRepo {
 }
 
 func (r *WorkspaceRepo) Create(ctx context.Context, ws *domain.Workspace) error {
-	row := r.pool.QueryRow(ctx,
-		`INSERT INTO workspaces (
-		    id, tenant_id, code, name, is_system, open_tracking_enabled, default_locale,
-		    allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors
-		)
-		 VALUES (
-		    @id, @tenant_id, @code, @name, @is_system, @open_tracking_enabled, @default_locale,
-		    @allow_workspace_local_templates, @allow_workspace_inherited_template_forks, @allow_workspace_local_injectors
-		)
-		 RETURNING is_active, created_at, updated_at`,
-		pgx.NamedArgs{
-			"id":                              ws.ID,
-			"tenant_id":                       ws.TenantID,
-			"code":                            ws.Code,
-			"name":                            ws.Name,
-			"is_system":                       ws.IsSystem,
-			"open_tracking_enabled":           ws.OpenTrackingEnabled,
-			"default_locale":                  ws.DefaultLocale,
-			"allow_workspace_local_templates": effectiveWorkspacePolicyValue(ws.AllowWorkspaceLocalTemplates, ws.WorkspacePoliciesInitialized),
-			"allow_workspace_inherited_template_forks": effectiveWorkspacePolicyValue(ws.AllowWorkspaceInheritedTemplateForks, ws.WorkspacePoliciesInitialized),
-			"allow_workspace_local_injectors":          effectiveWorkspacePolicyValue(ws.AllowWorkspaceLocalInjectors, ws.WorkspacePoliciesInitialized),
-		},
-	)
+	return insertWorkspace(ctx, r.pool, ws)
+}
 
-	if err := row.Scan(&ws.IsActive, &ws.CreatedAt, &ws.UpdatedAt); err != nil {
-		if appErr := classifyPgError(err); appErr != nil {
-			return appErr
-		}
-		return fmt.Errorf("inserting workspace: %w", err)
+func (r *WorkspaceRepo) CreateLogicalPair(ctx context.Context, prod *domain.Workspace, test *domain.Workspace) error {
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("beginning logical workspace transaction: %w", err)
 	}
-	ws.WorkspacePoliciesInitialized = true
+	defer func() { _ = tx.Rollback(ctx) }()
 
+	if err := insertWorkspace(ctx, tx, prod); err != nil {
+		return err
+	}
+	if err := insertWorkspace(ctx, tx, test); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("committing logical workspace transaction: %w", err)
+	}
 	return nil
 }
 
 func (r *WorkspaceRepo) GetByID(ctx context.Context, id uuid.UUID) (*domain.Workspace, error) {
 	row := r.pool.QueryRow(ctx,
-		`SELECT id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale,
+		`SELECT id, logical_workspace_id, tenant_id, code, name, environment, is_system, is_active, open_tracking_enabled, default_locale, test_recipient_mode, test_recipient_addresses,
 		        allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors,
 		        created_at, updated_at, deleted_at
 		 FROM workspaces
@@ -73,45 +61,45 @@ func (r *WorkspaceRepo) GetByID(ctx context.Context, id uuid.UUID) (*domain.Work
 	return scanWorkspace(row)
 }
 
-func (r *WorkspaceRepo) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
+func (r *WorkspaceRepo) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error) {
 	row := r.pool.QueryRow(ctx,
-		`SELECT id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale,
+		`SELECT id, logical_workspace_id, tenant_id, code, name, environment, is_system, is_active, open_tracking_enabled, default_locale, test_recipient_mode, test_recipient_addresses,
 		        allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors,
 		        created_at, updated_at, deleted_at
 		 FROM workspaces
-		 WHERE tenant_id = @tenant_id AND code = @code AND deleted_at IS NULL`,
-		pgx.NamedArgs{"tenant_id": tenantID, "code": code},
+		 WHERE tenant_id = @tenant_id AND code = @code AND environment = @environment AND deleted_at IS NULL`,
+		pgx.NamedArgs{"tenant_id": tenantID, "code": code, "environment": environment},
 	)
 
 	return scanWorkspace(row)
 }
 
-func (r *WorkspaceRepo) GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+func (r *WorkspaceRepo) GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID, environment domain.Environment) (*domain.Workspace, error) {
 	row := r.pool.QueryRow(ctx,
-		`SELECT id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale,
+		`SELECT id, logical_workspace_id, tenant_id, code, name, environment, is_system, is_active, open_tracking_enabled, default_locale, test_recipient_mode, test_recipient_addresses,
 		        allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors,
 		        created_at, updated_at, deleted_at
 		 FROM workspaces
-		 WHERE tenant_id = @tenant_id AND is_system = true AND deleted_at IS NULL`,
-		pgx.NamedArgs{"tenant_id": tenantID},
+		 WHERE tenant_id = @tenant_id AND is_system = true AND environment = @environment AND deleted_at IS NULL`,
+		pgx.NamedArgs{"tenant_id": tenantID, "environment": environment},
 	)
 
 	return scanWorkspace(row)
 }
 
-func (r *WorkspaceRepo) ListByTenant(ctx context.Context, tenantID uuid.UUID, opts port.ListOptions) ([]*domain.Workspace, string, error) {
+func (r *WorkspaceRepo) ListByTenant(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, opts port.ListOptions) ([]*domain.Workspace, string, error) {
 	limit, afterID, err := ApplyPagination(opts)
 	if err != nil {
 		return nil, "", err
 	}
 
 	fetchLimit := limit + 1
-	args := pgx.NamedArgs{"tenant_id": tenantID, "limit": fetchLimit}
+	args := pgx.NamedArgs{"tenant_id": tenantID, "environment": environment, "limit": fetchLimit}
 
 	var qb strings.Builder
-	qb.WriteString(`SELECT id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale,
+	qb.WriteString(`SELECT id, logical_workspace_id, tenant_id, code, name, environment, is_system, is_active, open_tracking_enabled, default_locale, test_recipient_mode, test_recipient_addresses,
 	allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors,
-	created_at, updated_at, deleted_at FROM workspaces WHERE tenant_id = @tenant_id AND deleted_at IS NULL`)
+	created_at, updated_at, deleted_at FROM workspaces WHERE tenant_id = @tenant_id AND environment = @environment AND deleted_at IS NULL`)
 
 	if afterID != nil {
 		qb.WriteString(` AND id < @after_id`)
@@ -130,12 +118,9 @@ func (r *WorkspaceRepo) ListByTenant(ctx context.Context, tenantID uuid.UUID, op
 		return nil, "", fmt.Errorf("listing workspaces: %w", err)
 	}
 
-	workspaces, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[domain.Workspace])
+	workspaces, err := pgx.CollectRows(rows, scanWorkspaceCollectableRow)
 	if err != nil {
 		return nil, "", fmt.Errorf("collecting workspaces: %w", err)
-	}
-	for _, workspace := range workspaces {
-		workspace.WorkspacePoliciesInitialized = true
 	}
 
 	var nextCursor string
@@ -147,6 +132,32 @@ func (r *WorkspaceRepo) ListByTenant(ctx context.Context, tenantID uuid.UUID, op
 	return workspaces, nextCursor, nil
 }
 
+func (r *WorkspaceRepo) UpdateShared(ctx context.Context, tenantID uuid.UUID, currentCode, nextCode, nextName string) error {
+	tag, err := r.pool.Exec(ctx,
+		`UPDATE workspaces
+		 SET code = @next_code,
+		     name = @next_name,
+		     updated_at = now()
+		 WHERE tenant_id = @tenant_id AND code = @current_code AND deleted_at IS NULL`,
+		pgx.NamedArgs{
+			"tenant_id":    tenantID,
+			"current_code": currentCode,
+			"next_code":    nextCode,
+			"next_name":    nextName,
+		},
+	)
+	if err != nil {
+		if appErr := classifyPgError(err); appErr != nil {
+			return appErr
+		}
+		return fmt.Errorf("updating shared workspace fields: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return apperr.NotFound("workspace %s not found", currentCode)
+	}
+	return nil
+}
+
 func (r *WorkspaceRepo) Update(ctx context.Context, ws *domain.Workspace) error {
 	row := r.pool.QueryRow(ctx,
 		`UPDATE workspaces
@@ -154,6 +165,8 @@ func (r *WorkspaceRepo) Update(ctx context.Context, ws *domain.Workspace) error 
 		     is_active = @is_active,
 		     open_tracking_enabled = @open_tracking_enabled,
 		     default_locale = @default_locale,
+		     test_recipient_mode = @test_recipient_mode,
+		     test_recipient_addresses = @test_recipient_addresses,
 		     allow_workspace_local_templates = @allow_workspace_local_templates,
 		     allow_workspace_inherited_template_forks = @allow_workspace_inherited_template_forks,
 		     allow_workspace_local_injectors = @allow_workspace_local_injectors,
@@ -166,6 +179,8 @@ func (r *WorkspaceRepo) Update(ctx context.Context, ws *domain.Workspace) error 
 			"is_active":                       ws.IsActive,
 			"open_tracking_enabled":           ws.OpenTrackingEnabled,
 			"default_locale":                  ws.DefaultLocale,
+			"test_recipient_mode":             effectiveTestRecipientMode(ws.TestRecipientMode),
+			"test_recipient_addresses":        domain.NormalizeRecipientAddresses(ws.TestRecipientAddresses),
 			"allow_workspace_local_templates": effectiveWorkspacePolicyValue(ws.AllowWorkspaceLocalTemplates, ws.WorkspacePoliciesInitialized),
 			"allow_workspace_inherited_template_forks": effectiveWorkspacePolicyValue(ws.AllowWorkspaceInheritedTemplateForks, ws.WorkspacePoliciesInitialized),
 			"allow_workspace_local_injectors":          effectiveWorkspacePolicyValue(ws.AllowWorkspaceLocalInjectors, ws.WorkspacePoliciesInitialized),
@@ -183,6 +198,22 @@ func (r *WorkspaceRepo) Update(ctx context.Context, ws *domain.Workspace) error 
 	return nil
 }
 
+func (r *WorkspaceRepo) SoftDeleteLogical(ctx context.Context, tenantID uuid.UUID, code string) error {
+	tag, err := r.pool.Exec(ctx,
+		`UPDATE workspaces
+		 SET deleted_at = now()
+		 WHERE tenant_id = @tenant_id AND code = @code AND deleted_at IS NULL`,
+		pgx.NamedArgs{"tenant_id": tenantID, "code": code},
+	)
+	if err != nil {
+		return fmt.Errorf("soft-deleting logical workspace: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return apperr.NotFound("workspace %s not found", code)
+	}
+	return nil
+}
+
 func (r *WorkspaceRepo) SoftDelete(ctx context.Context, id uuid.UUID) error {
 	tag, err := r.pool.Exec(ctx,
 		`UPDATE workspaces SET deleted_at = now() WHERE id = @id AND deleted_at IS NULL`,
@@ -197,7 +228,7 @@ func (r *WorkspaceRepo) SoftDelete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (r *WorkspaceRepo) ExistsActiveByTenantCode(ctx context.Context, tenantCode string, workspaceCodes []string) (map[string]bool, error) {
+func (r *WorkspaceRepo) ExistsActiveByTenantCode(ctx context.Context, tenantCode string, workspaceCodes []string, environment domain.Environment) (map[string]bool, error) {
 	result := make(map[string]bool, len(workspaceCodes))
 	if len(workspaceCodes) == 0 {
 		return result, nil
@@ -221,9 +252,10 @@ func (r *WorkspaceRepo) ExistsActiveByTenantCode(ctx context.Context, tenantCode
 		LEFT JOIN workspaces w
 		  ON w.tenant_id = t.id
 		 AND w.code = requested.code
+		 AND w.environment = $3
 		 AND w.deleted_at IS NULL
 		 AND w.is_active = true
-		ORDER BY requested.code`, tenantCode, requested)
+		ORDER BY requested.code`, tenantCode, requested, environment)
 	if err != nil {
 		return nil, fmt.Errorf("querying workspace existence by tenant code: %w", err)
 	}
@@ -244,11 +276,74 @@ func (r *WorkspaceRepo) ExistsActiveByTenantCode(ctx context.Context, tenantCode
 	return result, nil
 }
 
+type workspaceQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func insertWorkspace(ctx context.Context, q workspaceQuerier, ws *domain.Workspace) error {
+	if ws.LogicalWorkspaceID == uuid.Nil {
+		ws.LogicalWorkspaceID = ws.ID
+	}
+	if !ws.Environment.Valid() {
+		ws.Environment = domain.EnvironmentProd
+	}
+
+	row := q.QueryRow(ctx,
+		`INSERT INTO workspaces (
+		    id, logical_workspace_id, tenant_id, code, name, environment, is_system, open_tracking_enabled, default_locale, test_recipient_mode, test_recipient_addresses,
+		    allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors
+		)
+		 VALUES (
+		    @id, @logical_workspace_id, @tenant_id, @code, @name, @environment, @is_system, @open_tracking_enabled, @default_locale, @test_recipient_mode, @test_recipient_addresses,
+		    @allow_workspace_local_templates, @allow_workspace_inherited_template_forks, @allow_workspace_local_injectors
+		)
+		 RETURNING is_active, created_at, updated_at`,
+		pgx.NamedArgs{
+			"id":                              ws.ID,
+			"logical_workspace_id":            ws.LogicalWorkspaceID,
+			"tenant_id":                       ws.TenantID,
+			"code":                            ws.Code,
+			"name":                            ws.Name,
+			"environment":                     ws.Environment,
+			"is_system":                       ws.IsSystem,
+			"open_tracking_enabled":           ws.OpenTrackingEnabled,
+			"default_locale":                  ws.DefaultLocale,
+			"test_recipient_mode":             effectiveTestRecipientMode(ws.TestRecipientMode),
+			"test_recipient_addresses":        domain.NormalizeRecipientAddresses(ws.TestRecipientAddresses),
+			"allow_workspace_local_templates": effectiveWorkspacePolicyValue(ws.AllowWorkspaceLocalTemplates, ws.WorkspacePoliciesInitialized),
+			"allow_workspace_inherited_template_forks": effectiveWorkspacePolicyValue(ws.AllowWorkspaceInheritedTemplateForks, ws.WorkspacePoliciesInitialized),
+			"allow_workspace_local_injectors":          effectiveWorkspacePolicyValue(ws.AllowWorkspaceLocalInjectors, ws.WorkspacePoliciesInitialized),
+		},
+	)
+
+	if err := row.Scan(&ws.IsActive, &ws.CreatedAt, &ws.UpdatedAt); err != nil {
+		if appErr := classifyPgError(err); appErr != nil {
+			return appErr
+		}
+		return fmt.Errorf("inserting workspace: %w", err)
+	}
+	ws.WorkspacePoliciesInitialized = true
+
+	return nil
+}
+
 func scanWorkspace(row pgx.Row) (*domain.Workspace, error) {
+	return scanWorkspaceScanner(row)
+}
+
+func scanWorkspaceCollectableRow(row pgx.CollectableRow) (*domain.Workspace, error) {
+	return scanWorkspaceScanner(row)
+}
+
+type workspaceScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanWorkspaceScanner(row workspaceScanner) (*domain.Workspace, error) {
 	var ws domain.Workspace
 	err := row.Scan(
-		&ws.ID, &ws.TenantID, &ws.Code, &ws.Name, &ws.IsSystem, &ws.IsActive,
-		&ws.OpenTrackingEnabled, &ws.DefaultLocale,
+		&ws.ID, &ws.LogicalWorkspaceID, &ws.TenantID, &ws.Code, &ws.Name, &ws.Environment, &ws.IsSystem, &ws.IsActive,
+		&ws.OpenTrackingEnabled, &ws.DefaultLocale, &ws.TestRecipientMode, &ws.TestRecipientAddresses,
 		&ws.AllowWorkspaceLocalTemplates, &ws.AllowWorkspaceInheritedTemplateForks, &ws.AllowWorkspaceLocalInjectors,
 		&ws.CreatedAt, &ws.UpdatedAt, &ws.DeletedAt,
 	)
@@ -267,6 +362,13 @@ func effectiveWorkspacePolicyValue(value bool, initialized bool) bool {
 		return value
 	}
 	return true
+}
+
+func effectiveTestRecipientMode(mode domain.TestRecipientMode) domain.TestRecipientMode {
+	if mode.Valid() {
+		return mode
+	}
+	return domain.TestRecipientModeReplace
 }
 
 func uniqueWorkspaceCodes(workspaceCodes []string) []string {

--- a/internal/adapter/postgres/workspace_repo_listbytenant_regression_test.go
+++ b/internal/adapter/postgres/workspace_repo_listbytenant_regression_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	pgadapter "github.com/rendis/senda/internal/adapter/postgres"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/port"
+)
+
+func TestWorkspaceRepo_ListByTenant_DoesNotRequireNonPersistedFields(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	tenantRepo := pgadapter.NewTenantRepo(pool)
+	repo := pgadapter.NewWorkspaceRepo(pool)
+
+	tenant := createTestTenant(ctx, t, tenantRepo)
+	ws := &domain.Workspace{
+		ID:                  uuid.New(),
+		TenantID:            tenant.ID,
+		Code:                "main",
+		Name:                "Main Workspace",
+		Environment:         domain.EnvironmentProd,
+		OpenTrackingEnabled: true,
+	}
+	if err := repo.Create(ctx, ws); err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	workspaces, _, err := repo.ListByTenant(ctx, tenant.ID, domain.EnvironmentProd, port.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListByTenant() error: %v", err)
+	}
+	if len(workspaces) != 1 {
+		t.Fatalf("expected 1 workspace, got %d", len(workspaces))
+	}
+	if !workspaces[0].WorkspacePoliciesInitialized {
+		t.Fatal("expected workspace policies to be marked as initialized after scan")
+	}
+}

--- a/internal/adapter/postgres/workspace_repo_test.go
+++ b/internal/adapter/postgres/workspace_repo_test.go
@@ -168,7 +168,7 @@ func TestWorkspaceRepo_GetByTenantAndCode(t *testing.T) {
 		t.Fatalf("Create() error: %v", err)
 	}
 
-	got, err := repo.GetByTenantAndCode(ctx, tenant.ID, "tc-lookup")
+	got, err := repo.GetByTenantAndCode(ctx, tenant.ID, "tc-lookup", domain.EnvironmentProd)
 	if err != nil {
 		t.Fatalf("GetByTenantAndCode() error: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestWorkspaceRepo_GetByTenantAndCode_NotFound(t *testing.T) {
 	pool := setupTestDB(ctx, t)
 	repo := pgadapter.NewWorkspaceRepo(pool)
 
-	_, err := repo.GetByTenantAndCode(ctx, uuid.New(), "nonexistent")
+	_, err := repo.GetByTenantAndCode(ctx, uuid.New(), "nonexistent", domain.EnvironmentProd)
 	if err == nil {
 		t.Fatal("expected not found error")
 	}
@@ -212,7 +212,7 @@ func TestWorkspaceRepo_GetSystemWorkspace(t *testing.T) {
 		t.Fatalf("Create() error: %v", err)
 	}
 
-	got, err := repo.GetSystemWorkspace(ctx, tenant.ID)
+	got, err := repo.GetSystemWorkspace(ctx, tenant.ID, domain.EnvironmentProd)
 	if err != nil {
 		t.Fatalf("GetSystemWorkspace() error: %v", err)
 	}
@@ -226,7 +226,7 @@ func TestWorkspaceRepo_GetSystemWorkspace_NotFound(t *testing.T) {
 	pool := setupTestDB(ctx, t)
 	repo := pgadapter.NewWorkspaceRepo(pool)
 
-	_, err := repo.GetSystemWorkspace(ctx, uuid.New())
+	_, err := repo.GetSystemWorkspace(ctx, uuid.New(), domain.EnvironmentProd)
 	if err == nil {
 		t.Fatal("expected not found error")
 	}
@@ -383,7 +383,7 @@ func TestWorkspaceRepo_ListByTenant(t *testing.T) {
 	}
 
 	// First page
-	page1, cursor1, err := repo.ListByTenant(ctx, tenant.ID, port.ListOptions{Limit: 3})
+	page1, cursor1, err := repo.ListByTenant(ctx, tenant.ID, domain.EnvironmentProd, port.ListOptions{Limit: 3})
 	if err != nil {
 		t.Fatalf("ListByTenant(page1) error: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestWorkspaceRepo_ListByTenant(t *testing.T) {
 	}
 
 	// Second page
-	page2, cursor2, err := repo.ListByTenant(ctx, tenant.ID, port.ListOptions{Limit: 3, Cursor: cursor1})
+	page2, cursor2, err := repo.ListByTenant(ctx, tenant.ID, domain.EnvironmentProd, port.ListOptions{Limit: 3, Cursor: cursor1})
 	if err != nil {
 		t.Fatalf("ListByTenant(page2) error: %v", err)
 	}
@@ -435,7 +435,7 @@ func TestWorkspaceRepo_ListByTenant_SoftDeletedExcluded(t *testing.T) {
 		t.Fatalf("SoftDelete() error: %v", err)
 	}
 
-	results, _, err := repo.ListByTenant(ctx, tenant.ID, port.ListOptions{})
+	results, _, err := repo.ListByTenant(ctx, tenant.ID, domain.EnvironmentProd, port.ListOptions{})
 	if err != nil {
 		t.Fatalf("ListByTenant() error: %v", err)
 	}
@@ -467,7 +467,7 @@ func TestWorkspaceRepo_ListByTenant_IsolatesTenants(t *testing.T) {
 	}
 
 	// List for tenant2 should be empty
-	results, _, err := repo.ListByTenant(ctx, tenant2.ID, port.ListOptions{})
+	results, _, err := repo.ListByTenant(ctx, tenant2.ID, domain.EnvironmentProd, port.ListOptions{})
 	if err != nil {
 		t.Fatalf("ListByTenant() error: %v", err)
 	}
@@ -503,7 +503,7 @@ func TestWorkspaceRepo_ExistsActiveByTenantCode(t *testing.T) {
 		t.Fatalf("soft-deleting workspace: %v", err)
 	}
 
-	got, err := repo.ExistsActiveByTenantCode(ctx, tenant.Code, []string{"main", "paused", "deleted", "missing", "main", "foreign"})
+	got, err := repo.ExistsActiveByTenantCode(ctx, tenant.Code, []string{"main", "paused", "deleted", "missing", "main", "foreign"}, domain.EnvironmentProd)
 	if err != nil {
 		t.Fatalf("ExistsActiveByTenantCode() error: %v", err)
 	}
@@ -531,7 +531,7 @@ func TestWorkspaceRepo_ExistsActiveByTenantCode_EmptyInput(t *testing.T) {
 	pool := setupTestDB(ctx, t)
 	repo := pgadapter.NewWorkspaceRepo(pool)
 
-	got, err := repo.ExistsActiveByTenantCode(ctx, "tenant-does-not-matter", nil)
+	got, err := repo.ExistsActiveByTenantCode(ctx, "tenant-does-not-matter", nil, domain.EnvironmentProd)
 	if err != nil {
 		t.Fatalf("ExistsActiveByTenantCode() error: %v", err)
 	}

--- a/internal/adapter/river/send_worker.go
+++ b/internal/adapter/river/send_worker.go
@@ -123,6 +123,7 @@ func WithAdapterRuntime(adapterStore port.AdapterStore, crypto port.Crypto, send
 // Work processes a single email send job.
 func (w *SendWorker) Work(ctx context.Context, job *goriver.Job[SendJobArgs]) error { //nolint:gocognit,gocyclo,funlen // multi-step email send pipeline
 	args := job.Args
+	recoveringProcessingSend := false
 
 	// 1. Fetch email by tracking ID.
 	email, err := w.emailStore.GetByTrackingID(ctx, args.TrackingID)
@@ -141,13 +142,14 @@ func (w *SendWorker) Work(ctx context.Context, job *goriver.Job[SendJobArgs]) er
 		}
 		return nil
 	}
-	// If processing with no provider ID, the worker crashed between Send() and SetProviderMessageID.
-	// A recent timestamp means another worker may still be in-flight; an old one is definitely stuck.
+	// If processing with no provider ID, the worker may have crashed before completing
+	// the send pipeline. For recent timestamps we resume the delivery attempt; for
+	// stale ones we still fail permanently to avoid endlessly retrying ambiguous sends.
 	if email.Status == domain.StatusProcessing && (email.ProviderMessageID == nil || *email.ProviderMessageID == "") {
 		if time.Since(email.UpdatedAt) > staleProcessingThreshold {
 			return w.failPermanently(ctx, email, fmt.Errorf("send: email stuck in processing, likely crashed during send"))
 		}
-		return goriver.JobCancel(fmt.Errorf("send: email %s is processing (no provider ID, recently started — deferring)", email.ID))
+		recoveringProcessingSend = true
 	}
 
 	// 2. Rate limiter check (before status transition so email stays "queued" if denied).
@@ -162,21 +164,23 @@ func (w *SendWorker) Work(ctx context.Context, job *goriver.Job[SendJobArgs]) er
 
 	// 3. Mark as processing + add event.
 	now := time.Now().UTC()
-	if err := w.emailStore.UpdateStatus(ctx, email.ID, domain.StatusProcessing, domain.StatusQueued); err != nil {
-		if errors.Is(err, domain.ErrStatusConflict) {
-			return goriver.JobCancel(fmt.Errorf("send: email %s already claimed (status conflict)", email.ID))
+	if !recoveringProcessingSend {
+		if err := w.emailStore.UpdateStatus(ctx, email.ID, domain.StatusProcessing, domain.StatusQueued); err != nil {
+			if errors.Is(err, domain.ErrStatusConflict) {
+				return goriver.JobCancel(fmt.Errorf("send: email %s already claimed (status conflict)", email.ID))
+			}
+			return fmt.Errorf("send: update status to processing: %w", err)
 		}
-		return fmt.Errorf("send: update status to processing: %w", err)
-	}
-	email.Status = domain.StatusProcessing // Update in-memory state for downstream callers (failPermanently)
-	if err := w.emailStore.AddEvent(ctx, &domain.EmailEvent{
-		ID:         uuid.Must(uuid.NewV7()),
-		EmailID:    email.ID,
-		EventType:  domain.EventTypeProcessing,
-		OccurredAt: now,
-		CreatedAt:  now,
-	}); err != nil {
-		slog.Error("send_worker: failed to add processing event", append(emailLogAttrs(email), "error", err)...)
+		email.Status = domain.StatusProcessing // Update in-memory state for downstream callers (failPermanently)
+		if err := w.emailStore.AddEvent(ctx, &domain.EmailEvent{
+			ID:         uuid.Must(uuid.NewV7()),
+			EmailID:    email.ID,
+			EventType:  domain.EventTypeProcessing,
+			OccurredAt: now,
+			CreatedAt:  now,
+		}); err != nil {
+			slog.Error("send_worker: failed to add processing event", append(emailLogAttrs(email), "error", err)...)
+		}
 	}
 
 	// 4. Render MJML body with variables.

--- a/internal/adapter/river/send_worker_test.go
+++ b/internal/adapter/river/send_worker_test.go
@@ -58,6 +58,7 @@ func (m *mockEmailStore) GetByTrackingID(ctx context.Context, trackingID string)
 	}
 	return nil, domain.ErrNotFound
 }
+func (m *mockEmailStore) PurgeWorkspaceRuntime(_ context.Context, _ uuid.UUID) error { return nil }
 func (m *mockEmailStore) UpdateStatus(ctx context.Context, id uuid.UUID, newStatus, expectedStatus domain.EmailStatus) error {
 	m.updateStatusCalls = append(m.updateStatusCalls, updateStatusCall{ID: id, Status: newStatus})
 	if m.updateStatusFn != nil {
@@ -953,11 +954,11 @@ func TestSendWorker_ProcessingWithoutProviderID_Stale_FailsPermanently(t *testin
 	}
 }
 
-// TestSendWorker_ProcessingWithoutProviderID_Recent_CancelsJob verifies that
-// when the email is in Processing with no ProviderMessageID but was updated
-// recently (< 10 min), the worker defers to the possible concurrent worker by
-// returning JobCancel without marking the email failed.
-func TestSendWorker_ProcessingWithoutProviderID_Recent_CancelsJob(t *testing.T) {
+// TestSendWorker_ProcessingWithoutProviderID_Recent_ResumesDelivery verifies
+// that when the email is in Processing with no ProviderMessageID but was updated
+// recently (< 10 min), the worker resumes the delivery attempt after crash
+// recovery instead of cancelling the job permanently.
+func TestSendWorker_ProcessingWithoutProviderID_Recent_ResumesDelivery(t *testing.T) {
 	email := newTestEmail()
 	email.Status = domain.StatusProcessing
 	email.ProviderMessageID = nil
@@ -968,26 +969,34 @@ func TestSendWorker_ProcessingWithoutProviderID_Recent_CancelsJob(t *testing.T) 
 			return email, nil
 		},
 	}
-	worker := newTestSendWorker(emailStore, &mockCompiler{}, &mockRenderer{}, &mockRateLimiter{}, &mockSender{})
+	sender := &mockSender{
+		sendFn: func(_ context.Context, _ *port.OutgoingEmail) (string, error) {
+			return "provider-msg-recovered", nil
+		},
+	}
+	worker := newTestSendWorker(emailStore, &mockCompiler{}, &mockRenderer{}, &mockRateLimiter{}, sender)
 
 	job := makeJob(SendJobArgs{TrackingID: email.TrackingID, AdapterID: email.AdapterID}, 1)
 
 	err := worker.Work(context.Background(), job)
-	if err == nil {
-		t.Fatal("expected error, got nil")
+	if err != nil {
+		t.Fatalf("expected recovered processing email to resume successfully, got %v", err)
 	}
 
-	// Must be JobCancel.
-	var cancelErr *goriver.JobCancelError
-	if !errors.As(err, &cancelErr) {
-		t.Errorf("expected JobCancelError for recent processing email, got %T: %v", err, err)
+	if len(emailStore.updateStatusCalls) == 0 {
+		t.Fatal("expected status updates during resumed delivery")
 	}
-
-	// Email must NOT have been marked Failed — another worker may still own it.
+	foundSent := false
 	for _, call := range emailStore.updateStatusCalls {
-		if call.Status == domain.StatusFailed {
-			t.Error("email should NOT be marked failed when processing is recent (another worker may own it)")
+		if call.Status == domain.StatusSent {
+			foundSent = true
 		}
+		if call.Status == domain.StatusFailed {
+			t.Fatal("recovered processing email should not be marked failed")
+		}
+	}
+	if !foundSent {
+		t.Fatal("expected resumed delivery to mark email as sent")
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -199,7 +199,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *slog.Logger, ext
 
 	// 11. HTTP handlers.
 	tenantH := handler.NewTenantHandler(tenantRepo, wsRepo, adapterRepo)
-	workspaceH := handler.NewWorkspaceHandler(tenantRepo, wsRepo)
+	workspaceH := handler.NewWorkspaceHandler(tenantRepo, wsRepo, emailRepo)
 	workspacePolicyH := handler.NewWorkspacePolicyHandler(tenantRepo, wsRepo)
 	memberH := handler.NewMemberHandler(memberRepo, tenantRepo, wsRepo)
 	configH := handler.NewConfigHandler(configRepo, handler.OIDCInfo{

--- a/internal/domain/environment.go
+++ b/internal/domain/environment.go
@@ -1,0 +1,60 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Environment identifies the operational workspace environment.
+type Environment string
+
+const (
+	EnvironmentProd Environment = "prod"
+	EnvironmentTest Environment = "test"
+)
+
+// Environments returns the supported environments in stable order.
+func Environments() []Environment {
+	return []Environment{EnvironmentProd, EnvironmentTest}
+}
+
+// ParseEnvironment validates and normalizes a raw environment string.
+func ParseEnvironment(raw string) (Environment, error) {
+	switch Environment(strings.ToLower(strings.TrimSpace(raw))) {
+	case EnvironmentProd:
+		return EnvironmentProd, nil
+	case EnvironmentTest:
+		return EnvironmentTest, nil
+	default:
+		return "", fmt.Errorf("invalid environment %q", raw)
+	}
+}
+
+// MustParseEnvironment panics when the value is invalid. Intended for internal constants/tests.
+func MustParseEnvironment(raw string) Environment {
+	env, err := ParseEnvironment(raw)
+	if err != nil {
+		panic(err)
+	}
+	return env
+}
+
+// Valid reports whether the environment is one of the supported values.
+func (e Environment) Valid() bool {
+	return e == EnvironmentProd || e == EnvironmentTest
+}
+
+// String returns the canonical string value.
+func (e Environment) String() string {
+	return string(e)
+}
+
+// APIKeyTokenPrefix returns the raw API key prefix expected in Authorization headers.
+func (e Environment) APIKeyTokenPrefix() string {
+	return "senda_" + e.String() + "_"
+}
+
+// APIKeyPrefix returns the persisted prefix metadata stored with API keys.
+func (e Environment) APIKeyPrefix() string {
+	return "senda_" + e.String()
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -9,6 +9,7 @@ var (
 	ErrForbidden              = errors.New("forbidden")
 	ErrWorkspaceScopeMismatch = errors.New("workspace scope mismatch")
 	ErrSystemWorkspaceBlocked = errors.New("system workspace cannot be used for send")
+	ErrTestRecipientPolicyUnconfigured = errors.New("test recipient policy is unconfigured")
 	ErrNoAdapterConfigured    = errors.New("no adapter configured")
 	ErrInvalidRef             = errors.New("invalid template reference")
 	ErrSuppressed             = errors.New("recipient is suppressed")

--- a/internal/domain/template.go
+++ b/internal/domain/template.go
@@ -23,6 +23,8 @@ type TemplateType struct {
 	AdapterID           *uuid.UUID     // nil = not configured yet
 	SenderIdentityID    *uuid.UUID     // nil = use adapter default
 	VariableSchema      map[string]any // JSON Schema for event variables
+	TestRecipientMode   *TestRecipientMode
+	TestRecipientAddresses []string
 	OwnerScope          string
 	InheritedFromSystem bool
 	CreatedAt           time.Time

--- a/internal/domain/tenant.go
+++ b/internal/domain/tenant.go
@@ -18,13 +18,17 @@ type Tenant struct {
 
 type Workspace struct {
 	ID                                   uuid.UUID
+	LogicalWorkspaceID                   uuid.UUID
 	TenantID                             uuid.UUID
 	Code                                 string
 	Name                                 string
+	Environment                          Environment
 	IsSystem                             bool
 	IsActive                             bool
 	OpenTrackingEnabled                  bool
 	DefaultLocale                        *string
+	TestRecipientMode                    TestRecipientMode
+	TestRecipientAddresses               []string
 	AllowWorkspaceLocalTemplates         bool
 	AllowWorkspaceInheritedTemplateForks bool
 	AllowWorkspaceLocalInjectors         bool

--- a/internal/domain/test_recipient_policy.go
+++ b/internal/domain/test_recipient_policy.go
@@ -1,0 +1,44 @@
+package domain
+
+import (
+	"net/mail"
+	"strings"
+)
+
+type TestRecipientMode string
+
+const (
+	TestRecipientModeReplace TestRecipientMode = "replace"
+	TestRecipientModeAppend  TestRecipientMode = "append"
+)
+
+func (m TestRecipientMode) Valid() bool {
+	return m == TestRecipientModeReplace || m == TestRecipientModeAppend
+}
+
+func NormalizeRecipientAddresses(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func ValidateRecipientAddresses(values []string) error {
+	for _, value := range NormalizeRecipientAddresses(values) {
+		if _, err := mail.ParseAddress(value); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/http/handler/adapter_test.go
+++ b/internal/http/handler/adapter_test.go
@@ -346,7 +346,7 @@ func TestAdapterHandler_GetWorkspaceAccess_SystemScope(t *testing.T) {
 	workspaceBID := uuid.Must(uuid.NewV7())
 	adapterID := uuid.Must(uuid.NewV7())
 
-	wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
+wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID == tenant.ID && code == "_system" {
 			return &domain.Workspace{
 				ID:       systemWSID,
@@ -358,7 +358,7 @@ func TestAdapterHandler_GetWorkspaceAccess_SystemScope(t *testing.T) {
 		}
 		return nil, domain.ErrNotFound
 	}
-	wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 		if tenantID != tenant.ID {
 			return nil, "", domain.ErrNotFound
 		}
@@ -428,7 +428,7 @@ func TestAdapterHandler_UpdateWorkspaceAccess_WritesAudit(t *testing.T) {
 	systemWS := &domain.Workspace{ID: systemWSID, TenantID: tenant.ID, Code: "_system", Name: "System", IsSystem: true}
 	workspaceA := &domain.Workspace{ID: workspaceAID, TenantID: tenant.ID, Code: "alpha", Name: "Alpha"}
 
-	wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
+wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			return nil, domain.ErrNotFound
 		}
@@ -441,7 +441,7 @@ func TestAdapterHandler_UpdateWorkspaceAccess_WritesAudit(t *testing.T) {
 			return nil, domain.ErrNotFound
 		}
 	}
-	wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 		if tenantID != tenant.ID {
 			return nil, "", domain.ErrNotFound
 		}

--- a/internal/http/handler/apikey.go
+++ b/internal/http/handler/apikey.go
@@ -63,7 +63,7 @@ func (h *APIKeyHandler) Create(c *echo.Context) error {
 		return response.WriteError(c, http.StatusUnauthorized, "UNAUTHORIZED", "authentication required")
 	}
 
-	fullKey, key, err := h.svc.Generate(c.Request().Context(), ws.ID, req.Name, member.ID)
+	fullKey, key, err := h.svc.Generate(c.Request().Context(), ws.ID, ws.Environment, req.Name, member.ID)
 	if err != nil {
 		return mapStoreError(c, err)
 	}

--- a/internal/http/handler/apikey_test.go
+++ b/internal/http/handler/apikey_test.go
@@ -143,8 +143,8 @@ func TestAPIKeyHandler_Create_Success(t *testing.T) {
 	if !ok || key == "" {
 		t.Fatal("response must contain 'key' field")
 	}
-	if !strings.HasPrefix(key, "senda_live_") {
-		t.Fatalf("expected key prefix 'senda_live_', got %q", key)
+	if !strings.HasPrefix(key, "senda_prod_") {
+		t.Fatalf("expected key prefix 'senda_prod_', got %q", key)
 	}
 	if resp["hint"] == nil || resp["hint"] == "" {
 		t.Fatal("response must contain 'hint' field")

--- a/internal/http/handler/email_test.go
+++ b/internal/http/handler/email_test.go
@@ -31,6 +31,7 @@ type mockEmailStore struct {
 	queryByRecipientFn    func(ctx context.Context, wsID uuid.UUID, email string, cursor string, limit int) ([]*domain.Email, string, error)
 	queryByWorkspaceFn    func(ctx context.Context, wsID uuid.UUID, filters port.EmailFilters, cursor string, limit int) ([]*domain.Email, string, error)
 	queryByExternalIDGlobalFn func(ctx context.Context, externalID string, cursor string, limit int) ([]*domain.Email, string, error)
+	purgeWorkspaceFn      func(ctx context.Context, workspaceID uuid.UUID) error
 }
 
 func (m *mockEmailStore) Create(ctx context.Context, email *domain.Email) error {
@@ -48,6 +49,12 @@ func (m *mockEmailStore) GetByTrackingID(ctx context.Context, trackingID string)
 		return m.getByTrackingIDFn(ctx, trackingID)
 	}
 	return nil, domain.ErrNotFound
+}
+func (m *mockEmailStore) PurgeWorkspaceRuntime(ctx context.Context, workspaceID uuid.UUID) error {
+	if m.purgeWorkspaceFn != nil {
+		return m.purgeWorkspaceFn(ctx, workspaceID)
+	}
+	return nil
 }
 func (m *mockEmailStore) UpdateStatus(ctx context.Context, id uuid.UUID, newStatus, _ domain.EmailStatus) error {
 	if m.updateStatusFn != nil {

--- a/internal/http/handler/identity_test.go
+++ b/internal/http/handler/identity_test.go
@@ -223,7 +223,7 @@ func TestIdentityHandler_GetWorkspaceAccess_SystemScope(t *testing.T) {
 	adapterID := uuid.Must(uuid.NewV7())
 	identityID := uuid.Must(uuid.NewV7())
 
-	wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
+wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID == tenant.ID && code == "_system" {
 			return &domain.Workspace{
 				ID:       systemWSID,
@@ -235,7 +235,7 @@ func TestIdentityHandler_GetWorkspaceAccess_SystemScope(t *testing.T) {
 		}
 		return nil, domain.ErrNotFound
 	}
-	wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 		if tenantID != tenant.ID {
 			return nil, "", domain.ErrNotFound
 		}
@@ -331,7 +331,7 @@ func TestIdentityHandler_UpdateWorkspaceAccess_WritesAudit(t *testing.T) {
 	systemWS := &domain.Workspace{ID: systemWSID, TenantID: tenant.ID, Code: "_system", Name: "System", IsSystem: true}
 	workspaceA := &domain.Workspace{ID: workspaceAID, TenantID: tenant.ID, Code: "alpha", Name: "Alpha"}
 
-	wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
+wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			return nil, domain.ErrNotFound
 		}
@@ -344,7 +344,7 @@ func TestIdentityHandler_UpdateWorkspaceAccess_WritesAudit(t *testing.T) {
 			return nil, domain.ErrNotFound
 		}
 	}
-	wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 		if tenantID != tenant.ID {
 			return nil, "", domain.ErrNotFound
 		}

--- a/internal/http/handler/injector.go
+++ b/internal/http/handler/injector.go
@@ -237,7 +237,7 @@ func (h *InjectorHandler) listChain(ctx context.Context, workspace *domain.Works
 		return chain, nil
 	}
 
-	systemWorkspace, err := h.wsStore.GetSystemWorkspace(ctx, workspace.TenantID)
+	systemWorkspace, err := h.wsStore.GetSystemWorkspace(ctx, workspace.TenantID, workspace.Environment)
 	if err != nil {
 		if apperr.IsNotFound(err) || errorsIsNotFound(err) {
 			return chain, nil

--- a/internal/http/handler/injector_test.go
+++ b/internal/http/handler/injector_test.go
@@ -146,7 +146,7 @@ func testTenantAndWorkspace() (*domain.Tenant, *domain.Workspace, *mockTenantSto
 		},
 	}
 	wsStore := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			if tid == tenantID && code == ws.Code {
 				return ws, nil
 			}
@@ -245,7 +245,7 @@ func TestInjectorHandler_List_IncludeInheritedUsesResolutionChain(t *testing.T) 
 	tenant, ws, ts, wsStore := testTenantAndWorkspace()
 	systemID := uuid.Must(uuid.NewV7())
 
-	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("unexpected tenant id %s", tenantID)
 		}
@@ -295,7 +295,7 @@ func TestInjectorHandler_Get_ResolvesInheritedSystemInjectorInWorkspace(t *testi
 	systemID := uuid.Must(uuid.NewV7())
 	defID := uuid.Must(uuid.NewV7())
 
-	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("unexpected tenant id %s", tenantID)
 		}
@@ -364,7 +364,7 @@ func TestInjectorHandler_Get_DoesNotFallbackToGlobalInjectorInWorkspace(t *testi
 	tenant, _, ts, wsStore := testTenantAndWorkspace()
 	systemID := uuid.Must(uuid.NewV7())
 
-	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("unexpected tenant id %s", tenantID)
 		}

--- a/internal/http/handler/member_test.go
+++ b/internal/http/handler/member_test.go
@@ -131,27 +131,36 @@ func (m *memberMockTenantStore) SoftDelete(_ context.Context, _ uuid.UUID) error
 func (m *memberMockTenantStore) Purge(_ context.Context, _ uuid.UUID) error       { return nil }
 
 type memberMockWorkspaceStore struct {
-	getByTenantAndCodeFn func(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error)
+	getByTenantAndCodeFn func(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error)
 }
 
 func (m *memberMockWorkspaceStore) Create(_ context.Context, _ *domain.Workspace) error { return nil }
+func (m *memberMockWorkspaceStore) CreateLogicalPair(_ context.Context, _ *domain.Workspace, _ *domain.Workspace) error {
+	return nil
+}
 func (m *memberMockWorkspaceStore) GetByID(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
 	return nil, nil
 }
-func (m *memberMockWorkspaceStore) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
+func (m *memberMockWorkspaceStore) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error) {
 	if m.getByTenantAndCodeFn != nil {
-		return m.getByTenantAndCodeFn(ctx, tenantID, code)
+		return m.getByTenantAndCodeFn(ctx, tenantID, code, environment)
 	}
 	return nil, nil
 }
-func (m *memberMockWorkspaceStore) GetSystemWorkspace(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
+func (m *memberMockWorkspaceStore) GetSystemWorkspace(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 	return nil, nil
 }
-func (m *memberMockWorkspaceStore) ListByTenant(_ context.Context, _ uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+func (m *memberMockWorkspaceStore) ListByTenant(_ context.Context, _ uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 	return nil, "", nil
 }
+func (m *memberMockWorkspaceStore) UpdateShared(_ context.Context, _ uuid.UUID, _, _, _ string) error {
+	return nil
+}
 func (m *memberMockWorkspaceStore) Update(_ context.Context, _ *domain.Workspace) error { return nil }
-func (m *memberMockWorkspaceStore) SoftDelete(_ context.Context, _ uuid.UUID) error     { return nil }
+func (m *memberMockWorkspaceStore) SoftDeleteLogical(_ context.Context, _ uuid.UUID, _ string) error {
+	return nil
+}
+func (m *memberMockWorkspaceStore) SoftDelete(_ context.Context, _ uuid.UUID) error { return nil }
 
 func setupMemberTest(ms port.MemberStore, ts port.TenantStore, ws port.WorkspaceStore) *echo.Echo {
 	e := echo.New()
@@ -279,7 +288,7 @@ func TestMemberHandler_Create_WorkspaceScope_AssignsRole(t *testing.T) {
 		},
 	}
 	ws := &memberMockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			if tid != tenantID {
 				t.Fatalf("expected tenant id %s, got %s", tenantID, tid)
 			}
@@ -362,7 +371,7 @@ func TestMemberHandler_Create_WorkspaceScope_RequiresRole(t *testing.T) {
 		},
 	}
 	ws := &memberMockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			if tid != tenantID {
 				t.Fatalf("expected tenant id %s, got %s", tenantID, tid)
 			}
@@ -435,7 +444,7 @@ func TestMemberHandler_Create_ExistingEmail_ReusesIdentity(t *testing.T) {
 		},
 	}
 	ws := &memberMockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{ID: workspaceID, TenantID: tenantID, Code: code}, nil
 		},
 	}
@@ -462,6 +471,58 @@ func TestMemberHandler_Create_ExistingEmail_ReusesIdentity(t *testing.T) {
 	}
 	if addedRole.Role != domain.RoleWorkspaceAdmin {
 		t.Fatalf("expected workspace_admin role, got %s", addedRole.Role)
+	}
+}
+
+func TestMemberHandler_Create_GlobalExistingEmail_ReusesIdentity(t *testing.T) {
+	existingMemberID := uuid.New()
+	now := time.Now().UTC()
+	displayName := "Existing User"
+
+	createCalled := false
+	ms := &mockMemberStore{
+		getByEmailFn: func(_ context.Context, email string) (*domain.Member, error) {
+			return &domain.Member{
+				ID:          existingMemberID,
+				Email:       email,
+				DisplayName: &displayName,
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			}, nil
+		},
+		createFn: func(_ context.Context, _ *domain.Member) error {
+			createCalled = true
+			return nil
+		},
+	}
+
+	e := setupMemberTest(ms, &memberMockTenantStore{}, &memberMockWorkspaceStore{})
+
+	body := `{"email":"existing@example.com","display_name":"Duplicate Attempt"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/members", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if createCalled {
+		t.Fatal("expected Create NOT to be called for existing member")
+	}
+
+	var resp response.MemberWithRolesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.ID != existingMemberID.String() {
+		t.Fatalf("expected existing member id %s, got %s", existingMemberID, resp.ID)
+	}
+	if resp.DisplayName == nil || *resp.DisplayName != displayName {
+		t.Fatalf("expected existing display name %q, got %v", displayName, resp.DisplayName)
+	}
+	if len(resp.Roles) != 0 {
+		t.Fatalf("expected no roles on global reuse, got %d", len(resp.Roles))
 	}
 }
 
@@ -592,7 +653,7 @@ func TestMemberHandler_WorkspaceList_FiltersRoles(t *testing.T) {
 		},
 	}
 	ws := &memberMockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tID uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			if tID != tenantID {
 				t.Fatalf("expected tenant id %s, got %s", tenantID, tID)
 			}
@@ -684,7 +745,7 @@ func TestMemberHandler_WorkspaceAddRole_Success(t *testing.T) {
 		},
 	}
 	ws := &memberMockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tID uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			if tID != tenantID {
 				t.Fatalf("expected tenant id %s, got %s", tenantID, tID)
 			}
@@ -737,7 +798,7 @@ func TestMemberHandler_WorkspaceGet_404OutsideScope(t *testing.T) {
 		},
 	}
 	ws := &memberMockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tID uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{ID: workspaceID, TenantID: tenantID, Code: code}, nil
 		},
 	}
@@ -776,7 +837,7 @@ func TestMemberHandler_WorkspaceRemoveRole_RequiresScope(t *testing.T) {
 		},
 	}
 	ws := &memberMockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tID uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{ID: workspaceID, TenantID: tenantID, Code: code}, nil
 		},
 	}

--- a/internal/http/handler/onboarding_test.go
+++ b/internal/http/handler/onboarding_test.go
@@ -163,19 +163,32 @@ func (m *mockWorkspaceStoreOnb) Create(ctx context.Context, ws *domain.Workspace
 	}
 	return nil
 }
+func (m *mockWorkspaceStoreOnb) CreateLogicalPair(ctx context.Context, prod *domain.Workspace, test *domain.Workspace) error {
+	if m.createFn != nil {
+		if err := m.createFn(ctx, prod); err != nil {
+			return err
+		}
+		return m.createFn(ctx, test)
+	}
+	return nil
+}
 func (m *mockWorkspaceStoreOnb) GetByID(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
 	return nil, nil
 }
-func (m *mockWorkspaceStoreOnb) GetByTenantAndCode(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+func (m *mockWorkspaceStoreOnb) GetByTenantAndCode(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 	return nil, nil
 }
-func (m *mockWorkspaceStoreOnb) GetSystemWorkspace(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
+func (m *mockWorkspaceStoreOnb) GetSystemWorkspace(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 	return nil, nil
 }
-func (m *mockWorkspaceStoreOnb) ListByTenant(_ context.Context, _ uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+func (m *mockWorkspaceStoreOnb) ListByTenant(_ context.Context, _ uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 	return nil, "", nil
 }
+func (m *mockWorkspaceStoreOnb) UpdateShared(_ context.Context, _ uuid.UUID, _, _, _ string) error { return nil }
 func (m *mockWorkspaceStoreOnb) Update(_ context.Context, _ *domain.Workspace) error { return nil }
+func (m *mockWorkspaceStoreOnb) SoftDeleteLogical(_ context.Context, _ uuid.UUID, _ string) error {
+	return nil
+}
 func (m *mockWorkspaceStoreOnb) SoftDelete(_ context.Context, _ uuid.UUID) error     { return nil }
 
 type mockAuditStoreOnb struct{}

--- a/internal/http/handler/resolve.go
+++ b/internal/http/handler/resolve.go
@@ -4,6 +4,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/http/middleware"
 	"github.com/rendis/senda/internal/port"
 )
 
@@ -18,12 +19,24 @@ func resolveWorkspace(c *echo.Context, ts port.TenantStore, ws port.WorkspaceSto
 		return nil, err
 	}
 
-	workspace, err := ws.GetByTenantAndCode(ctx, tenant.ID, wsCode)
+	workspace, err := ws.GetByTenantAndCode(ctx, tenant.ID, wsCode, requestEnvironment(c))
 	if err != nil {
 		return nil, err
 	}
 
 	return workspace, nil
+}
+
+func requestEnvironment(c *echo.Context) domain.Environment {
+	if rawEnvironment := c.Param("environment"); rawEnvironment != "" {
+		if environment, err := domain.ParseEnvironment(rawEnvironment); err == nil {
+			return environment
+		}
+	}
+	if environment, ok := c.Get(middleware.ContextKeyEnvironment).(domain.Environment); ok && environment.Valid() {
+		return environment
+	}
+	return domain.EnvironmentProd
 }
 
 // resolveTenant looks up a tenant by :tenant_code path param.

--- a/internal/http/handler/scope_inheritance.go
+++ b/internal/http/handler/scope_inheritance.go
@@ -45,7 +45,7 @@ func resolveSystemWorkspace(ctx context.Context, current *domain.Workspace, wsSt
 		return current, nil
 	}
 
-	systemWorkspace, err := wsStore.GetSystemWorkspace(ctx, current.TenantID)
+	systemWorkspace, err := wsStore.GetSystemWorkspace(ctx, current.TenantID, current.Environment)
 	if err != nil {
 		if apperr.IsNotFound(err) || errors.Is(err, domain.ErrNotFound) {
 			return nil, nil

--- a/internal/http/handler/send.go
+++ b/internal/http/handler/send.go
@@ -70,17 +70,17 @@ func (h *SendHandler) Send(c *echo.Context) error {
 		}
 	}
 
-		svcReq := &service.SendRequest{
-			Ref:             req.Ref,
-			To:              req.To,
-			CC:              req.CC,
-			BCC:             req.BCC,
-			Variables:       req.Variables,
-			Injectors:       req.Injectors,
-			ExternalID:      req.ExternalID,
-			Locale:          req.Locale,
-			AuthWorkspaceID: wsID,
-			Headers:         headers,
+	svcReq := &service.SendRequest{
+		Ref:             req.Ref,
+		To:              req.To,
+		CC:              req.CC,
+		BCC:             req.BCC,
+		Variables:       req.Variables,
+		Injectors:       req.Injectors,
+		ExternalID:      req.ExternalID,
+		Locale:          req.Locale,
+		AuthWorkspaceID: wsID,
+		Headers:         headers,
 		Source: service.SendSource{
 			Type: domain.EmailSourceTypeDataPlaneAPIKey,
 		},
@@ -140,17 +140,17 @@ func (h *SendHandler) SendBatch(c *echo.Context) error {
 	}
 
 	items := make([]service.SendBatchItemRequest, len(req.Items))
-		for i, item := range req.Items {
-			items[i] = service.SendBatchItemRequest{
-				To:         item.To,
-				CC:         item.CC,
-				BCC:        item.BCC,
-				Variables:  item.Variables,
-				Injectors:  item.Injectors,
-				ExternalID: item.ExternalID,
-				Locale:     item.Locale,
-			}
+	for i, item := range req.Items {
+		items[i] = service.SendBatchItemRequest{
+			To:         item.To,
+			CC:         item.CC,
+			BCC:        item.BCC,
+			Variables:  item.Variables,
+			Injectors:  item.Injectors,
+			ExternalID: item.ExternalID,
+			Locale:     item.Locale,
 		}
+	}
 
 	resp, err := h.sendService.SendBatch(c.Request().Context(), &service.SendBatchRequest{
 		Ref:             req.Ref,
@@ -194,6 +194,8 @@ func mapSendError(c *echo.Context, err error) error {
 	case errors.Is(err, domain.ErrSystemWorkspaceBlocked):
 		slog.Warn("send rejected", "reason", "system_workspace_blocked")
 		return response.WriteError(c, http.StatusUnprocessableEntity, "SYSTEM_WORKSPACE_BLOCKED", "system workspace cannot send emails")
+	case errors.Is(err, domain.ErrTestRecipientPolicyUnconfigured):
+		return response.WriteError(c, http.StatusUnprocessableEntity, "TEST_RECIPIENT_POLICY_UNCONFIGURED", "test environment recipient policy is unconfigured")
 	case errors.Is(err, domain.ErrDomainNotVerified):
 		return response.WriteError(c, http.StatusUnprocessableEntity, "DOMAIN_NOT_VERIFIED", "from domain is not verified")
 	case errors.Is(err, domain.ErrSuppressed):

--- a/internal/http/handler/template_test.go
+++ b/internal/http/handler/template_test.go
@@ -407,7 +407,7 @@ func TestTemplateHandler_ListByTemplateType_ResolvesVisibleSystemTemplateInWorks
 	typeID := uuid.Must(uuid.NewV7())
 	templateID := uuid.Must(uuid.NewV7())
 
-	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
 		}
@@ -477,7 +477,7 @@ func TestTemplateHandler_CreateVersion_BlocksInheritedSystemTemplateInWorkspace(
 	systemWorkspace := uuid.Must(uuid.NewV7())
 	templateID := uuid.Must(uuid.NewV7())
 
-	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
 		}
@@ -530,7 +530,7 @@ func TestTemplateHandler_UpdateVersion_BlocksInheritedSystemTemplateInWorkspace(
 	templateID := uuid.Must(uuid.NewV7())
 	versionID := uuid.Must(uuid.NewV7())
 
-	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
 		}
@@ -594,7 +594,7 @@ func TestTemplateHandler_ForkTemplate_Success(t *testing.T) {
 	systemWorkspace := uuid.Must(uuid.NewV7())
 	invalidatedWorkspace := uuid.Nil
 
-	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
 		}

--- a/internal/http/handler/template_type.go
+++ b/internal/http/handler/template_type.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
@@ -108,6 +109,11 @@ func (h *TemplateTypeHandler) create(c *echo.Context, workspace *domain.Workspac
 		}
 	}
 
+	testRecipientMode, testRecipientAddresses, policyFieldErrors := parseTemplateTypeTestRecipientPolicyForCreate(workspace, req)
+	if len(policyFieldErrors) > 0 {
+		return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed", policyFieldErrors...)
+	}
+
 	var workspaceID *uuid.UUID
 	if workspace != nil {
 		workspaceID = &workspace.ID
@@ -119,7 +125,18 @@ func (h *TemplateTypeHandler) create(c *echo.Context, workspace *domain.Workspac
 		}
 	}
 
-	tt, err := h.svc.Create(c.Request().Context(), req.Slug, req.Name, req.Description, adapterID, senderIdentityID, variableSchema, workspaceID)
+	tt, err := h.svc.Create(
+		c.Request().Context(),
+		req.Slug,
+		req.Name,
+		req.Description,
+		adapterID,
+		senderIdentityID,
+		variableSchema,
+		testRecipientMode,
+		testRecipientAddresses,
+		workspaceID,
+	)
 	if err != nil {
 		return mapStoreError(c, err)
 	}
@@ -219,7 +236,7 @@ func (h *TemplateTypeHandler) update(c *echo.Context, workspace *domain.Workspac
 	}
 
 	previousSlug := tt.Slug
-	if field, err := applyTemplateTypeUpdateRequest(tt, req); err != nil {
+	if field, err := applyTemplateTypeUpdateRequest(tt, req, workspace); err != nil {
 		return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "invalid "+field)
 	}
 
@@ -285,7 +302,7 @@ func validateTemplateTypeUpdateRequest(req request.UpdateTemplateTypeRequest) []
 	return fieldErrors
 }
 
-func applyTemplateTypeUpdateRequest(tt *domain.TemplateType, req request.UpdateTemplateTypeRequest) (string, error) {
+func applyTemplateTypeUpdateRequest(tt *domain.TemplateType, req request.UpdateTemplateTypeRequest, workspace *domain.Workspace) (string, error) { //nolint:gocognit // request patching mixes optional field updates with environment-aware validation
 	if req.Slug != nil {
 		tt.Slug = *req.Slug
 	}
@@ -315,7 +332,68 @@ func applyTemplateTypeUpdateRequest(tt *domain.TemplateType, req request.UpdateT
 			tt.SenderIdentityID = senderIdentityID
 		}
 	}
+	if req.TestRecipientMode != nil || req.TestRecipientAddresses != nil {
+		if workspace == nil || workspace.Environment != domain.EnvironmentTest {
+			return "test_recipient_mode", domain.ErrValidation
+		}
+		if req.TestRecipientMode != nil {
+			trimmed := strings.TrimSpace(*req.TestRecipientMode)
+			if trimmed == "" {
+				tt.TestRecipientMode = nil
+			} else {
+				mode := domain.TestRecipientMode(trimmed)
+				if !mode.Valid() {
+					return "test_recipient_mode", domain.ErrValidation
+				}
+				tt.TestRecipientMode = &mode
+			}
+		}
+		if req.TestRecipientAddresses != nil {
+			if len(*req.TestRecipientAddresses) == 0 {
+				tt.TestRecipientAddresses = nil
+				return "", nil
+			}
+			addresses := domain.NormalizeRecipientAddresses(*req.TestRecipientAddresses)
+			if err := domain.ValidateRecipientAddresses(addresses); err != nil {
+				return "test_recipient_addresses", err
+			}
+			tt.TestRecipientAddresses = addresses
+		}
+	}
 	return "", nil
+}
+
+func parseTemplateTypeTestRecipientPolicyForCreate(
+	workspace *domain.Workspace,
+	req request.CreateTemplateTypeRequest,
+) (*domain.TestRecipientMode, []string, []response.FieldError) {
+	if req.TestRecipientMode == nil && len(req.TestRecipientAddresses) == 0 {
+		return nil, nil, nil
+	}
+	if workspace == nil || workspace.Environment != domain.EnvironmentTest {
+		return nil, nil, []response.FieldError{
+			{Field: "test_recipient_mode", Message: "is only supported in the test environment"},
+		}
+	}
+
+	mode := domain.TestRecipientModeReplace
+	if req.TestRecipientMode != nil {
+		mode = domain.TestRecipientMode(strings.TrimSpace(*req.TestRecipientMode))
+		if !mode.Valid() {
+			return nil, nil, []response.FieldError{
+				{Field: "test_recipient_mode", Message: "must be replace or append"},
+			}
+		}
+	}
+
+	addresses := domain.NormalizeRecipientAddresses(req.TestRecipientAddresses)
+	if err := domain.ValidateRecipientAddresses(addresses); err != nil {
+		return nil, nil, []response.FieldError{
+			{Field: "test_recipient_addresses", Message: "must contain valid email addresses"},
+		}
+	}
+
+	return &mode, addresses, nil
 }
 
 func workspaceIDFor(workspace *domain.Workspace) *uuid.UUID {

--- a/internal/http/handler/template_type_test.go
+++ b/internal/http/handler/template_type_test.go
@@ -224,6 +224,10 @@ func setupTemplateTypeTest(store port.TemplateStore, ts port.TenantStore, ws por
 	e.GET("/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code/template-types", h.List)
 	e.GET("/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code/template-types/:slug", h.Get)
 	e.PUT("/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code/template-types/:slug", h.Update)
+	e.POST("/api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code/template-types", h.Create)
+	e.GET("/api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code/template-types", h.List)
+	e.GET("/api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code/template-types/:slug", h.Get)
+	e.PUT("/api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code/template-types/:slug", h.Update)
 
 	// Global routes.
 	e.POST("/api/v1/manage/global/template-types", h.CreateGlobal)
@@ -277,6 +281,66 @@ func TestTemplateTypeHandler_Create_Success(t *testing.T) {
 	}
 	if resp.Slug != "welcome-email" {
 		t.Fatalf("expected slug 'welcome-email' in response, got %q", resp.Slug)
+	}
+}
+
+func TestTemplateTypeHandler_Update_AllowsClearingTestRecipientOverride(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+	ws.Environment = domain.EnvironmentTest
+
+	var updated *domain.TemplateType
+	store := &mockTemplateStore{
+		getTypeBySlugFn: func(_ context.Context, slug string, _ []uuid.NullUUID) (*domain.TemplateType, error) {
+			if slug != "welcome-email" {
+				return nil, domain.ErrNotFound
+			}
+			mode := domain.TestRecipientModeAppend
+			return &domain.TemplateType{
+				ID:                     uuid.Must(uuid.NewV7()),
+				WorkspaceID:            &ws.ID,
+				Slug:                   slug,
+				Name:                   "Welcome Email",
+				TestRecipientMode:      &mode,
+				TestRecipientAddresses: []string{"qa@example.com"},
+				CreatedAt:              time.Now().UTC(),
+				UpdatedAt:              time.Now().UTC(),
+			}, nil
+		},
+		findTypeBySlugInScopeFn: func(_ context.Context, slug string, _ *uuid.UUID) (*domain.TemplateType, error) {
+			if slug == "welcome-email" {
+				return nil, domain.ErrNotFound
+			}
+			return nil, domain.ErrNotFound
+		},
+		updateTypeFn: func(_ context.Context, tt *domain.TemplateType) error {
+			updated = tt
+			return nil
+		},
+	}
+
+	e, _ := setupTemplateTypeTest(store, ts, wsStore)
+
+	body := `{"test_recipient_mode":"","test_recipient_addresses":[]}`
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/api/v1/manage/environments/test/tenants/acme/workspaces/default/template-types/welcome-email",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if updated == nil {
+		t.Fatal("expected template type to be updated")
+	}
+	if updated.TestRecipientMode != nil {
+		t.Fatalf("expected test recipient mode to be cleared, got %v", *updated.TestRecipientMode)
+	}
+	if len(updated.TestRecipientAddresses) != 0 {
+		t.Fatalf("expected test recipient addresses to be cleared, got %v", updated.TestRecipientAddresses)
 	}
 }
 
@@ -527,7 +591,7 @@ func TestTemplateTypeHandler_Get_ResolvesInheritedSystemTypeInWorkspace(t *testi
 	systemWorkspace := uuid.Must(uuid.NewV7())
 	ttID := uuid.Must(uuid.NewV7())
 
-	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
 		}
@@ -738,7 +802,7 @@ func TestTemplateTypeHandler_List_ExcludesGlobalTemplateTypesForWorkspace(t *tes
 	systemWorkspaceID := uuid.Must(uuid.NewV7())
 	now := time.Now().UTC()
 
-	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
 		}

--- a/internal/http/handler/tenant.go
+++ b/internal/http/handler/tenant.go
@@ -66,12 +66,15 @@ func (h *TenantHandler) Create(c *echo.Context) error {
 		return mapStoreError(c, err)
 	}
 
-	// Create the _system workspace for the new tenant.
-	sysWS := &domain.Workspace{
+	// Create the _system logical workspace pair for the new tenant.
+	logicalWorkspaceID := uuid.Must(uuid.NewV7())
+	sysWSProd := &domain.Workspace{
 		ID:                                   uuid.Must(uuid.NewV7()),
+		LogicalWorkspaceID:                   logicalWorkspaceID,
 		TenantID:                             tenant.ID,
 		Code:                                 "_system",
 		Name:                                 "System",
+		Environment:                          domain.EnvironmentProd,
 		IsSystem:                             true,
 		IsActive:                             true,
 		AllowWorkspaceLocalTemplates:         true,
@@ -81,7 +84,23 @@ func (h *TenantHandler) Create(c *echo.Context) error {
 		CreatedAt:                            now,
 		UpdatedAt:                            now,
 	}
-	if err := h.wsStore.Create(ctx, sysWS); err != nil {
+	sysWSTest := &domain.Workspace{
+		ID:                                   uuid.Must(uuid.NewV7()),
+		LogicalWorkspaceID:                   logicalWorkspaceID,
+		TenantID:                             tenant.ID,
+		Code:                                 "_system",
+		Name:                                 "System",
+		Environment:                          domain.EnvironmentTest,
+		IsSystem:                             true,
+		IsActive:                             true,
+		AllowWorkspaceLocalTemplates:         true,
+		AllowWorkspaceInheritedTemplateForks: true,
+		AllowWorkspaceLocalInjectors:         true,
+		WorkspacePoliciesInitialized:         true,
+		CreatedAt:                            now,
+		UpdatedAt:                            now,
+	}
+	if err := h.wsStore.CreateLogicalPair(ctx, sysWSProd, sysWSTest); err != nil {
 		return mapStoreError(c, err)
 	}
 
@@ -203,49 +222,51 @@ const tenantDeleteBlockedReasonTemplate = "Delete disabled: tenant still has act
 // deletion. This is intentionally simple as a short-term safety guard, but it
 // has an N+1 access pattern. If this path becomes hot, replace it with a
 // dedicated store/service query such as "has active SES adapters by tenant".
-func (h *TenantHandler) deleteBlockedReason(ctx context.Context, tenantID uuid.UUID) (string, error) {
+func (h *TenantHandler) deleteBlockedReason(ctx context.Context, tenantID uuid.UUID) (string, error) { //nolint:gocognit // tenant-wide SES guard scans paginated workspaces across both environments
 	if h.adapterStore == nil {
 		return "", nil
 	}
 
-	workspaceCursor := ""
-	for {
-		workspaces, nextCursor, err := h.wsStore.ListByTenant(ctx, tenantID, port.ListOptions{
-			Cursor: workspaceCursor,
-			Limit:  100,
-		})
-		if err != nil {
-			return "", err
-		}
-
-		for _, ws := range workspaces {
-			adapterCursor := ""
-			for {
-				page, err := h.adapterStore.ListByWorkspace(ctx, &ws.ID, port.ListOptions{
-					Cursor: adapterCursor,
-					Limit:  100,
-				})
-				if err != nil {
-					return "", err
-				}
-
-				for _, adapter := range page.Items {
-					if adapter.AdapterType == domain.AdapterTypeSES {
-						return deleteBlockedReasonMessage(adapter.Name, ws.Code), nil
-					}
-				}
-
-				if !page.HasMore || page.NextCursor == "" {
-					break
-				}
-				adapterCursor = page.NextCursor
+	for _, environment := range domain.Environments() {
+		workspaceCursor := ""
+		for {
+			workspaces, nextCursor, err := h.wsStore.ListByTenant(ctx, tenantID, environment, port.ListOptions{
+				Cursor: workspaceCursor,
+				Limit:  100,
+			})
+			if err != nil {
+				return "", err
 			}
-		}
 
-		if nextCursor == "" {
-			break
+			for _, ws := range workspaces {
+				adapterCursor := ""
+				for {
+					page, err := h.adapterStore.ListByWorkspace(ctx, &ws.ID, port.ListOptions{
+						Cursor: adapterCursor,
+						Limit:  100,
+					})
+					if err != nil {
+						return "", err
+					}
+
+					for _, adapter := range page.Items {
+						if adapter.AdapterType == domain.AdapterTypeSES {
+							return deleteBlockedReasonMessage(adapter.Name, ws.Code), nil
+						}
+					}
+
+					if !page.HasMore || page.NextCursor == "" {
+						break
+					}
+					adapterCursor = page.NextCursor
+				}
+			}
+
+			if nextCursor == "" {
+				break
+			}
+			workspaceCursor = nextCursor
 		}
-		workspaceCursor = nextCursor
 	}
 
 	return "", nil

--- a/internal/http/handler/tenant_test.go
+++ b/internal/http/handler/tenant_test.go
@@ -70,9 +70,10 @@ func (m *mockTenantStore) Purge(_ context.Context, _ uuid.UUID) error { return n
 type mockWorkspaceStore struct {
 	createFn             func(ctx context.Context, ws *domain.Workspace) error
 	getByIDFn            func(ctx context.Context, id uuid.UUID) (*domain.Workspace, error)
-	getByTenantAndCodeFn func(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error)
-	getSystemWorkspaceFn func(ctx context.Context, tenantID uuid.UUID) (*domain.Workspace, error)
-	listByTenantFn       func(ctx context.Context, tenantID uuid.UUID, opts port.ListOptions) ([]*domain.Workspace, string, error)
+	getByTenantAndCodeFn func(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error)
+	getSystemWorkspaceFn func(ctx context.Context, tenantID uuid.UUID, environment domain.Environment) (*domain.Workspace, error)
+	listByTenantFn       func(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, opts port.ListOptions) ([]*domain.Workspace, string, error)
+	updateSharedFn       func(ctx context.Context, tenantID uuid.UUID, currentCode, nextCode, nextName string) error
 	updateFn             func(ctx context.Context, ws *domain.Workspace) error
 	softDeleteFn         func(ctx context.Context, id uuid.UUID) error
 }
@@ -83,33 +84,58 @@ func (m *mockWorkspaceStore) Create(ctx context.Context, ws *domain.Workspace) e
 	}
 	return nil
 }
+func (m *mockWorkspaceStore) CreateLogicalPair(ctx context.Context, prod *domain.Workspace, test *domain.Workspace) error {
+	if m.createFn != nil {
+		if err := m.createFn(ctx, prod); err != nil {
+			return err
+		}
+		return m.createFn(ctx, test)
+	}
+	return nil
+}
 func (m *mockWorkspaceStore) GetByID(ctx context.Context, id uuid.UUID) (*domain.Workspace, error) {
 	if m.getByIDFn != nil {
 		return m.getByIDFn(ctx, id)
 	}
 	return nil, nil
 }
-func (m *mockWorkspaceStore) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
+func (m *mockWorkspaceStore) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error) {
 	if m.getByTenantAndCodeFn != nil {
-		return m.getByTenantAndCodeFn(ctx, tenantID, code)
+		return m.getByTenantAndCodeFn(ctx, tenantID, code, environment)
 	}
 	return nil, nil
 }
-func (m *mockWorkspaceStore) GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+func (m *mockWorkspaceStore) GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID, environment domain.Environment) (*domain.Workspace, error) {
 	if m.getSystemWorkspaceFn != nil {
-		return m.getSystemWorkspaceFn(ctx, tenantID)
+		return m.getSystemWorkspaceFn(ctx, tenantID, environment)
 	}
 	return nil, nil
 }
-func (m *mockWorkspaceStore) ListByTenant(ctx context.Context, tenantID uuid.UUID, opts port.ListOptions) ([]*domain.Workspace, string, error) {
+func (m *mockWorkspaceStore) ListByTenant(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, opts port.ListOptions) ([]*domain.Workspace, string, error) {
 	if m.listByTenantFn != nil {
-		return m.listByTenantFn(ctx, tenantID, opts)
+		return m.listByTenantFn(ctx, tenantID, environment, opts)
 	}
 	return nil, "", nil
+}
+func (m *mockWorkspaceStore) UpdateShared(ctx context.Context, tenantID uuid.UUID, currentCode, nextCode, nextName string) error {
+	if m.updateSharedFn != nil {
+		return m.updateSharedFn(ctx, tenantID, currentCode, nextCode, nextName)
+	}
+	return nil
 }
 func (m *mockWorkspaceStore) Update(ctx context.Context, ws *domain.Workspace) error {
 	if m.updateFn != nil {
 		return m.updateFn(ctx, ws)
+	}
+	return nil
+}
+func (m *mockWorkspaceStore) SoftDeleteLogical(ctx context.Context, tenantID uuid.UUID, code string) error {
+	if m.getByTenantAndCodeFn != nil && m.softDeleteFn != nil {
+		ws, err := m.getByTenantAndCodeFn(ctx, tenantID, code, domain.EnvironmentProd)
+		if err != nil {
+			return err
+		}
+		return m.softDeleteFn(ctx, ws.ID)
 	}
 	return nil
 }
@@ -302,7 +328,7 @@ func TestTenantHandler_List_IncludesDeleteBlockedReasonForTenantWithSESAdapter(t
 		},
 	}
 	ws := &mockWorkspaceStore{
-		listByTenantFn: func(_ context.Context, tenantID uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+		listByTenantFn: func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 			if tenantID == tenantWithSES.ID {
 				return []*domain.Workspace{systemWS}, "", nil
 			}
@@ -521,7 +547,7 @@ func TestTenantHandler_SoftDelete_BlocksWhenTenantHasSESAdapter(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		listByTenantFn: func(_ context.Context, tenantID uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+		listByTenantFn: func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 			if tenantID != tenant.ID {
 				t.Fatalf("expected tenant ID %s, got %s", tenant.ID, tenantID)
 			}
@@ -552,5 +578,76 @@ func TestTenantHandler_SoftDelete_BlocksWhenTenantHasSESAdapter(t *testing.T) {
 	}
 	if softDeleteCalled {
 		t.Fatal("expected tenant soft delete to be blocked")
+	}
+}
+
+func TestTenantHandler_SoftDelete_BlocksWhenTenantHasTestEnvironmentSESAdapter(t *testing.T) {
+	now := time.Now().UTC()
+	tenant := &domain.Tenant{ID: uuid.New(), Code: "acme", Name: "Acme Corp", CreatedAt: now, UpdatedAt: now}
+	testSystemWS := &domain.Workspace{
+		ID:          uuid.New(),
+		TenantID:    tenant.ID,
+		Code:        "_system",
+		Name:        "System",
+		IsSystem:    true,
+		Environment: domain.EnvironmentTest,
+	}
+
+	softDeleteCalled := false
+	ts := &mockTenantStore{
+		getByCodeFn: func(_ context.Context, _ string) (*domain.Tenant, error) {
+			return tenant, nil
+		},
+		softDeleteFn: func(_ context.Context, _ uuid.UUID) error {
+			softDeleteCalled = true
+			return nil
+		},
+	}
+
+	var listedEnvironments []domain.Environment
+	ws := &mockWorkspaceStore{
+		listByTenantFn: func(_ context.Context, tenantID uuid.UUID, environment domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+			if tenantID != tenant.ID {
+				t.Fatalf("expected tenant ID %s, got %s", tenant.ID, tenantID)
+			}
+			listedEnvironments = append(listedEnvironments, environment)
+			switch environment {
+			case domain.EnvironmentProd:
+				return nil, "", nil
+			case domain.EnvironmentTest:
+				return []*domain.Workspace{testSystemWS}, "", nil
+			default:
+				t.Fatalf("unexpected environment %s", environment)
+				return nil, "", nil
+			}
+		},
+	}
+	as := &mockAdapterStore{
+		listByWorkspaceFn: func(_ context.Context, workspaceID *uuid.UUID, _ port.ListOptions) (*port.PageResult[domain.Adapter], error) {
+			if workspaceID == nil || *workspaceID != testSystemWS.ID {
+				t.Fatalf("expected workspace ID %s", testSystemWS.ID)
+			}
+			return &port.PageResult[domain.Adapter]{
+				Items: []*domain.Adapter{
+					{ID: uuid.New(), Name: "SES Test", WorkspaceID: workspaceID, AdapterType: domain.AdapterTypeSES},
+				},
+			}, nil
+		},
+	}
+
+	e, _ := setupTenantTest(ts, ws, as)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/manage/tenants/acme", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if softDeleteCalled {
+		t.Fatal("expected tenant soft delete to be blocked by test-environment SES adapter")
+	}
+	if len(listedEnvironments) != 2 {
+		t.Fatalf("expected tenant delete scan to cover both environments, got %v", listedEnvironments)
 	}
 }

--- a/internal/http/handler/tracking_test.go
+++ b/internal/http/handler/tracking_test.go
@@ -31,6 +31,9 @@ func (m *mockTrackingEmailStore) GetByTrackingID(ctx context.Context, trackingID
 	}
 	return nil, domain.ErrNotFound
 }
+func (m *mockTrackingEmailStore) PurgeWorkspaceRuntime(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
 
 // newTrackingEventProcessor builds a real EventProcessor backed by tracking mocks.
 func newTrackingEventProcessor(lookup service.EmailLookup, updater service.EmailStatusUpdater) *service.EventProcessor {

--- a/internal/http/handler/workspace.go
+++ b/internal/http/handler/workspace.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,13 +19,14 @@ import (
 type WorkspaceHandler struct {
 	tenantStore port.TenantStore
 	wsStore     port.WorkspaceStore
+	emailStore  port.EmailStore
 }
 
 const systemWorkspaceProtectedMessage = "system workspace is protected and cannot be modified from workspace management"
 
 // NewWorkspaceHandler creates a new WorkspaceHandler.
-func NewWorkspaceHandler(ts port.TenantStore, ws port.WorkspaceStore) *WorkspaceHandler {
-	return &WorkspaceHandler{tenantStore: ts, wsStore: ws}
+func NewWorkspaceHandler(ts port.TenantStore, ws port.WorkspaceStore, emailStore port.EmailStore) *WorkspaceHandler {
+	return &WorkspaceHandler{tenantStore: ts, wsStore: ws, emailStore: emailStore}
 }
 
 // resolveTenant looks up a tenant by the :tenant_code path param.
@@ -63,22 +65,37 @@ func (h *WorkspaceHandler) Create(c *echo.Context) error {
 	}
 
 	now := time.Now().UTC()
-	ws := &domain.Workspace{
-		ID:            uuid.Must(uuid.NewV7()),
-		TenantID:      tenant.ID,
-		Code:          req.Code,
-		Name:          req.Name,
-		IsActive:      true,
-		DefaultLocale: req.DefaultLocale,
-		CreatedAt:     now,
-		UpdatedAt:     now,
+	logicalWorkspaceID := uuid.Must(uuid.NewV7())
+	prod := &domain.Workspace{
+		ID:                 uuid.Must(uuid.NewV7()),
+		LogicalWorkspaceID: logicalWorkspaceID,
+		TenantID:           tenant.ID,
+		Code:               req.Code,
+		Name:               req.Name,
+		Environment:        domain.EnvironmentProd,
+		IsActive:           true,
+		DefaultLocale:      req.DefaultLocale,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	test := &domain.Workspace{
+		ID:                 uuid.Must(uuid.NewV7()),
+		LogicalWorkspaceID: logicalWorkspaceID,
+		TenantID:           tenant.ID,
+		Code:               req.Code,
+		Name:               req.Name,
+		Environment:        domain.EnvironmentTest,
+		IsActive:           true,
+		DefaultLocale:      req.DefaultLocale,
+		CreatedAt:          now,
+		UpdatedAt:          now,
 	}
 
-	if err := h.wsStore.Create(c.Request().Context(), ws); err != nil {
+	if err := h.wsStore.CreateLogicalPair(c.Request().Context(), prod, test); err != nil {
 		return mapStoreError(c, err)
 	}
 
-	return c.JSON(http.StatusCreated, response.NewWorkspaceResponse(ws))
+	return c.JSON(http.StatusCreated, response.NewWorkspaceResponse(prod))
 }
 
 // List handles GET /api/v1/manage/tenants/:tenant_code/workspaces.
@@ -90,7 +107,7 @@ func (h *WorkspaceHandler) List(c *echo.Context) error {
 
 	opts := pagination.ParseListOptions(c)
 
-	workspaces, nextCursor, err := h.wsStore.ListByTenant(c.Request().Context(), tenant.ID, opts)
+	workspaces, nextCursor, err := h.wsStore.ListByTenant(c.Request().Context(), tenant.ID, requestEnvironment(c), opts)
 	if err != nil {
 		return mapStoreError(c, err)
 	}
@@ -115,7 +132,7 @@ func (h *WorkspaceHandler) Get(c *echo.Context) error {
 	}
 
 	wsCode := c.Param("workspace_code")
-	ws, err := h.wsStore.GetByTenantAndCode(c.Request().Context(), tenant.ID, wsCode)
+	ws, err := h.wsStore.GetByTenantAndCode(c.Request().Context(), tenant.ID, wsCode, requestEnvironment(c))
 	if err != nil {
 		return mapStoreError(c, err)
 	}
@@ -124,7 +141,7 @@ func (h *WorkspaceHandler) Get(c *echo.Context) error {
 }
 
 // Update handles PUT /api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code.
-func (h *WorkspaceHandler) Update(c *echo.Context) error {
+func (h *WorkspaceHandler) Update(c *echo.Context) error { //nolint:gocognit,gocyclo,funlen // shared and environment-scoped workspace updates intentionally share validation/orchestration
 	tenant, err := h.resolveTenant(c)
 	if err != nil {
 		return mapStoreError(c, err)
@@ -132,7 +149,8 @@ func (h *WorkspaceHandler) Update(c *echo.Context) error {
 
 	wsCode := c.Param("workspace_code")
 	ctx := c.Request().Context()
-	ws, err := h.wsStore.GetByTenantAndCode(ctx, tenant.ID, wsCode)
+	environment := requestEnvironment(c)
+	ws, err := h.wsStore.GetByTenantAndCode(ctx, tenant.ID, wsCode, environment)
 	if err != nil {
 		return mapStoreError(c, err)
 	}
@@ -145,6 +163,40 @@ func (h *WorkspaceHandler) Update(c *echo.Context) error {
 		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
 	}
 
+	isEnvironmentScoped := c.Param("environment") != ""
+	if !isEnvironmentScoped {
+		fieldErrors := make([]response.FieldError, 0, 5)
+		if req.IsActive != nil {
+			fieldErrors = append(fieldErrors, response.FieldError{Field: "is_active", Message: "is only supported on environment-scoped workspace routes"})
+		}
+		if req.OpenTrackingEnabled != nil {
+			fieldErrors = append(fieldErrors, response.FieldError{Field: "open_tracking_enabled", Message: "is only supported on environment-scoped workspace routes"})
+		}
+		if req.DefaultLocale != nil {
+			fieldErrors = append(fieldErrors, response.FieldError{Field: "default_locale", Message: "is only supported on environment-scoped workspace routes"})
+		}
+		if req.TestRecipientMode != nil {
+			fieldErrors = append(fieldErrors, response.FieldError{Field: "test_recipient_mode", Message: "is only supported on environment-scoped workspace routes"})
+		}
+		if req.TestRecipientAddresses != nil {
+			fieldErrors = append(fieldErrors, response.FieldError{Field: "test_recipient_addresses", Message: "is only supported on environment-scoped workspace routes"})
+		}
+		if len(fieldErrors) > 0 {
+			return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed", fieldErrors...)
+		}
+	}
+
+	nextCode := ws.Code
+	if req.Code != nil {
+		if err := slug.Validate(*req.Code); err != nil {
+			return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed",
+				response.FieldError{Field: "code", Message: err.Error()},
+			)
+		}
+		nextCode = *req.Code
+	}
+
+	nextName := ws.Name
 	if req.Name != nil {
 		if *req.Name == "" {
 			return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed",
@@ -156,24 +208,75 @@ func (h *WorkspaceHandler) Update(c *echo.Context) error {
 				response.FieldError{Field: "name", Message: "must be at most 255 characters"},
 			)
 		}
-		ws.Name = *req.Name
+		nextName = *req.Name
 	}
+
+	if nextCode != ws.Code || nextName != ws.Name {
+		if err := h.wsStore.UpdateShared(ctx, tenant.ID, ws.Code, nextCode, nextName); err != nil {
+			return mapStoreError(c, err)
+		}
+		ws.Code = nextCode
+		ws.Name = nextName
+	}
+
+	needsEnvironmentUpdate := false
 	if req.IsActive != nil {
 		ws.IsActive = *req.IsActive
+		needsEnvironmentUpdate = true
 	}
 	if req.OpenTrackingEnabled != nil {
 		ws.OpenTrackingEnabled = *req.OpenTrackingEnabled
+		needsEnvironmentUpdate = true
 	}
 	if req.DefaultLocale != nil {
 		ws.DefaultLocale = req.DefaultLocale
+		needsEnvironmentUpdate = true
+	}
+	if req.TestRecipientMode != nil || req.TestRecipientAddresses != nil {
+		if environment != domain.EnvironmentTest {
+			return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed",
+				response.FieldError{Field: "test_recipient_mode", Message: "is only supported in the test environment"},
+			)
+		}
+
+		nextMode := ws.TestRecipientMode
+		if req.TestRecipientMode != nil {
+			nextMode = domain.TestRecipientMode(strings.TrimSpace(*req.TestRecipientMode))
+			if !nextMode.Valid() {
+				return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed",
+					response.FieldError{Field: "test_recipient_mode", Message: "must be replace or append"},
+				)
+			}
+		}
+
+		nextAddresses := append([]string(nil), ws.TestRecipientAddresses...)
+		if req.TestRecipientAddresses != nil {
+			nextAddresses = domain.NormalizeRecipientAddresses(*req.TestRecipientAddresses)
+			if err := domain.ValidateRecipientAddresses(nextAddresses); err != nil {
+				return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed",
+					response.FieldError{Field: "test_recipient_addresses", Message: "must contain valid email addresses"},
+				)
+			}
+		}
+
+		ws.TestRecipientMode = nextMode
+		ws.TestRecipientAddresses = nextAddresses
+		needsEnvironmentUpdate = true
 	}
 
-	ws.UpdatedAt = time.Now().UTC()
-	if err := h.wsStore.Update(ctx, ws); err != nil {
+	if needsEnvironmentUpdate {
+		ws.UpdatedAt = time.Now().UTC()
+		if err := h.wsStore.Update(ctx, ws); err != nil {
+			return mapStoreError(c, err)
+		}
+	}
+
+	refreshed, err := h.wsStore.GetByTenantAndCode(ctx, tenant.ID, ws.Code, environment)
+	if err != nil {
 		return mapStoreError(c, err)
 	}
 
-	return c.JSON(http.StatusOK, response.NewWorkspaceResponse(ws))
+	return c.JSON(http.StatusOK, response.NewWorkspaceResponse(refreshed))
 }
 
 // SoftDelete handles DELETE /api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code.
@@ -185,7 +288,7 @@ func (h *WorkspaceHandler) SoftDelete(c *echo.Context) error {
 
 	wsCode := c.Param("workspace_code")
 	ctx := c.Request().Context()
-	ws, err := h.wsStore.GetByTenantAndCode(ctx, tenant.ID, wsCode)
+	ws, err := h.wsStore.GetByTenantAndCode(ctx, tenant.ID, wsCode, requestEnvironment(c))
 	if err != nil {
 		return mapStoreError(c, err)
 	}
@@ -193,7 +296,32 @@ func (h *WorkspaceHandler) SoftDelete(c *echo.Context) error {
 		return response.WriteError(c, http.StatusConflict, "SYSTEM_WORKSPACE_PROTECTED", systemWorkspaceProtectedMessage)
 	}
 
-	if err := h.wsStore.SoftDelete(ctx, ws.ID); err != nil {
+	if err := h.wsStore.SoftDeleteLogical(ctx, tenant.ID, ws.Code); err != nil {
+		return mapStoreError(c, err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// ResetRuntime handles POST /api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code/runtime/reset.
+func (h *WorkspaceHandler) ResetRuntime(c *echo.Context) error {
+	if requestEnvironment(c) != domain.EnvironmentTest {
+		return response.WriteError(c, http.StatusConflict, "TEST_ENVIRONMENT_REQUIRED", "runtime reset is only available for the test environment")
+	}
+
+	tenant, err := h.resolveTenant(c)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+
+	wsCode := c.Param("workspace_code")
+	ctx := c.Request().Context()
+	ws, err := h.wsStore.GetByTenantAndCode(ctx, tenant.ID, wsCode, domain.EnvironmentTest)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+
+	if err := h.emailStore.PurgeWorkspaceRuntime(ctx, ws.ID); err != nil {
 		return mapStoreError(c, err)
 	}
 

--- a/internal/http/handler/workspace_policy_test.go
+++ b/internal/http/handler/workspace_policy_test.go
@@ -39,7 +39,7 @@ func TestWorkspacePolicyHandler_Get_SystemWorkspaceSuccess(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			if tid != tenantID {
 				t.Fatalf("expected tenant id %s, got %s", tenantID, tid)
 			}
@@ -99,7 +99,7 @@ func TestWorkspacePolicyHandler_Get_WorkspaceReturnsSystemPolicies(t *testing.T)
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			if tid != tenantID {
 				t.Fatalf("expected tenant id %s, got %s", tenantID, tid)
 			}
@@ -116,7 +116,7 @@ func TestWorkspacePolicyHandler_Get_WorkspaceReturnsSystemPolicies(t *testing.T)
 				UpdatedAt: now,
 			}, nil
 		},
-		getSystemWorkspaceFn: func(_ context.Context, tid uuid.UUID) (*domain.Workspace, error) {
+		getSystemWorkspaceFn: func(_ context.Context, tid uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 			if tid != tenantID {
 				t.Fatalf("expected tenant id %s, got %s", tenantID, tid)
 			}
@@ -187,7 +187,7 @@ func TestWorkspacePolicyHandler_Update_SystemWorkspaceSuccess(t *testing.T) {
 
 	var updated *domain.Workspace
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			if tid != tenantID || code != "_system" {
 				t.Fatalf("unexpected lookup %s %q", tid, code)
 			}
@@ -237,7 +237,7 @@ func TestWorkspacePolicyHandler_Update_RejectsNonSystemWorkspace(t *testing.T) {
 
 	var updateCalled bool
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{
 				ID:        uuid.New(),
 				TenantID:  tid,

--- a/internal/http/handler/workspace_test.go
+++ b/internal/http/handler/workspace_test.go
@@ -18,18 +18,21 @@ import (
 	"github.com/rendis/senda/internal/port"
 )
 
-func setupWorkspaceTest(ts port.TenantStore, ws port.WorkspaceStore) *echo.Echo {
+func setupWorkspaceTest(ts port.TenantStore, ws port.WorkspaceStore, emails port.EmailStore) *echo.Echo {
 	e := echo.New()
 	e.HTTPErrorHandler = response.HTTPErrorHandler
 	e.Use(middleware.RequestID())
 	e.Use(middleware.Scope())
 
-	h := handler.NewWorkspaceHandler(ts, ws)
+	h := handler.NewWorkspaceHandler(ts, ws, emails)
 	e.POST("/api/v1/manage/tenants/:tenant_code/workspaces", h.Create)
 	e.GET("/api/v1/manage/tenants/:tenant_code/workspaces", h.List)
 	e.GET("/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code", h.Get)
 	e.PUT("/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code", h.Update)
+	e.GET("/api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code", h.Get)
+	e.PUT("/api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code", h.Update)
 	e.DELETE("/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code", h.SoftDelete)
+	e.POST("/api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code/runtime/reset", h.ResetRuntime)
 	return e
 }
 
@@ -49,7 +52,7 @@ func TestWorkspaceHandler_Create_Success(t *testing.T) {
 		},
 	}
 
-	e := setupWorkspaceTest(ts, ws)
+	e := setupWorkspaceTest(ts, ws, &mockEmailStore{})
 
 	body := `{"code":"main","name":"Main Workspace"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces", strings.NewReader(body))
@@ -92,7 +95,7 @@ func TestWorkspaceHandler_Create_InvalidSlug(t *testing.T) {
 		},
 	}
 
-	e := setupWorkspaceTest(ts, &mockWorkspaceStore{})
+	e := setupWorkspaceTest(ts, &mockWorkspaceStore{}, &mockEmailStore{})
 
 	body := `{"code":"AB","name":"Bad Slug"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces", strings.NewReader(body))
@@ -112,7 +115,7 @@ func TestWorkspaceHandler_Create_TenantNotFound(t *testing.T) {
 		},
 	}
 
-	e := setupWorkspaceTest(ts, &mockWorkspaceStore{})
+	e := setupWorkspaceTest(ts, &mockWorkspaceStore{}, &mockEmailStore{})
 
 	body := `{"code":"main","name":"Main"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/nonexistent/workspaces", strings.NewReader(body))
@@ -139,7 +142,7 @@ func TestWorkspaceHandler_List_Success(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		listByTenantFn: func(_ context.Context, tid uuid.UUID, opts port.ListOptions) ([]*domain.Workspace, string, error) {
+		listByTenantFn: func(_ context.Context, tid uuid.UUID, _ domain.Environment, opts port.ListOptions) ([]*domain.Workspace, string, error) {
 			if tid != tenantID {
 				t.Fatalf("expected tenant ID %s, got %s", tenantID, tid)
 			}
@@ -147,7 +150,7 @@ func TestWorkspaceHandler_List_Success(t *testing.T) {
 		},
 	}
 
-	e := setupWorkspaceTest(ts, ws)
+	e := setupWorkspaceTest(ts, ws, &mockEmailStore{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/manage/tenants/acme/workspaces", nil)
 	rec := httptest.NewRecorder()
@@ -186,7 +189,7 @@ func TestWorkspaceHandler_Get_Success(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{
 				ID: wsID, TenantID: tid, Code: code, Name: "Main", IsActive: true,
 				CreatedAt: now, UpdatedAt: now,
@@ -194,7 +197,7 @@ func TestWorkspaceHandler_Get_Success(t *testing.T) {
 		},
 	}
 
-	e := setupWorkspaceTest(ts, ws)
+	e := setupWorkspaceTest(ts, ws, &mockEmailStore{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/manage/tenants/acme/workspaces/main", nil)
 	rec := httptest.NewRecorder()
@@ -216,35 +219,44 @@ func TestWorkspaceHandler_Get_Success(t *testing.T) {
 	}
 }
 
-func TestWorkspaceHandler_Update_Success(t *testing.T) {
+func TestWorkspaceHandler_Update_SharedFieldsSuccess(t *testing.T) {
 	tenantID := uuid.New()
 	wsID := uuid.New()
 	now := time.Now().UTC()
 
+	var sharedTenantID uuid.UUID
+	var sharedCurrentCode string
+	var sharedNextCode string
 	var updatedName string
-	var updatedActive bool
+	var updateCalled bool
 	ts := &mockTenantStore{
 		getByCodeFn: func(_ context.Context, _ string) (*domain.Tenant, error) {
 			return &domain.Tenant{ID: tenantID, Code: "acme"}, nil
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{
 				ID: wsID, TenantID: tenantID, Code: "main", Name: "Main", IsActive: true,
 				CreatedAt: now, UpdatedAt: now,
 			}, nil
 		},
+		updateSharedFn: func(_ context.Context, tenantID uuid.UUID, currentCode, nextCode, nextName string) error {
+			sharedTenantID = tenantID
+			sharedCurrentCode = currentCode
+			sharedNextCode = nextCode
+			updatedName = nextName
+			return nil
+		},
 		updateFn: func(_ context.Context, w *domain.Workspace) error {
-			updatedName = w.Name
-			updatedActive = w.IsActive
+			updateCalled = true
 			return nil
 		},
 	}
 
-	e := setupWorkspaceTest(ts, ws)
+	e := setupWorkspaceTest(ts, ws, &mockEmailStore{})
 
-	body := `{"name":"Production","is_active":false}`
+	body := `{"name":"Production","code":"prod-main"}`
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/main", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -253,11 +265,135 @@ func TestWorkspaceHandler_Update_Success(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if updatedName != "Production" {
-		t.Fatalf("expected updated name 'Production', got %q", updatedName)
+	if sharedTenantID != tenantID {
+		t.Fatalf("expected shared update tenant %s, got %s", tenantID, sharedTenantID)
 	}
-	if updatedActive {
-		t.Fatal("expected workspace to be disabled")
+	if sharedCurrentCode != "main" || sharedNextCode != "prod-main" {
+		t.Fatalf("expected shared code update main -> prod-main, got %q -> %q", sharedCurrentCode, sharedNextCode)
+	}
+	if updatedName != "Production" {
+		t.Fatalf("expected shared updated name 'Production', got %q", updatedName)
+	}
+	if updateCalled {
+		t.Fatal("expected shared-only update to skip environment row mutation")
+	}
+}
+
+func TestWorkspaceHandler_Update_SharedRouteRejectsEnvironmentFields(t *testing.T) {
+	tenantID := uuid.New()
+	wsID := uuid.New()
+	now := time.Now().UTC()
+	defaultLocale := "en"
+
+	var sharedUpdateCalled bool
+	var environmentUpdateCalled bool
+	ts := &mockTenantStore{
+		getByCodeFn: func(_ context.Context, _ string) (*domain.Tenant, error) {
+			return &domain.Tenant{ID: tenantID, Code: "acme"}, nil
+		},
+	}
+	ws := &mockWorkspaceStore{
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
+			return &domain.Workspace{
+				ID:                  wsID,
+				TenantID:            tenantID,
+				Code:                "main",
+				Name:                "Main",
+				IsActive:            true,
+				OpenTrackingEnabled: true,
+				DefaultLocale:       &defaultLocale,
+				CreatedAt:           now,
+				UpdatedAt:           now,
+			}, nil
+		},
+		updateSharedFn: func(_ context.Context, _ uuid.UUID, _, _, _ string) error {
+			sharedUpdateCalled = true
+			return nil
+		},
+		updateFn: func(_ context.Context, _ *domain.Workspace) error {
+			environmentUpdateCalled = true
+			return nil
+		},
+	}
+
+	e := setupWorkspaceTest(ts, ws, &mockEmailStore{})
+
+	body := `{"is_active":false,"open_tracking_enabled":false,"default_locale":"es"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/main", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if sharedUpdateCalled {
+		t.Fatal("expected shared route to reject environment fields before shared update")
+	}
+	if environmentUpdateCalled {
+		t.Fatal("expected shared route to reject environment fields before environment update")
+	}
+}
+
+func TestWorkspaceHandler_Update_EnvironmentRouteAllowsEnvironmentFields(t *testing.T) {
+	tenantID := uuid.New()
+	wsID := uuid.New()
+	now := time.Now().UTC()
+	defaultLocale := "en"
+
+	var updatedWorkspace *domain.Workspace
+	ts := &mockTenantStore{
+		getByCodeFn: func(_ context.Context, _ string) (*domain.Tenant, error) {
+			return &domain.Tenant{ID: tenantID, Code: "acme"}, nil
+		},
+	}
+	ws := &mockWorkspaceStore{
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, environment domain.Environment) (*domain.Workspace, error) {
+			if environment != domain.EnvironmentTest {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Workspace{
+				ID:                  wsID,
+				TenantID:            tenantID,
+				Code:                "main",
+				Name:                "Main",
+				Environment:         domain.EnvironmentTest,
+				IsActive:            true,
+				OpenTrackingEnabled: true,
+				DefaultLocale:       &defaultLocale,
+				CreatedAt:           now,
+				UpdatedAt:           now,
+			}, nil
+		},
+		updateFn: func(_ context.Context, w *domain.Workspace) error {
+			copy := *w
+			updatedWorkspace = &copy
+			return nil
+		},
+	}
+
+	e := setupWorkspaceTest(ts, ws, &mockEmailStore{})
+
+	body := `{"is_active":false,"open_tracking_enabled":false,"default_locale":"es"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/environments/test/tenants/acme/workspaces/main", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if updatedWorkspace == nil {
+		t.Fatal("expected environment route to persist workspace row changes")
+	}
+	if updatedWorkspace.IsActive {
+		t.Fatal("expected environment route to disable workspace")
+	}
+	if updatedWorkspace.OpenTrackingEnabled {
+		t.Fatal("expected environment route to disable open tracking")
+	}
+	if updatedWorkspace.DefaultLocale == nil || *updatedWorkspace.DefaultLocale != "es" {
+		t.Fatalf("expected default locale es, got %v", updatedWorkspace.DefaultLocale)
 	}
 }
 
@@ -272,7 +408,7 @@ func TestWorkspaceHandler_Update_SystemWorkspaceBlocked(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{
 				ID: uuid.New(), TenantID: tenantID, Code: "_system", Name: "System", IsSystem: true, IsActive: true,
 				CreatedAt: now, UpdatedAt: now,
@@ -284,7 +420,7 @@ func TestWorkspaceHandler_Update_SystemWorkspaceBlocked(t *testing.T) {
 		},
 	}
 
-	e := setupWorkspaceTest(ts, ws)
+	e := setupWorkspaceTest(ts, ws, &mockEmailStore{})
 
 	body := `{"name":"Renamed System","is_active":false}`
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/_system", strings.NewReader(body))
@@ -312,7 +448,7 @@ func TestWorkspaceHandler_SoftDelete_Success(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{
 				ID: wsID, TenantID: tenantID, Code: "staging", Name: "Staging",
 				CreatedAt: now, UpdatedAt: now,
@@ -324,7 +460,7 @@ func TestWorkspaceHandler_SoftDelete_Success(t *testing.T) {
 		},
 	}
 
-	e := setupWorkspaceTest(ts, ws)
+	e := setupWorkspaceTest(ts, ws, &mockEmailStore{})
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/manage/tenants/acme/workspaces/staging", nil)
 	rec := httptest.NewRecorder()
@@ -349,7 +485,7 @@ func TestWorkspaceHandler_SoftDelete_SystemWorkspaceBlocked(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{
 				ID: uuid.New(), TenantID: tenantID, Code: "_system", Name: "System", IsSystem: true, IsActive: true,
 				CreatedAt: now, UpdatedAt: now,
@@ -361,7 +497,7 @@ func TestWorkspaceHandler_SoftDelete_SystemWorkspaceBlocked(t *testing.T) {
 		},
 	}
 
-	e := setupWorkspaceTest(ts, ws)
+	e := setupWorkspaceTest(ts, ws, &mockEmailStore{})
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/manage/tenants/acme/workspaces/_system", nil)
 	rec := httptest.NewRecorder()
@@ -372,5 +508,83 @@ func TestWorkspaceHandler_SoftDelete_SystemWorkspaceBlocked(t *testing.T) {
 	}
 	if softDeleteCalled {
 		t.Fatal("expected protected system workspace to skip delete")
+	}
+}
+
+func TestWorkspaceHandler_ResetRuntime_TestEnvironment_Success(t *testing.T) {
+	tenantID := uuid.New()
+	wsID := uuid.New()
+	now := time.Now().UTC()
+
+	var purgedWorkspaceID uuid.UUID
+	ts := &mockTenantStore{
+		getByCodeFn: func(_ context.Context, _ string) (*domain.Tenant, error) {
+			return &domain.Tenant{ID: tenantID, Code: "acme"}, nil
+		},
+	}
+	ws := &mockWorkspaceStore{
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error) {
+			if code != "staging" || environment != domain.EnvironmentTest {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Workspace{
+				ID:          wsID,
+				TenantID:    tenantID,
+				Code:        "staging",
+				Name:        "Staging",
+				Environment: domain.EnvironmentTest,
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			}, nil
+		},
+	}
+	emails := &mockEmailStore{
+		purgeWorkspaceFn: func(_ context.Context, workspaceID uuid.UUID) error {
+			purgedWorkspaceID = workspaceID
+			return nil
+		},
+	}
+
+	e := setupWorkspaceTest(ts, ws, emails)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/environments/test/tenants/acme/workspaces/staging/runtime/reset", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if purgedWorkspaceID != wsID {
+		t.Fatalf("expected purge for workspace %s, got %s", wsID, purgedWorkspaceID)
+	}
+}
+
+func TestWorkspaceHandler_ResetRuntime_ProdBlocked(t *testing.T) {
+	tenantID := uuid.New()
+	var purgeCalled bool
+
+	ts := &mockTenantStore{
+		getByCodeFn: func(_ context.Context, _ string) (*domain.Tenant, error) {
+			return &domain.Tenant{ID: tenantID, Code: "acme"}, nil
+		},
+	}
+	emails := &mockEmailStore{
+		purgeWorkspaceFn: func(_ context.Context, _ uuid.UUID) error {
+			purgeCalled = true
+			return nil
+		},
+	}
+
+	e := setupWorkspaceTest(ts, &mockWorkspaceStore{}, emails)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/environments/prod/tenants/acme/workspaces/staging/runtime/reset", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if purgeCalled {
+		t.Fatal("expected prod runtime reset to skip purge")
 	}
 }

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/labstack/echo/v5"
+	"github.com/rendis/senda/internal/domain"
 	"github.com/rendis/senda/internal/http/response"
 	"github.com/rendis/senda/internal/port"
 	"github.com/rendis/senda/internal/service"
@@ -24,8 +25,8 @@ const (
 
 	// ContextKeyWorkspaceID holds the uuid.UUID of the workspace (API key path only).
 	ContextKeyWorkspaceID = "workspace_id"
-
-	apiKeyPrefix = "senda_live_"
+	// ContextKeyEnvironment holds the normalized request environment when present.
+	ContextKeyEnvironment = "environment"
 )
 
 // Auth returns middleware that authenticates requests via API key or OIDC bearer token.
@@ -49,8 +50,8 @@ func Auth(apiKeyStore port.APIKeyStore, memberStore port.MemberStore, oidcVerifi
 
 			ctx := c.Request().Context()
 
-			if strings.HasPrefix(token, apiKeyPrefix) {
-				return authenticateAPIKey(c, ctx, token, apiKeyStore, pepper, next)
+			if environment, ok := apiKeyEnvironment(token); ok {
+				return authenticateAPIKey(c, ctx, token, environment, apiKeyStore, pepper, next)
 			}
 
 			return authenticateOIDC(c, ctx, token, oidcVerifier, memberStore, next)
@@ -58,7 +59,7 @@ func Auth(apiKeyStore port.APIKeyStore, memberStore port.MemberStore, oidcVerifi
 	}
 }
 
-func authenticateAPIKey(c *echo.Context, ctx context.Context, token string, store port.APIKeyStore, pepper string, next echo.HandlerFunc) error {
+func authenticateAPIKey(c *echo.Context, ctx context.Context, token string, environment domain.Environment, store port.APIKeyStore, pepper string, next echo.HandlerFunc) error {
 	// Try HMAC-SHA256 hash first (new keys).
 	hash := service.HashKeyHMAC(token, pepper)
 	key, err := store.GetByHash(ctx, hash)
@@ -86,8 +87,18 @@ func authenticateAPIKey(c *echo.Context, ctx context.Context, token string, stor
 
 	c.Set(ContextKeyAuthType, "apikey")
 	c.Set(ContextKeyWorkspaceID, key.WorkspaceID)
+	c.Set(ContextKeyEnvironment, environment)
 
 	return next(c)
+}
+
+func apiKeyEnvironment(token string) (domain.Environment, bool) {
+	for _, environment := range domain.Environments() {
+		if strings.HasPrefix(token, environment.APIKeyTokenPrefix()) {
+			return environment, true
+		}
+	}
+	return "", false
 }
 
 func authenticateOIDC(c *echo.Context, ctx context.Context, token string, verifier port.OIDCVerifier, memberStore port.MemberStore, next echo.HandlerFunc) error {

--- a/internal/http/middleware/auth_test.go
+++ b/internal/http/middleware/auth_test.go
@@ -145,18 +145,19 @@ func TestAuth_ValidAPIKey(t *testing.T) {
 		},
 	}
 
-	var gotAuthType, gotWSID any
+	var gotAuthType, gotWSID, gotEnvironment any
 
 	e := echo.New()
 	e.Use(middleware.Auth(store, &mockMemberStore{}, &mockOIDCVerifier{}, "test-pepper"))
 	e.GET("/test", func(c *echo.Context) error {
 		gotAuthType = c.Get(middleware.ContextKeyAuthType)
 		gotWSID = c.Get(middleware.ContextKeyWorkspaceID)
+		gotEnvironment = c.Get(middleware.ContextKeyEnvironment)
 		return c.String(http.StatusOK, "ok")
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer senda_live_abc123xyz")
+	req.Header.Set("Authorization", "Bearer senda_prod_abc123xyz")
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
@@ -168,6 +169,9 @@ func TestAuth_ValidAPIKey(t *testing.T) {
 	}
 	if gotWSID != wsID {
 		t.Fatalf("expected workspace_id=%s, got %v", wsID, gotWSID)
+	}
+	if gotEnvironment != domain.EnvironmentProd {
+		t.Fatalf("expected environment=%q, got %v", domain.EnvironmentProd, gotEnvironment)
 	}
 }
 
@@ -189,7 +193,7 @@ func TestAuth_RevokedAPIKey(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer senda_live_abc123xyz")
+	req.Header.Set("Authorization", "Bearer senda_prod_abc123xyz")
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
@@ -212,7 +216,7 @@ func TestAuth_UnknownAPIKey(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer senda_live_unknownkey")
+	req.Header.Set("Authorization", "Bearer senda_prod_unknownkey")
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
@@ -343,7 +347,7 @@ func TestAuth_OIDCEmailNotRegistered(t *testing.T) {
 }
 
 func TestAuth_APIKeyPrefixDetection(t *testing.T) {
-	// Token without "senda_live_" prefix should go through OIDC path, not API key path.
+	// Token without a supported senda_<environment>_ prefix should go through OIDC path, not API key path.
 	verifier := &mockOIDCVerifier{
 		verifyFn: func(_ context.Context, _ string) (*port.OIDCClaims, error) {
 			return nil, errors.New("invalid token")

--- a/internal/http/middleware/external_integration.go
+++ b/internal/http/middleware/external_integration.go
@@ -34,6 +34,8 @@ const (
 	// ContextKeyExternalIntegrationAllowedHeaders stores the explicit profile-allowed
 	// headers captured from the incoming request for downstream use.
 	ContextKeyExternalIntegrationAllowedHeaders = "external_integration_allowed_headers"
+
+	ExternalIntegrationEnvironmentHeader = "X-Senda-Environment"
 )
 
 // ExternalAction identifies the capability required by a given external route.
@@ -69,6 +71,9 @@ func ExternalIntegration(h ExternalIntegrationResolverStore) echo.MiddlewareFunc
 		return func(c *echo.Context) error {
 			profile, err := loadExternalProfileForRequest(c, h)
 			if err != nil || responseCommitted(c) {
+				return err
+			}
+			if err := validateExternalEnvironment(c); err != nil || responseCommitted(c) {
 				return err
 			}
 			if err := validateExternalRequiredHeaders(c, profile); err != nil || responseCommitted(c) {
@@ -136,8 +141,10 @@ func resolveExternalDependencies(c *echo.Context, h ExternalIntegrationResolverS
 }
 
 func newExternalIntegrationRequest(c *echo.Context, profile domain.ExternalIntegrationProfile) *port.ExternalIntegrationRequest {
+	environment, _ := domain.ParseEnvironment(c.Request().Header.Get(ExternalIntegrationEnvironmentHeader))
 	reqCtx := &port.ExternalIntegrationRequest{
 		ProfileSlug: profile.Slug,
+		Environment: environment,
 		TenantCode:  c.Param("tenant_code"),
 		Token:       externalIntegrationToken(c),
 		Headers:     collectAllowedHeaders(c.Request().Header, profile.AllowedHeaders),
@@ -202,10 +209,22 @@ func applyExternalIntegrationContext(c *echo.Context, profile domain.ExternalInt
 	c.Set(ContextKeyExternalIntegrationReadOnly, readOnly)
 	c.Set(ContextKeyExternalIntegrationEffectiveWorkspaceCode, effectiveWorkspaceCode)
 	c.Set(ContextKeyExternalIntegrationAllowedHeaders, cloneStringMap(reqCtx.Headers))
+	c.Set(ContextKeyEnvironment, reqCtx.Environment)
 	c.Set(ContextKeyTenantCode, reqCtx.TenantCode)
 	c.Set(ContextKeyWorkspaceCode, effectiveWorkspaceCode)
 
 	patchExternalWorkspaceParam(c, effectiveWorkspaceCode)
+}
+
+func validateExternalEnvironment(c *echo.Context) error {
+	environmentHeader := c.Request().Header.Get(ExternalIntegrationEnvironmentHeader)
+	if strings.TrimSpace(environmentHeader) == "" {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "missing required header X-Senda-Environment")
+	}
+	if _, err := domain.ParseEnvironment(environmentHeader); err != nil {
+		return response.WriteError(c, http.StatusBadRequest, "BAD_REQUEST", "invalid X-Senda-Environment header")
+	}
+	return nil
 }
 
 func mapExternalProfileLoadError(c *echo.Context, err error) error {

--- a/internal/http/middleware/rbac.go
+++ b/internal/http/middleware/rbac.go
@@ -14,7 +14,7 @@ import (
 // API key authentication bypasses RBAC (API keys are workspace-scoped, data-plane only).
 // OIDC authentication checks the member's roles against the required minimum role
 // within the resolved tenant/workspace scope.
-func RequireRole(minRole domain.Role, tenantStore port.TenantStore, wsStore port.WorkspaceStore) echo.MiddlewareFunc {
+func RequireRole(minRole domain.Role, tenantStore port.TenantStore, wsStore port.WorkspaceStore) echo.MiddlewareFunc { //nolint:gocognit // auth type, tenant, and workspace scope resolution branch by design
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			authType, _ := c.Get(ContextKeyAuthType).(string)
@@ -49,7 +49,11 @@ func RequireRole(minRole domain.Role, tenantStore port.TenantStore, wsStore port
 			// Resolve workspace ID from workspace_code if present.
 			var workspaceID *uuid.UUID
 			if wc, _ := c.Get(ContextKeyWorkspaceCode).(string); wc != "" && tenantID != nil {
-				ws, err := wsStore.GetByTenantAndCode(ctx, *tenantID, wc)
+				environment, _ := c.Get(ContextKeyEnvironment).(domain.Environment)
+				if !environment.Valid() {
+					environment = domain.EnvironmentProd
+				}
+				ws, err := wsStore.GetByTenantAndCode(ctx, *tenantID, wc, environment)
 				if err != nil {
 					return response.WriteError(c, http.StatusForbidden, "FORBIDDEN", "invalid workspace")
 				}

--- a/internal/http/middleware/rbac_test.go
+++ b/internal/http/middleware/rbac_test.go
@@ -34,23 +34,30 @@ func (m *mockTenantStore) SoftDelete(_ context.Context, _ uuid.UUID) error     {
 func (m *mockTenantStore) Purge(_ context.Context, _ uuid.UUID) error          { return nil }
 
 type mockWorkspaceStore struct {
-	getByTenantAndCodeFn func(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error)
+	getByTenantAndCodeFn func(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error)
 }
 
 func (m *mockWorkspaceStore) Create(_ context.Context, _ *domain.Workspace) error { return nil }
+func (m *mockWorkspaceStore) CreateLogicalPair(_ context.Context, _ *domain.Workspace, _ *domain.Workspace) error {
+	return nil
+}
 func (m *mockWorkspaceStore) GetByID(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
 	return nil, nil
 }
-func (m *mockWorkspaceStore) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
-	return m.getByTenantAndCodeFn(ctx, tenantID, code)
+func (m *mockWorkspaceStore) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error) {
+	return m.getByTenantAndCodeFn(ctx, tenantID, code, environment)
 }
-func (m *mockWorkspaceStore) GetSystemWorkspace(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
+func (m *mockWorkspaceStore) GetSystemWorkspace(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 	return nil, nil
 }
-func (m *mockWorkspaceStore) ListByTenant(_ context.Context, _ uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+func (m *mockWorkspaceStore) ListByTenant(_ context.Context, _ uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 	return nil, "", nil
 }
+func (m *mockWorkspaceStore) UpdateShared(_ context.Context, _ uuid.UUID, _, _, _ string) error { return nil }
 func (m *mockWorkspaceStore) Update(_ context.Context, _ *domain.Workspace) error { return nil }
+func (m *mockWorkspaceStore) SoftDeleteLogical(_ context.Context, _ uuid.UUID, _ string) error {
+	return nil
+}
 func (m *mockWorkspaceStore) SoftDelete(_ context.Context, _ uuid.UUID) error     { return nil }
 
 // --- Helper: build Echo with pre-set context values ---
@@ -127,7 +134,7 @@ func TestRequireRole_SuperadminAccessAnything(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{ID: wsID, TenantID: tenantID, Code: "main"}, nil
 		},
 	}
@@ -158,7 +165,7 @@ func TestRequireRole_SuperadminWrongScopeType(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{ID: wsID, TenantID: tenantID, Code: "main"}, nil
 		},
 	}
@@ -172,7 +179,7 @@ func TestRequireRole_SuperadminWrongScopeType(t *testing.T) {
 	// But it should NOT bypass into a different workspace
 	otherWsID := uuid.New()
 	wsOther := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{ID: otherWsID, TenantID: tenantID, Code: "other"}, nil
 		},
 	}
@@ -250,7 +257,7 @@ func TestRequireRole_WorkspaceAdminOwnWorkspace(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{ID: wsID, TenantID: tenantID, Code: "main"}, nil
 		},
 	}
@@ -280,7 +287,7 @@ func TestRequireRole_ViewerCannotAccessEditorEndpoint(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{ID: wsID, TenantID: tenantID, Code: "main"}, nil
 		},
 	}
@@ -311,7 +318,7 @@ func TestRequireRole_NoMatchingRoleForScope(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{ID: requestedWsID, TenantID: tenantID, Code: "other"}, nil
 		},
 	}
@@ -349,7 +356,7 @@ func TestRequireRole_TenantAdminAccessWorkspaceInOwnTenant(t *testing.T) {
 		},
 	}
 	ws := &mockWorkspaceStore{
-		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, _ string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tid uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{ID: wsID, TenantID: tid, Code: "main"}, nil
 		},
 	}

--- a/internal/http/middleware/scope.go
+++ b/internal/http/middleware/scope.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"github.com/labstack/echo/v5"
+	"github.com/rendis/senda/internal/domain"
 )
 
 const (
@@ -23,6 +24,11 @@ func Scope() echo.MiddlewareFunc {
 			}
 			if wc := c.Param("workspace_code"); wc != "" {
 				c.Set(ContextKeyWorkspaceCode, wc)
+			}
+			if rawEnvironment := c.Param("environment"); rawEnvironment != "" {
+				if environment, err := domain.ParseEnvironment(rawEnvironment); err == nil {
+					c.Set(ContextKeyEnvironment, environment)
+				}
 			}
 
 			return next(c)

--- a/internal/http/request/template.go
+++ b/internal/http/request/template.go
@@ -12,6 +12,8 @@ type CreateTemplateTypeRequest struct {
 	AdapterID        *string         `json:"adapter_id,omitempty"`
 	SenderIdentityID *string         `json:"sender_identity_id,omitempty"`
 	VariableSchema   json.RawMessage `json:"variable_schema,omitempty"`
+	TestRecipientMode      *string   `json:"test_recipient_mode,omitempty"`
+	TestRecipientAddresses []string  `json:"test_recipient_addresses,omitempty"`
 }
 
 // UpdateTemplateTypeRequest is the request body for PUT template-types/:slug.
@@ -22,6 +24,8 @@ type UpdateTemplateTypeRequest struct {
 	AdapterID        *string          `json:"adapter_id,omitempty"`
 	SenderIdentityID *string          `json:"sender_identity_id,omitempty"`
 	VariableSchema   *json.RawMessage `json:"variable_schema,omitempty"`
+	TestRecipientMode      *string    `json:"test_recipient_mode,omitempty"`
+	TestRecipientAddresses *[]string  `json:"test_recipient_addresses,omitempty"`
 }
 
 // --- Templates ---

--- a/internal/http/request/workspace.go
+++ b/internal/http/request/workspace.go
@@ -9,10 +9,13 @@ type CreateWorkspaceRequest struct {
 
 // UpdateWorkspaceRequest is the request body for PUT /api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code.
 type UpdateWorkspaceRequest struct {
+	Code                *string `json:"code,omitempty"`
 	Name                *string `json:"name"`
 	IsActive            *bool   `json:"is_active,omitempty"`
 	OpenTrackingEnabled *bool   `json:"open_tracking_enabled"`
 	DefaultLocale       *string `json:"default_locale"`
+	TestRecipientMode   *string   `json:"test_recipient_mode,omitempty"`
+	TestRecipientAddresses *[]string `json:"test_recipient_addresses,omitempty"`
 }
 
 // UpdateWorkspacePolicyRequest is the request body for PUT /api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code/policies.

--- a/internal/http/response/template.go
+++ b/internal/http/response/template.go
@@ -19,6 +19,8 @@ type TemplateTypeResponse struct {
 	AdapterID           *string          `json:"adapter_id,omitempty"`
 	SenderIdentityID    *string          `json:"sender_identity_id,omitempty"`
 	VariableSchema      *json.RawMessage `json:"variable_schema,omitempty"`
+	TestRecipientMode   *string          `json:"test_recipient_mode,omitempty"`
+	TestRecipientAddresses []string      `json:"test_recipient_addresses,omitempty"`
 	OwnerScope          string           `json:"owner_scope,omitempty"`
 	InheritedFromSystem bool             `json:"inherited_from_system"`
 	CreatedAt           string           `json:"created_at"`
@@ -64,6 +66,13 @@ func NewTemplateTypeResponse(tt *domain.TemplateType) TemplateTypeResponse {
 			rm := json.RawMessage(raw)
 			resp.VariableSchema = &rm
 		}
+	}
+	if tt.TestRecipientMode != nil {
+		mode := string(*tt.TestRecipientMode)
+		resp.TestRecipientMode = &mode
+	}
+	if len(tt.TestRecipientAddresses) > 0 {
+		resp.TestRecipientAddresses = append([]string(nil), tt.TestRecipientAddresses...)
 	}
 	return resp
 }

--- a/internal/http/response/workspace.go
+++ b/internal/http/response/workspace.go
@@ -1,21 +1,26 @@
 package response
 
 import (
+	"github.com/google/uuid"
 	"github.com/rendis/senda/internal/domain"
 )
 
 // WorkspaceResponse is the JSON response for a single workspace.
 type WorkspaceResponse struct {
-	ID                  string  `json:"id"`
-	TenantID            string  `json:"tenant_id"`
-	Code                string  `json:"code"`
-	Name                string  `json:"name"`
-	IsSystem            bool    `json:"is_system"`
-	IsActive            bool    `json:"is_active"`
-	OpenTrackingEnabled bool    `json:"open_tracking_enabled"`
-	DefaultLocale       *string `json:"default_locale"`
-	CreatedAt           string  `json:"created_at"`
-	UpdatedAt           string  `json:"updated_at"`
+	ID                     string   `json:"id"`
+	LogicalWorkspaceID     string   `json:"logical_workspace_id"`
+	TenantID               string   `json:"tenant_id"`
+	Code                   string   `json:"code"`
+	Name                   string   `json:"name"`
+	Environment            string   `json:"environment"`
+	IsSystem               bool     `json:"is_system"`
+	IsActive               bool     `json:"is_active"`
+	OpenTrackingEnabled    bool     `json:"open_tracking_enabled"`
+	DefaultLocale          *string  `json:"default_locale"`
+	TestRecipientMode      string   `json:"test_recipient_mode"`
+	TestRecipientAddresses []string `json:"test_recipient_addresses"`
+	CreatedAt              string   `json:"created_at"`
+	UpdatedAt              string   `json:"updated_at"`
 }
 
 // WorkspaceListResponse is the JSON response for a paginated list of workspaces.
@@ -27,16 +32,33 @@ type WorkspaceListResponse struct {
 
 // NewWorkspaceResponse maps a domain Workspace to a WorkspaceResponse.
 func NewWorkspaceResponse(ws *domain.Workspace) WorkspaceResponse {
+	logicalWorkspaceID := ws.LogicalWorkspaceID
+	if logicalWorkspaceID == uuid.Nil {
+		logicalWorkspaceID = ws.ID
+	}
+	environment := ws.Environment
+	if !environment.Valid() {
+		environment = domain.EnvironmentProd
+	}
+	testRecipientMode := ws.TestRecipientMode
+	if !testRecipientMode.Valid() {
+		testRecipientMode = domain.TestRecipientModeReplace
+	}
+	testRecipientAddresses := append([]string{}, ws.TestRecipientAddresses...)
 	return WorkspaceResponse{
-		ID:                  ws.ID.String(),
-		TenantID:            ws.TenantID.String(),
-		Code:                ws.Code,
-		Name:                ws.Name,
-		IsSystem:            ws.IsSystem,
-		IsActive:            ws.IsActive,
-		OpenTrackingEnabled: ws.OpenTrackingEnabled,
-		DefaultLocale:       ws.DefaultLocale,
-		CreatedAt:           ws.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt:           ws.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		ID:                     ws.ID.String(),
+		LogicalWorkspaceID:     logicalWorkspaceID.String(),
+		TenantID:               ws.TenantID.String(),
+		Code:                   ws.Code,
+		Name:                   ws.Name,
+		Environment:            environment.String(),
+		IsSystem:               ws.IsSystem,
+		IsActive:               ws.IsActive,
+		OpenTrackingEnabled:    ws.OpenTrackingEnabled,
+		DefaultLocale:          ws.DefaultLocale,
+		TestRecipientMode:      string(testRecipientMode),
+		TestRecipientAddresses: testRecipientAddresses,
+		CreatedAt:              ws.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:              ws.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
 	}
 }

--- a/internal/http/response/workspace_test.go
+++ b/internal/http/response/workspace_test.go
@@ -1,0 +1,34 @@
+package response_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/http/response"
+)
+
+func TestNewWorkspaceResponse_EmptyRecipientAddressesMarshalAsArray(t *testing.T) {
+	ws := &domain.Workspace{
+		ID:          uuid.New(),
+		TenantID:    uuid.New(),
+		Code:        "marketing",
+		Name:        "Marketing",
+		Environment: domain.EnvironmentProd,
+		CreatedAt:   time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	}
+
+	body, err := json.Marshal(response.NewWorkspaceResponse(ws))
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	const expected = `"test_recipient_addresses":[]`
+	if !strings.Contains(string(body), expected) {
+		t.Fatalf("expected marshaled response to contain %s, got %s", expected, string(body))
+	}
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -406,6 +406,7 @@ func (s *Server) registerRoutes() { //nolint:gocognit,gocyclo,funlen // route re
 	if s.externalIntegrationHandler != nil {
 		external := s.echo.Group("/api/v1/external/:profile_slug")
 		external.GET("/bootstrap", s.externalIntegrationHandler.Bootstrap)
+		external.GET("/environments/:environment/bootstrap", s.externalIntegrationHandler.Bootstrap)
 
 		if s.templateTypeHandler != nil || s.templateHandler != nil || s.injectorHandler != nil {
 			externalScoped := external.Group("/tenants/:tenant_code/workspaces/:workspace_code")
@@ -468,6 +469,7 @@ func (s *Server) registerRoutes() { //nolint:gocognit,gocyclo,funlen // route re
 			mgmt.GET("/tenants/:tenant_code/workspaces/:workspace_code", s.workspaceHandler.Get, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
 			mgmt.PUT("/tenants/:tenant_code/workspaces/:workspace_code", s.workspaceHandler.Update, middleware.RequireRole(domain.RoleWorkspaceAdmin, s.tenantStore, s.wsStore))
 			mgmt.DELETE("/tenants/:tenant_code/workspaces/:workspace_code", s.workspaceHandler.SoftDelete, middleware.RequireRole(domain.RoleTenantAdmin, s.tenantStore, s.wsStore))
+			mgmt.GET("/environments/:environment/tenants/:tenant_code/workspaces", s.workspaceHandler.List, middleware.RequireRole(domain.RoleTenantAdmin, s.tenantStore, s.wsStore))
 		}
 		if s.workspacePolicyHandler != nil {
 			mgmt.GET("/tenants/:tenant_code/workspaces/:workspace_code/policies", s.workspacePolicyHandler.Get, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
@@ -501,10 +503,7 @@ func (s *Server) registerRoutes() { //nolint:gocognit,gocyclo,funlen // route re
 			mgmt.PUT("/config", s.configHandler.Update, middleware.RequireRole(domain.RoleSuperadmin, s.tenantStore, s.wsStore))
 		}
 
-		// Workspace-scoped resources.
-		{
-			ws := mgmt.Group("/tenants/:tenant_code/workspaces/:workspace_code")
-
+		registerWorkspaceScopedRoutes := func(ws *echo.Group) {
 			if s.injectorHandler != nil { //nolint:dupl // repeated route group pattern
 				ws.POST("/injectors", s.injectorHandler.Create, middleware.RequireRole(domain.RoleWorkspaceAdmin, s.tenantStore, s.wsStore))
 				ws.GET("/injectors", s.injectorHandler.List, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
@@ -622,6 +621,29 @@ func (s *Server) registerRoutes() { //nolint:gocognit,gocyclo,funlen // route re
 			if s.dashboardHandler != nil {
 				ws.GET("/dashboard-stats", s.dashboardHandler.Stats, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
 			}
+		}
+
+		// Workspace-scoped resources.
+		{
+			ws := mgmt.Group("/tenants/:tenant_code/workspaces/:workspace_code")
+			registerWorkspaceScopedRoutes(ws)
+		}
+
+		// Environment-scoped workspace resources.
+		{
+			envWS := mgmt.Group("/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code")
+
+			if s.workspaceHandler != nil {
+				envWS.GET("", s.workspaceHandler.Get, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
+				envWS.PUT("", s.workspaceHandler.Update, middleware.RequireRole(domain.RoleWorkspaceAdmin, s.tenantStore, s.wsStore))
+				envWS.POST("/runtime/reset", s.workspaceHandler.ResetRuntime, middleware.RequireRole(domain.RoleWorkspaceAdmin, s.tenantStore, s.wsStore))
+			}
+			if s.workspacePolicyHandler != nil {
+				envWS.GET("/policies", s.workspacePolicyHandler.Get, middleware.RequireRole(domain.RoleWorkspaceViewer, s.tenantStore, s.wsStore))
+				envWS.PUT("/policies", s.workspacePolicyHandler.Update, middleware.RequireRole(domain.RoleTenantAdmin, s.tenantStore, s.wsStore))
+			}
+
+			registerWorkspaceScopedRoutes(envWS)
 		}
 
 		// Global resources (superadmin only).

--- a/internal/http/server_external_test.go
+++ b/internal/http/server_external_test.go
@@ -162,6 +162,24 @@ func TestServer_ExternalIntegrationSurface_BootstrapRemainsOutsideOIDC(t *testin
 	}
 }
 
+func TestServer_ExternalIntegrationSurface_EnvironmentBootstrapPath(t *testing.T) {
+	h := handler.NewExternalIntegrationHandler(&externalConfigStore{
+		getFn: func(context.Context) (*domain.GlobalConfig, error) {
+			return externalProfileConfig(), nil
+		},
+	}, []port.ExternalAuthMethod{&externalAuthMethod{name: "signed-headers"}}, []port.ExternalWorkspaceResolver{&externalResolver{name: "tenant-workspace-resolver"}})
+
+	srv := sendahttp.NewServer(testConfig(), testLogger(), sendahttp.WithExternalIntegrationHandler(h))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/environments/test/bootstrap", nil)
+	rec := httptest.NewRecorder()
+	srv.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestExternalIntegrationMiddleware_SuccessAndPathRewrite(t *testing.T) {
 	cfg := externalProfileConfig()
 	auth := &externalAuthMethod{
@@ -190,6 +208,7 @@ func TestExternalIntegrationMiddleware_SuccessAndPathRewrite(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
 	req.Header.Set("X-Tenant-Code", "acme")
 	req.Header.Set("X-Signature", "sig")
+	req.Header.Set(middleware.ExternalIntegrationEnvironmentHeader, string(domain.EnvironmentProd))
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
@@ -227,6 +246,7 @@ func TestExternalIntegrationMiddleware_AllowsPoliciesReadForBuilder(t *testing.T
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/policies", nil)
 	req.Header.Set("X-Tenant-Code", "acme")
 	req.Header.Set("X-Signature", "sig")
+	req.Header.Set(middleware.ExternalIntegrationEnvironmentHeader, string(domain.EnvironmentProd))
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
@@ -254,12 +274,13 @@ func TestExternalIntegrationMiddleware_DisabledProfile(t *testing.T) {
 func TestExternalIntegrationMiddleware_MissingRequiredHeader(t *testing.T) {
 	e := setupExternalRouteServer(externalProfileConfig(), &externalAuthMethod{name: "signed-headers"}, &externalResolver{name: "tenant-workspace-resolver"})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
+	req.Header.Set(middleware.ExternalIntegrationEnvironmentHeader, string(domain.EnvironmentProd))
 	req.Header.Set("X-Signature", "sig")
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401 for missing required header, got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("expected 401 for missing X-Tenant-Code header, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -276,6 +297,7 @@ func TestExternalIntegrationMiddleware_AuthDenyAndError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
 	req.Header.Set("X-Tenant-Code", "acme")
 	req.Header.Set("X-Signature", "sig")
+	req.Header.Set(middleware.ExternalIntegrationEnvironmentHeader, string(domain.EnvironmentProd))
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
@@ -291,6 +313,7 @@ func TestExternalIntegrationMiddleware_AuthDenyAndError(t *testing.T) {
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
 	req.Header.Set("X-Tenant-Code", "acme")
 	req.Header.Set("X-Signature", "sig")
+	req.Header.Set(middleware.ExternalIntegrationEnvironmentHeader, string(domain.EnvironmentProd))
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	if rec.Code != http.StatusInternalServerError {
@@ -310,6 +333,7 @@ func TestExternalIntegrationMiddleware_ResolverMismatch(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/other/template-types", nil)
 	req.Header.Set("X-Tenant-Code", "acme")
 	req.Header.Set("X-Signature", "sig")
+	req.Header.Set(middleware.ExternalIntegrationEnvironmentHeader, string(domain.EnvironmentProd))
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
@@ -344,6 +368,7 @@ func TestExternalIntegrationMiddleware_FallbackReadOnlyAllowsReadBlocksMutation(
 	readReq := httptest.NewRequest(http.MethodGet, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/template-types", nil)
 	readReq.Header.Set("X-Tenant-Code", "acme")
 	readReq.Header.Set("X-Signature", "sig")
+	readReq.Header.Set(middleware.ExternalIntegrationEnvironmentHeader, string(domain.EnvironmentProd))
 	readRec := httptest.NewRecorder()
 	e.ServeHTTP(readRec, readReq)
 	if readRec.Code != http.StatusOK {
@@ -361,6 +386,7 @@ func TestExternalIntegrationMiddleware_FallbackReadOnlyAllowsReadBlocksMutation(
 	mutReq := httptest.NewRequest(http.MethodPut, "/api/v1/external/partner-portal/tenants/acme/workspaces/main/templates/t1/versions/v1", nil)
 	mutReq.Header.Set("X-Tenant-Code", "acme")
 	mutReq.Header.Set("X-Signature", "sig")
+	mutReq.Header.Set(middleware.ExternalIntegrationEnvironmentHeader, string(domain.EnvironmentProd))
 	mutRec := httptest.NewRecorder()
 	e.ServeHTTP(mutRec, mutReq)
 	if mutRec.Code != http.StatusForbidden {

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -64,6 +64,8 @@ func RegisteredRoutes() ([]Route, error) {
 		sendahttp.WithDashboardHandler(&handler.DashboardHandler{}),
 		sendahttp.WithTrackingHandler(&handler.TrackingHandler{}),
 		sendahttp.WithMediaHandler(&handler.MediaHandler{}),
+		sendahttp.WithWorkspacePolicyHandler(&handler.WorkspacePolicyHandler{}),
+		sendahttp.WithExternalIntegrationHandler(&handler.ExternalIntegrationHandler{}),
 	)
 
 	routes := srv.Echo().Router().Routes()
@@ -132,6 +134,7 @@ func GenerateSwagDocsContent(routes []Route) string {
 	buf.WriteString("type DocHealthResponse struct {\n\tStatus string `json:\"status\"`\n\tError string `json:\"error,omitempty\"`\n}\n\n")
 	buf.WriteString("type DocStatusResponse struct {\n\tStatus string `json:\"status\"`\n}\n\n")
 	buf.WriteString("type DocTemplateLocaleListResponse struct {\n\tItems []response.TemplateVersionLocaleResponse `json:\"items\"`\n}\n\n")
+	buf.WriteString("type DocWorkspacePolicyResponse struct {\n\tAllowWorkspaceLocalTemplates bool `json:\"allow_workspace_local_templates\"`\n\tAllowWorkspaceInheritedTemplateForks bool `json:\"allow_workspace_inherited_template_forks\"`\n\tAllowWorkspaceLocalInjectors bool `json:\"allow_workspace_local_injectors\"`\n}\n\n")
 	writef := func(format string, args ...any) {
 		_, _ = fmt.Fprintf(&buf, format, args...)
 	}
@@ -270,8 +273,22 @@ func routeParameters(route Route) []operationParam {
 			operationParam{Name: "limit", In: "query", Type: "integer", Required: false, Description: "Page size"},
 		)
 	}
+	if routeRequiresExternalEnvironmentHeader(route) {
+		params = append(params, operationParam{
+			Name:        "X-Senda-Environment",
+			In:          "header",
+			Type:        "string",
+			Required:    true,
+			Description: "External integration environment selector (`prod` or `test`)",
+		})
+	}
 
 	return params
+}
+
+func routeRequiresExternalEnvironmentHeader(route Route) bool {
+	normalized := NormalizeEchoPath(route.Path)
+	return strings.HasPrefix(normalized, "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}")
 }
 
 func routeSupportsCursor(route Route) bool {
@@ -312,6 +329,8 @@ func routeTag(route Route) string {
 		return "health"
 	case strings.HasPrefix(normalized, "/t/o/"):
 		return "tracking"
+	case strings.HasPrefix(normalized, "/api/v1/external/"):
+		return "external"
 	case normalized == "/public/video-thumbnail":
 		return "media"
 	case normalized == "/api/v1/send", normalized == "/api/v1/send/batch":
@@ -418,6 +437,11 @@ func routeRequestType(route Route) string {
 		if route.Method == "PUT" {
 			return "request.UpdateConfigRequest"
 		}
+	case "/api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies",
+		"/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies":
+		if route.Method == "PUT" {
+			return "request.UpdateWorkspacePolicyRequest"
+		}
 	}
 
 	switch {
@@ -479,6 +503,11 @@ func routeSuccessType(route Route) string {
 		return "response.ConfigResponse"
 	case "/api/v1/members/me":
 		return "response.MemberWithRolesResponse"
+	case "/api/v1/external/{profile_slug}/bootstrap",
+		"/api/v1/external/{profile_slug}/environments/{environment}/bootstrap":
+		return "response.ExternalIntegrationBootstrapResponse"
+	case "/api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/session":
+		return "response.ExternalIntegrationSessionResponse"
 	case "/api/v1/manage/tenants":
 		if route.Method == "GET" {
 			return "response.TenantListResponse"
@@ -497,6 +526,9 @@ func routeSuccessType(route Route) string {
 		}
 	case "/api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}":
 		return "response.WorkspaceResponse"
+	case "/api/v1/manage/tenants/{tenant_code}/workspaces/{workspace_code}/policies",
+		"/api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies":
+		return "DocWorkspacePolicyResponse"
 	case "/api/v1/manage/members":
 		if route.Method == "GET" {
 			return "response.MemberListResponse"
@@ -721,8 +753,8 @@ func PatchSecuritySchemes(doc *openapi3.T) {
 		Value: &openapi3.SecurityScheme{
 			Type:         "http",
 			Scheme:       "bearer",
-			BearerFormat: "senda_live",
-			Description:  "Workspace-scoped API key sent as Authorization: Bearer senda_live_...",
+			BearerFormat: "senda_prod|senda_test",
+			Description:  "Workspace-scoped API key sent as Authorization: Bearer senda_prod_... or senda_test_....",
 		},
 	}
 }

--- a/internal/openapi/openapi_test.go
+++ b/internal/openapi/openapi_test.go
@@ -52,6 +52,27 @@ func TestRouteSecurity(t *testing.T) {
 	}
 }
 
+func TestRouteParametersAddsExternalEnvironmentHeader(t *testing.T) {
+	t.Parallel()
+
+	got := routeParameters(Route{
+		Method:     "GET",
+		Path:       "/api/v1/external/:profile_slug/tenants/:tenant_code/workspaces/:workspace_code/session",
+		Parameters: []string{"profile_slug", "tenant_code", "workspace_code"},
+	})
+
+	var found bool
+	for _, param := range got {
+		if param.Name == "X-Senda-Environment" && param.In == "header" && param.Required {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("routeParameters() did not include required X-Senda-Environment header: %#v", got)
+	}
+}
+
 func TestPatchSecuritySchemes(t *testing.T) {
 	t.Parallel()
 
@@ -73,8 +94,8 @@ func TestPatchSecuritySchemes(t *testing.T) {
 	}
 
 	data := doc.Components.SecuritySchemes["WorkspaceAPIKeyBearer"].Value
-	if data.Type != "http" || data.Scheme != "bearer" || data.BearerFormat != "senda_live" {
-		t.Fatalf("workspace API key scheme = %#v, want http bearer senda_live", data)
+	if data.Type != "http" || data.Scheme != "bearer" || data.BearerFormat != "senda_prod|senda_test" {
+		t.Fatalf("workspace API key scheme = %#v, want http bearer senda_prod|senda_test", data)
 	}
 }
 
@@ -104,12 +125,45 @@ func TestValidateRouteCoverage(t *testing.T) {
 	}
 }
 
+func TestRegisteredRoutesIncludesEnvironmentAndExternalSurfaces(t *testing.T) {
+	t.Parallel()
+
+	routes, err := RegisteredRoutes()
+	if err != nil {
+		t.Fatalf("RegisteredRoutes() error = %v", err)
+	}
+
+	wanted := map[string]bool{
+		"GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces":                                            false,
+		"POST /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/runtime/reset":           false,
+		"GET /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies":                 false,
+		"PUT /api/v1/manage/environments/{environment}/tenants/{tenant_code}/workspaces/{workspace_code}/policies":                 false,
+		"GET /api/v1/external/{profile_slug}/bootstrap":                                                                              false,
+		"GET /api/v1/external/{profile_slug}/environments/{environment}/bootstrap":                                                  false,
+		"GET /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/session":                            false,
+	}
+
+	for _, route := range routes {
+		key := route.Method + " " + NormalizeEchoPath(route.Path)
+		if _, ok := wanted[key]; ok {
+			wanted[key] = true
+		}
+	}
+
+	for key, found := range wanted {
+		if !found {
+			t.Fatalf("RegisteredRoutes() missing %s", key)
+		}
+	}
+}
+
 func TestGenerateSwagDocsContent(t *testing.T) {
 	t.Parallel()
 
 	content := GenerateSwagDocsContent([]Route{
 		{Method: "POST", Path: "/api/v1/send", Parameters: nil},
 		{Method: "GET", Path: "/api/v1/manage/tenants/:tenant_code", Parameters: []string{"tenant_code"}},
+		{Method: "GET", Path: "/api/v1/external/:profile_slug/tenants/:tenant_code/workspaces/:workspace_code/session", Parameters: []string{"profile_slug", "tenant_code", "workspace_code"}},
 	})
 
 	for _, want := range []string{
@@ -119,6 +173,8 @@ func TestGenerateSwagDocsContent(t *testing.T) {
 		"@Router       /api/v1/manage/tenants/{tenant_code} [get]",
 		"@Param        tenant_code  path",
 		"@Security     ManagementBearer",
+		"@Router       /api/v1/external/{profile_slug}/tenants/{tenant_code}/workspaces/{workspace_code}/session [get]",
+		"@Param        X-Senda-Environment  header  string  true",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("generated docs missing %q\n%s", want, content)

--- a/internal/port/code_injector.go
+++ b/internal/port/code_injector.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rendis/senda/internal/domain"
 )
 
 // CodeInjector is the interface for user-provided code injectors
@@ -55,6 +56,7 @@ type InjectorContext struct {
 	// Resolved by Senda's resolution engine.
 	tenantID     uuid.UUID
 	workspaceID  uuid.UUID
+	environment  domain.Environment
 	templateType string
 
 	// Merged values from DB + code injectors already resolved.
@@ -67,6 +69,7 @@ func NewInjectorContext(
 	ref string,
 	variables map[string]any,
 	tenantID, workspaceID uuid.UUID,
+	environment domain.Environment,
 	templateType string,
 ) *InjectorContext {
 	return &InjectorContext{
@@ -75,6 +78,7 @@ func NewInjectorContext(
 		variables:    variables,
 		tenantID:     tenantID,
 		workspaceID:  workspaceID,
+		environment:  environment,
 		templateType: templateType,
 		resolved:     make(map[string]map[string]any),
 	}
@@ -130,6 +134,9 @@ func (c *InjectorContext) TenantID() uuid.UUID { return c.tenantID }
 
 // WorkspaceID returns the resolved workspace UUID.
 func (c *InjectorContext) WorkspaceID() uuid.UUID { return c.workspaceID }
+
+// Environment returns the resolved workspace environment.
+func (c *InjectorContext) Environment() domain.Environment { return c.environment }
 
 // TemplateType returns the resolved template type slug.
 func (c *InjectorContext) TemplateType() string { return c.templateType }

--- a/internal/port/external_integration.go
+++ b/internal/port/external_integration.go
@@ -1,11 +1,16 @@
 package port
 
-import "context"
+import (
+	"context"
+
+	"github.com/rendis/senda/internal/domain"
+)
 
 // ExternalIntegrationRequest carries the request context for external
 // integration auth and workspace resolution flows.
 type ExternalIntegrationRequest struct {
 	ProfileSlug    string
+	Environment    domain.Environment
 	TenantCode     string
 	WorkspaceCodes []string
 	Token          string

--- a/internal/port/store.go
+++ b/internal/port/store.go
@@ -23,11 +23,14 @@ type TenantStore interface {
 // WorkspaceStore manages workspace persistence.
 type WorkspaceStore interface {
 	Create(ctx context.Context, ws *domain.Workspace) error
+	CreateLogicalPair(ctx context.Context, prod *domain.Workspace, test *domain.Workspace) error
 	GetByID(ctx context.Context, id uuid.UUID) (*domain.Workspace, error)
-	GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error)
-	GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID) (*domain.Workspace, error)
-	ListByTenant(ctx context.Context, tenantID uuid.UUID, opts ListOptions) ([]*domain.Workspace, string, error)
+	GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error)
+	GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID, environment domain.Environment) (*domain.Workspace, error)
+	ListByTenant(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, opts ListOptions) ([]*domain.Workspace, string, error)
+	UpdateShared(ctx context.Context, tenantID uuid.UUID, currentCode, nextCode, nextName string) error
 	Update(ctx context.Context, ws *domain.Workspace) error
+	SoftDeleteLogical(ctx context.Context, tenantID uuid.UUID, code string) error
 	SoftDelete(ctx context.Context, id uuid.UUID) error
 }
 
@@ -35,7 +38,7 @@ type WorkspaceStore interface {
 type WorkspaceExistenceStore interface {
 	// ExistsActiveByTenantCode returns a dense map where each requested workspace code is present
 	// and mapped to true only when the workspace exists for the tenant, is active, and is not soft-deleted.
-	ExistsActiveByTenantCode(ctx context.Context, tenantCode string, workspaceCodes []string) (map[string]bool, error)
+	ExistsActiveByTenantCode(ctx context.Context, tenantCode string, workspaceCodes []string, environment domain.Environment) (map[string]bool, error)
 }
 
 // InjectorStore manages injector persistence.
@@ -118,6 +121,7 @@ type EmailStore interface {
 	CreateTx(ctx context.Context, tx pgx.Tx, email *domain.Email) error
 	GetByTrackingID(ctx context.Context, trackingID string) (*domain.Email, error)
 	GetByProviderMessageID(ctx context.Context, providerMessageID string) (*domain.Email, error)
+	PurgeWorkspaceRuntime(ctx context.Context, workspaceID uuid.UUID) error
 	UpdateStatus(ctx context.Context, id uuid.UUID, newStatus, expectedStatus domain.EmailStatus) error
 	UpdateRetry(ctx context.Context, id uuid.UUID, retryCount int, nextRetryAt *time.Time) error
 	SetProviderMessageID(ctx context.Context, id uuid.UUID, providerMessageID string) error

--- a/internal/resolution/cache_invalidator.go
+++ b/internal/resolution/cache_invalidator.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"github.com/google/uuid"
+	"github.com/rendis/senda/internal/domain"
 	"github.com/rendis/senda/internal/port"
 )
 
@@ -44,15 +45,17 @@ func (c *CacheInvalidator) InvalidateDomainValidation(ctx context.Context, works
 // workspaces belonging to a tenant. If listing workspaces fails, it falls back
 // to a global invalidation so stale data is never served.
 func (c *CacheInvalidator) InvalidateTenantWorkspaces(ctx context.Context, tenantID uuid.UUID) {
-	workspaces, _, err := c.workspaceStore.ListByTenant(ctx, tenantID, port.ListOptions{Limit: 1000})
-	if err != nil {
-		slog.Error("failed to list workspaces for cache invalidation, falling back to global",
-			"tenant_id", tenantID, "error", err)
-		c.InvalidateGlobal(ctx)
-		return
-	}
-	for _, ws := range workspaces {
-		c.InvalidateWorkspace(ctx, ws.ID)
+	for _, environment := range domain.Environments() {
+		workspaces, _, err := c.workspaceStore.ListByTenant(ctx, tenantID, environment, port.ListOptions{Limit: 1000})
+		if err != nil {
+			slog.Error("failed to list workspaces for cache invalidation, falling back to global",
+				"tenant_id", tenantID, "environment", environment, "error", err)
+			c.InvalidateGlobal(ctx)
+			return
+		}
+		for _, ws := range workspaces {
+			c.InvalidateWorkspace(ctx, ws.ID)
+		}
 	}
 }
 

--- a/internal/resolution/cache_invalidator_test.go
+++ b/internal/resolution/cache_invalidator_test.go
@@ -17,25 +17,34 @@ import (
 // --- Mock workspace store with ListByTenant support ---
 
 type mockWorkspaceStoreWithList struct {
-	listByTenant func(ctx context.Context, tenantID uuid.UUID, opts port.ListOptions) ([]*domain.Workspace, string, error)
+	listByTenant func(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, opts port.ListOptions) ([]*domain.Workspace, string, error)
 }
 
 func (m *mockWorkspaceStoreWithList) Create(_ context.Context, _ *domain.Workspace) error {
 	return nil
 }
+func (m *mockWorkspaceStoreWithList) CreateLogicalPair(_ context.Context, _ *domain.Workspace, _ *domain.Workspace) error {
+	return nil
+}
 func (m *mockWorkspaceStoreWithList) GetByID(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
 	return nil, nil
 }
-func (m *mockWorkspaceStoreWithList) GetByTenantAndCode(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+func (m *mockWorkspaceStoreWithList) GetByTenantAndCode(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 	return nil, nil
 }
-func (m *mockWorkspaceStoreWithList) GetSystemWorkspace(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
+func (m *mockWorkspaceStoreWithList) GetSystemWorkspace(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 	return nil, nil
 }
-func (m *mockWorkspaceStoreWithList) ListByTenant(ctx context.Context, tenantID uuid.UUID, opts port.ListOptions) ([]*domain.Workspace, string, error) {
-	return m.listByTenant(ctx, tenantID, opts)
+func (m *mockWorkspaceStoreWithList) ListByTenant(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, opts port.ListOptions) ([]*domain.Workspace, string, error) {
+	return m.listByTenant(ctx, tenantID, environment, opts)
+}
+func (m *mockWorkspaceStoreWithList) UpdateShared(_ context.Context, _ uuid.UUID, _, _, _ string) error {
+	return nil
 }
 func (m *mockWorkspaceStoreWithList) Update(_ context.Context, _ *domain.Workspace) error {
+	return nil
+}
+func (m *mockWorkspaceStoreWithList) SoftDeleteLogical(_ context.Context, _ uuid.UUID, _ string) error {
 	return nil
 }
 func (m *mockWorkspaceStoreWithList) SoftDelete(_ context.Context, _ uuid.UUID) error { return nil }
@@ -43,7 +52,7 @@ func (m *mockWorkspaceStoreWithList) SoftDelete(_ context.Context, _ uuid.UUID) 
 // --- Mock cache with DeletePattern support (enhances the one in chain_test) ---
 
 type mockCacheWithPattern struct {
-	data       map[string][]byte
+	data        map[string][]byte
 	deletedKeys []string
 }
 
@@ -89,7 +98,7 @@ func TestCacheInvalidator_InvalidateWorkspace(t *testing.T) {
 	_ = cache.Set(context.Background(), cacheKey, []byte("data"), time.Minute)
 
 	wsStore := &mockWorkspaceStoreWithList{
-		listByTenant: func(_ context.Context, _ uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+		listByTenant: func(_ context.Context, _ uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 			return nil, "", nil
 		},
 	}
@@ -109,7 +118,7 @@ func TestCacheInvalidator_InvalidateAdapter(t *testing.T) {
 	_ = cache.Set(context.Background(), cacheKey, []byte("data"), time.Minute)
 
 	wsStore := &mockWorkspaceStoreWithList{
-		listByTenant: func(_ context.Context, _ uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+		listByTenant: func(_ context.Context, _ uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 			return nil, "", nil
 		},
 	}
@@ -130,7 +139,7 @@ func TestCacheInvalidator_InvalidateDomainValidation(t *testing.T) {
 	_ = cache.Set(context.Background(), cacheKey, []byte("1"), time.Minute)
 
 	wsStore := &mockWorkspaceStoreWithList{
-		listByTenant: func(_ context.Context, _ uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+		listByTenant: func(_ context.Context, _ uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 			return nil, "", nil
 		},
 	}
@@ -157,7 +166,7 @@ func TestCacheInvalidator_InvalidateGlobal(t *testing.T) {
 	_ = cache.Set(context.Background(), "domain_valid:some:key", []byte("1"), time.Minute)
 
 	wsStore := &mockWorkspaceStoreWithList{
-		listByTenant: func(_ context.Context, _ uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+		listByTenant: func(_ context.Context, _ uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 			return nil, "", nil
 		},
 	}
@@ -183,36 +192,45 @@ func TestCacheInvalidator_InvalidateGlobal(t *testing.T) {
 
 func TestCacheInvalidator_InvalidateTenantWorkspaces(t *testing.T) {
 	tenantID := uuid.New()
-	ws1 := uuid.New()
-	ws2 := uuid.New()
+	prodWS := uuid.New()
+	testWS := uuid.New()
 
 	cache := newMockCacheWithPattern()
-	_ = cache.Set(context.Background(), fmt.Sprintf("chain:%s", ws1.String()), []byte("data"), time.Minute)
-	_ = cache.Set(context.Background(), fmt.Sprintf("chain:%s", ws2.String()), []byte("data"), time.Minute)
+	_ = cache.Set(context.Background(), fmt.Sprintf("chain:%s", prodWS.String()), []byte("data"), time.Minute)
+	_ = cache.Set(context.Background(), fmt.Sprintf("chain:%s", testWS.String()), []byte("data"), time.Minute)
+	seenEnvironments := make([]domain.Environment, 0, 2)
 
 	wsStore := &mockWorkspaceStoreWithList{
-		listByTenant: func(_ context.Context, tid uuid.UUID, opts port.ListOptions) ([]*domain.Workspace, string, error) {
+		listByTenant: func(_ context.Context, tid uuid.UUID, environment domain.Environment, opts port.ListOptions) ([]*domain.Workspace, string, error) {
 			if tid != tenantID {
 				t.Errorf("ListByTenant called with %v, want %v", tid, tenantID)
 			}
 			if opts.Limit != 1000 {
 				t.Errorf("ListByTenant limit = %d, want 1000", opts.Limit)
 			}
-			return []*domain.Workspace{
-				{ID: ws1, TenantID: tenantID},
-				{ID: ws2, TenantID: tenantID},
-			}, "", nil
+			seenEnvironments = append(seenEnvironments, environment)
+			switch environment {
+			case domain.EnvironmentProd:
+				return []*domain.Workspace{{ID: prodWS, TenantID: tenantID, Environment: domain.EnvironmentProd}}, "", nil
+			case domain.EnvironmentTest:
+				return []*domain.Workspace{{ID: testWS, TenantID: tenantID, Environment: domain.EnvironmentTest}}, "", nil
+			default:
+				return nil, "", fmt.Errorf("unexpected environment %s", environment)
+			}
 		},
 	}
 
 	inv := resolution.NewCacheInvalidator(cache, wsStore)
 	inv.InvalidateTenantWorkspaces(context.Background(), tenantID)
 
-	if _, err := cache.Get(context.Background(), fmt.Sprintf("chain:%s", ws1.String())); err == nil {
-		t.Error("expected chain key for ws1 to be deleted")
+	if len(seenEnvironments) != 2 {
+		t.Fatalf("expected invalidator to scan 2 environments, got %d (%v)", len(seenEnvironments), seenEnvironments)
 	}
-	if _, err := cache.Get(context.Background(), fmt.Sprintf("chain:%s", ws2.String())); err == nil {
-		t.Error("expected chain key for ws2 to be deleted")
+	if _, err := cache.Get(context.Background(), fmt.Sprintf("chain:%s", prodWS.String())); err == nil {
+		t.Error("expected chain key for prod workspace to be deleted")
+	}
+	if _, err := cache.Get(context.Background(), fmt.Sprintf("chain:%s", testWS.String())); err == nil {
+		t.Error("expected chain key for test workspace to be deleted")
 	}
 }
 
@@ -222,7 +240,7 @@ func TestCacheInvalidator_InvalidateTenantWorkspaces_ListError(t *testing.T) {
 	cache := newMockCacheWithPattern()
 
 	wsStore := &mockWorkspaceStoreWithList{
-		listByTenant: func(_ context.Context, _ uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+		listByTenant: func(_ context.Context, _ uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 			return nil, "", errors.New("db error")
 		},
 	}

--- a/internal/resolution/chain.go
+++ b/internal/resolution/chain.go
@@ -67,7 +67,7 @@ func (r *ChainResolver) Resolve(ctx context.Context, workspaceID uuid.UUID) (*Re
 			},
 		}
 	} else {
-		sysWS, err := r.workspaceStore.GetSystemWorkspace(ctx, ws.TenantID)
+		sysWS, err := r.workspaceStore.GetSystemWorkspace(ctx, ws.TenantID, ws.Environment)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/resolution/chain_test.go
+++ b/internal/resolution/chain_test.go
@@ -18,23 +18,30 @@ import (
 
 type mockWorkspaceStore struct {
 	getByID            func(ctx context.Context, id uuid.UUID) (*domain.Workspace, error)
-	getSystemWorkspace func(ctx context.Context, tenantID uuid.UUID) (*domain.Workspace, error)
+	getSystemWorkspace func(ctx context.Context, tenantID uuid.UUID, environment domain.Environment) (*domain.Workspace, error)
 }
 
 func (m *mockWorkspaceStore) Create(_ context.Context, _ *domain.Workspace) error { return nil }
+func (m *mockWorkspaceStore) CreateLogicalPair(_ context.Context, _ *domain.Workspace, _ *domain.Workspace) error {
+	return nil
+}
 func (m *mockWorkspaceStore) GetByID(ctx context.Context, id uuid.UUID) (*domain.Workspace, error) {
 	return m.getByID(ctx, id)
 }
-func (m *mockWorkspaceStore) GetByTenantAndCode(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+func (m *mockWorkspaceStore) GetByTenantAndCode(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 	return nil, nil
 }
-func (m *mockWorkspaceStore) GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
-	return m.getSystemWorkspace(ctx, tenantID)
+func (m *mockWorkspaceStore) GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID, environment domain.Environment) (*domain.Workspace, error) {
+	return m.getSystemWorkspace(ctx, tenantID, environment)
 }
-func (m *mockWorkspaceStore) ListByTenant(_ context.Context, _ uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+func (m *mockWorkspaceStore) ListByTenant(_ context.Context, _ uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 	return nil, "", nil
 }
+func (m *mockWorkspaceStore) UpdateShared(_ context.Context, _ uuid.UUID, _, _, _ string) error { return nil }
 func (m *mockWorkspaceStore) Update(_ context.Context, _ *domain.Workspace) error { return nil }
+func (m *mockWorkspaceStore) SoftDeleteLogical(_ context.Context, _ uuid.UUID, _ string) error {
+	return nil
+}
 func (m *mockWorkspaceStore) SoftDelete(_ context.Context, _ uuid.UUID) error     { return nil }
 
 // --- Mock Cache ---
@@ -86,7 +93,7 @@ func TestChainResolver_RegularWorkspace(t *testing.T) {
 
 	store := &mockWorkspaceStore{
 		getByID:            func(_ context.Context, id uuid.UUID) (*domain.Workspace, error) { return ws, nil },
-		getSystemWorkspace: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) { return sysWS, nil },
+		getSystemWorkspace: func(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) { return sysWS, nil },
 	}
 	cache := newMockCache()
 	resolver := resolution.NewChainResolver(store, cache)
@@ -126,7 +133,7 @@ func TestChainResolver_SystemWorkspace(t *testing.T) {
 
 	store := &mockWorkspaceStore{
 		getByID: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) { return sysWS, nil },
-		getSystemWorkspace: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
+		getSystemWorkspace: func(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 			t.Error("GetSystemWorkspace should not be called for system workspace")
 			return nil, nil
 		},
@@ -176,7 +183,7 @@ func TestChainResolver_CacheHit(t *testing.T) {
 			storeCalled = true
 			return nil, errors.New("should not be called")
 		},
-		getSystemWorkspace: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
+		getSystemWorkspace: func(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 			storeCalled = true
 			return nil, errors.New("should not be called")
 		},
@@ -203,7 +210,7 @@ func TestChainResolver_WorkspaceNotFound(t *testing.T) {
 		getByID: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
 			return nil, apperr.NotFound("workspace not found")
 		},
-		getSystemWorkspace: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
+		getSystemWorkspace: func(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 			return nil, nil
 		},
 	}
@@ -227,7 +234,7 @@ func TestChainResolver_SystemWorkspaceNotFound(t *testing.T) {
 
 	store := &mockWorkspaceStore{
 		getByID: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) { return ws, nil },
-		getSystemWorkspace: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
+		getSystemWorkspace: func(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 			return nil, apperr.NotFound("system workspace not found")
 		},
 	}
@@ -254,7 +261,7 @@ func TestChainResolver_CacheSetFailureStillReturns(t *testing.T) {
 
 	store := &mockWorkspaceStore{
 		getByID:            func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) { return ws, nil },
-		getSystemWorkspace: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) { return sysWS, nil },
+		getSystemWorkspace: func(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) { return sysWS, nil },
 	}
 	cache := newMockCache()
 	cache.setErr = errors.New("cache write failed")

--- a/internal/resolution/injector_merger_test.go
+++ b/internal/resolution/injector_merger_test.go
@@ -84,7 +84,7 @@ func newTestChainResolver(chain *resolution.ResolutionChain, err error) *resolut
 			}
 			return &domain.Workspace{ID: wsID, TenantID: tenantID, IsSystem: false}, nil
 		},
-		getSystemWorkspace: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
+		getSystemWorkspace: func(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 			return &domain.Workspace{ID: sysID, TenantID: tenantID, IsSystem: true}, nil
 		},
 	}
@@ -96,7 +96,7 @@ func newErrorChainResolver(retErr error) *resolution.ChainResolver {
 		getByID: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
 			return nil, retErr
 		},
-		getSystemWorkspace: func(_ context.Context, _ uuid.UUID) (*domain.Workspace, error) {
+		getSystemWorkspace: func(_ context.Context, _ uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 			return nil, nil
 		},
 	}
@@ -501,7 +501,7 @@ func TestResolveWithContext_CodeInjectorsOnly(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{codeInj}, nil)
-	injCtx := port.NewInjectorContext(nil, "t:w:welcome", nil, uuid.Nil, wsID, "welcome")
+	injCtx := port.NewInjectorContext(nil, "t:w:welcome", nil, uuid.Nil, wsID, domain.EnvironmentProd, "welcome")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
 	if err != nil {
@@ -536,7 +536,7 @@ func TestResolveWithContext_InitFunc(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{inj}, initFunc)
-	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, "t")
+	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
 	if err != nil {
@@ -559,7 +559,7 @@ func TestResolveWithContext_NonCriticalSkipped(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{failInj, okInj}, nil)
-	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, "t")
+	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
 	if err != nil {
@@ -584,7 +584,7 @@ func TestResolveWithContext_CriticalAborts(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{criticalInj}, nil)
-	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, "t")
+	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	_, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
 	if err == nil {
@@ -606,7 +606,7 @@ func TestResolveWithContext_DependencyOrder(t *testing.T) {
 	cr := newTestChainResolver(chain, nil)
 	// Register child BEFORE parent to test dependency resolution.
 	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{childInj, parentInj}, nil)
-	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, "t")
+	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	_, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
 	if err != nil {
@@ -669,7 +669,7 @@ func TestResolveWithContext_CodeOverridesDB(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(injStore, cr, []port.CodeInjector{codeInj}, nil)
-	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, "t")
+	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
 	if err != nil {
@@ -716,7 +716,7 @@ func TestResolveWithContext_MixedDBAndCode(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(injStore, cr, []port.CodeInjector{codeInj}, nil)
-	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, "t")
+	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
 	if err != nil {
@@ -759,7 +759,7 @@ func TestResolveWithContext_NoCodeInjectors_SameAsResolve(t *testing.T) {
 	cr := newTestChainResolver(chain, nil)
 	// No code injectors.
 	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
-	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, "t")
+	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	resultCtx, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
 	if err != nil {
@@ -821,7 +821,7 @@ func TestResolveWithContext_InitFuncError(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{inj}, failInit)
-	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, "t")
+	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	_, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
 	if err == nil {
@@ -876,7 +876,7 @@ func TestResolveWithContext_DepOnDBInjector(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(injStore, cr, []port.CodeInjector{codeInj}, nil)
-	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, "t")
+	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
 	if err != nil {
@@ -902,7 +902,7 @@ func TestResolveWithContext_DuplicateCodeInjectorCodes(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{first, second}, nil)
-	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, "t")
+	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
 	if err != nil {
@@ -954,7 +954,7 @@ func TestResolveWithContext_RequestInjectorsOverrideCodeAndDefault(t *testing.T)
 
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(injStore, cr, []port.CodeInjector{codeInj}, nil)
-	injCtx := port.NewInjectorContext(nil, "t:w:welcome", nil, uuid.Nil, wsID, "welcome")
+	injCtx := port.NewInjectorContext(nil, "t:w:welcome", nil, uuid.Nil, wsID, domain.EnvironmentProd, "welcome")
 	injCtx.SetRequestInjectors(map[string]map[string]any{
 		"student": {"name": "Request Student"},
 	})
@@ -1011,7 +1011,7 @@ func TestResolveWithContext_LockedFieldAlwaysUsesDefault(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	merger := resolution.NewInjectorMerger(injStore, cr, []port.CodeInjector{codeInj}, nil)
-	injCtx := port.NewInjectorContext(nil, "t:w:welcome", nil, uuid.Nil, wsID, "welcome")
+	injCtx := port.NewInjectorContext(nil, "t:w:welcome", nil, uuid.Nil, wsID, domain.EnvironmentProd, "welcome")
 	injCtx.SetRequestInjectors(map[string]map[string]any{
 		"student": {"name": "Request Student"},
 	})

--- a/internal/service/adapter_access.go
+++ b/internal/service/adapter_access.go
@@ -203,7 +203,7 @@ func (s *AdapterAccessService) ReplaceAdapterWorkspaceAccess(ctx context.Context
 	if adapter.WorkspaceID == nil || *adapter.WorkspaceID != systemWorkspace.ID || adapter.AdapterType != domain.AdapterTypeGmail {
 		return fmt.Errorf("%w: only system-owned gmail adapters can be shared", domain.ErrValidation)
 	}
-	validTargets, err := s.validWorkspaceTargets(ctx, systemWorkspace.TenantID, workspaceIDs)
+	validTargets, err := s.validWorkspaceTargets(ctx, systemWorkspace.TenantID, workspaceEnvironment(systemWorkspace), workspaceIDs)
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func (s *AdapterAccessService) ReplaceIdentityWorkspaceAccess(ctx context.Contex
 	if identity.AdapterID != adapterID || identity.IdentityType != domain.IdentityTypeEmail {
 		return fmt.Errorf("%w: only email identities can be shared", domain.ErrValidation)
 	}
-	validTargets, err := s.validWorkspaceTargets(ctx, systemWorkspace.TenantID, workspaceIDs)
+	validTargets, err := s.validWorkspaceTargets(ctx, systemWorkspace.TenantID, workspaceEnvironment(systemWorkspace), workspaceIDs)
 	if err != nil {
 		return err
 	}
@@ -274,7 +274,7 @@ func (s *AdapterAccessService) ListAdapterWorkspaceAccess(ctx context.Context, s
 	if adapter.WorkspaceID == nil || *adapter.WorkspaceID != systemWorkspace.ID || adapter.AdapterType != domain.AdapterTypeGmail {
 		return nil, fmt.Errorf("%w: only system-owned gmail adapters can be shared", domain.ErrValidation)
 	}
-	return s.listWorkspaceAccess(ctx, systemWorkspace.TenantID, func() ([]uuid.UUID, error) {
+	return s.listWorkspaceAccess(ctx, systemWorkspace.TenantID, workspaceEnvironment(systemWorkspace), func() ([]uuid.UUID, error) {
 		return s.adapterGrants.ListAdapterWorkspaceGrants(ctx, adapterID)
 	})
 }
@@ -298,7 +298,7 @@ func (s *AdapterAccessService) ListIdentityWorkspaceAccess(ctx context.Context, 
 	if identity.AdapterID != adapterID || identity.IdentityType != domain.IdentityTypeEmail {
 		return nil, fmt.Errorf("%w: only email identities can be shared", domain.ErrValidation)
 	}
-	return s.listWorkspaceAccess(ctx, systemWorkspace.TenantID, func() ([]uuid.UUID, error) {
+	return s.listWorkspaceAccess(ctx, systemWorkspace.TenantID, workspaceEnvironment(systemWorkspace), func() ([]uuid.UUID, error) {
 		return s.identityGrants.ListIdentityWorkspaceGrants(ctx, identityID)
 	})
 }
@@ -325,11 +325,18 @@ func (s *AdapterAccessService) validateSenderIdentity(ctx context.Context, adapt
 	return nil
 }
 
-func (s *AdapterAccessService) validWorkspaceTargets(ctx context.Context, tenantID uuid.UUID, requested []uuid.UUID) ([]uuid.UUID, error) {
+func workspaceEnvironment(workspace *domain.Workspace) domain.Environment {
+	if workspace != nil && workspace.Environment.Valid() {
+		return workspace.Environment
+	}
+	return domain.EnvironmentProd
+}
+
+func (s *AdapterAccessService) validWorkspaceTargets(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, requested []uuid.UUID) ([]uuid.UUID, error) {
 	if len(requested) == 0 {
 		return nil, nil
 	}
-	workspaces, _, err := s.workspaceStore.ListByTenant(ctx, tenantID, port.ListOptions{Limit: 1000})
+	workspaces, _, err := s.workspaceStore.ListByTenant(ctx, tenantID, environment, port.ListOptions{Limit: 1000})
 	if err != nil {
 		return nil, err
 	}
@@ -355,8 +362,8 @@ func (s *AdapterAccessService) validWorkspaceTargets(ctx context.Context, tenant
 	return result, nil
 }
 
-func (s *AdapterAccessService) listWorkspaceAccess(ctx context.Context, tenantID uuid.UUID, loadGrants func() ([]uuid.UUID, error)) ([]WorkspaceAccessGrant, error) {
-	workspaces, _, err := s.workspaceStore.ListByTenant(ctx, tenantID, port.ListOptions{Limit: 1000})
+func (s *AdapterAccessService) listWorkspaceAccess(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, loadGrants func() ([]uuid.UUID, error)) ([]WorkspaceAccessGrant, error) {
+	workspaces, _, err := s.workspaceStore.ListByTenant(ctx, tenantID, environment, port.ListOptions{Limit: 1000})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/adapter_access_test.go
+++ b/internal/service/adapter_access_test.go
@@ -336,7 +336,7 @@ func TestAdapterAccessService_ReplaceIdentityWorkspaceAccess_BlocksRevokeWhenInU
 	}
 
 	wsStore := &mockWorkspaceStoreSend{
-		listByTenantFn: func(_ context.Context, tenantID uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+		listByTenantFn: func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 			if tenantID != systemWorkspace.TenantID {
 				return nil, "", errors.New("unexpected tenant lookup")
 			}
@@ -424,7 +424,7 @@ func TestAdapterAccessService_ReplaceIdentityWorkspaceAccess_RejectsDomainIdenti
 	}
 
 	wsStore := &mockWorkspaceStoreSend{
-		listByTenantFn: func(_ context.Context, tenantID uuid.UUID, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+		listByTenantFn: func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 			if tenantID != systemWorkspace.TenantID {
 				return nil, "", errors.New("unexpected tenant lookup")
 			}
@@ -444,5 +444,165 @@ func TestAdapterAccessService_ReplaceIdentityWorkspaceAccess_RejectsDomainIdenti
 	err := svc.ReplaceIdentityWorkspaceAccess(context.Background(), systemWorkspace, adapterID, identityID, []uuid.UUID{workspaceID})
 	if !errors.Is(err, domain.ErrValidation) {
 		t.Fatalf("expected ErrValidation for domain identity sharing, got %v", err)
+	}
+}
+
+func TestAdapterAccessService_ReplaceAdapterWorkspaceAccess_UsesSystemWorkspaceEnvironment(t *testing.T) {
+	systemWorkspaceID := uuid.Must(uuid.NewV7())
+	workspaceID := uuid.Must(uuid.NewV7())
+	adapterID := uuid.Must(uuid.NewV7())
+
+	systemWorkspace := &domain.Workspace{
+		ID:          systemWorkspaceID,
+		TenantID:    uuid.Must(uuid.NewV7()),
+		Code:        "_system",
+		IsSystem:    true,
+		Environment: domain.EnvironmentTest,
+	}
+	workspace := &domain.Workspace{
+		ID:          workspaceID,
+		TenantID:    systemWorkspace.TenantID,
+		Code:        "default",
+		Environment: domain.EnvironmentTest,
+	}
+
+	var listedEnvironment domain.Environment
+	var replacedTargets []uuid.UUID
+
+	wsStore := &mockWorkspaceStoreSend{
+		listByTenantFn: func(_ context.Context, tenantID uuid.UUID, environment domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+			if tenantID != systemWorkspace.TenantID {
+				return nil, "", errors.New("unexpected tenant lookup")
+			}
+			listedEnvironment = environment
+			return []*domain.Workspace{systemWorkspace, workspace}, "", nil
+		},
+	}
+	adapterStore := &mockAdapterStoreSend{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Adapter{
+				ID:          adapterID,
+				WorkspaceID: &systemWorkspaceID,
+				AdapterType: domain.AdapterTypeGmail,
+			}, nil
+		},
+	}
+	adapterGrants := &mockAdapterGrantStore{
+		replaceAdapterWorkspaceGrantsFn: func(_ context.Context, id uuid.UUID, workspaceIDs []uuid.UUID) error {
+			if id != adapterID {
+				return errors.New("unexpected adapter id")
+			}
+			replacedTargets = append([]uuid.UUID(nil), workspaceIDs...)
+			return nil
+		},
+	}
+
+	svc := service.NewAdapterAccessService(
+		adapterStore,
+		&mockAdapterIdentityStoreSend{},
+		wsStore,
+		adapterGrants,
+		&mockIdentityGrantStore{},
+		&mockTemplateTypeUsageStore{},
+	)
+
+	if err := svc.ReplaceAdapterWorkspaceAccess(context.Background(), systemWorkspace, adapterID, []uuid.UUID{workspaceID}); err != nil {
+		t.Fatalf("expected replace grants to succeed, got %v", err)
+	}
+	if listedEnvironment != domain.EnvironmentTest {
+		t.Fatalf("expected workspace validation in test environment, got %s", listedEnvironment)
+	}
+	if len(replacedTargets) != 1 || replacedTargets[0] != workspaceID {
+		t.Fatalf("expected replace grants with workspace %s, got %v", workspaceID, replacedTargets)
+	}
+}
+
+func TestAdapterAccessService_ListIdentityWorkspaceAccess_UsesSystemWorkspaceEnvironment(t *testing.T) {
+	systemWorkspaceID := uuid.Must(uuid.NewV7())
+	workspaceID := uuid.Must(uuid.NewV7())
+	adapterID := uuid.Must(uuid.NewV7())
+	identityID := uuid.Must(uuid.NewV7())
+
+	systemWorkspace := &domain.Workspace{
+		ID:          systemWorkspaceID,
+		TenantID:    uuid.Must(uuid.NewV7()),
+		Code:        "_system",
+		IsSystem:    true,
+		Environment: domain.EnvironmentTest,
+	}
+	workspace := &domain.Workspace{
+		ID:          workspaceID,
+		TenantID:    systemWorkspace.TenantID,
+		Code:        "default",
+		Name:        "Default",
+		Environment: domain.EnvironmentTest,
+	}
+
+	var listedEnvironment domain.Environment
+
+	wsStore := &mockWorkspaceStoreSend{
+		listByTenantFn: func(_ context.Context, tenantID uuid.UUID, environment domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+			if tenantID != systemWorkspace.TenantID {
+				return nil, "", errors.New("unexpected tenant lookup")
+			}
+			listedEnvironment = environment
+			return []*domain.Workspace{systemWorkspace, workspace}, "", nil
+		},
+	}
+	adapterStore := &mockAdapterStoreSend{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Adapter{
+				ID:          adapterID,
+				WorkspaceID: &systemWorkspaceID,
+				AdapterType: domain.AdapterTypeSES,
+			}, nil
+		},
+	}
+	identityStore := &mockAdapterIdentityStoreSend{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.AdapterIdentity, error) {
+			if id != identityID {
+				return nil, domain.ErrIdentityNotFound
+			}
+			return &domain.AdapterIdentity{
+				ID:           identityID,
+				AdapterID:    adapterID,
+				Identity:     "a@example.dev",
+				IdentityType: domain.IdentityTypeEmail,
+			}, nil
+		},
+	}
+	identityGrants := &mockIdentityGrantStore{
+		listIdentityWorkspaceGrantsFn: func(_ context.Context, id uuid.UUID) ([]uuid.UUID, error) {
+			if id != identityID {
+				return nil, errors.New("unexpected identity id")
+			}
+			return []uuid.UUID{workspaceID}, nil
+		},
+	}
+
+	svc := service.NewAdapterAccessService(
+		adapterStore,
+		identityStore,
+		wsStore,
+		&mockAdapterGrantStore{},
+		identityGrants,
+		&mockTemplateTypeUsageStore{},
+	)
+
+	grants, err := svc.ListIdentityWorkspaceAccess(context.Background(), systemWorkspace, adapterID, identityID)
+	if err != nil {
+		t.Fatalf("expected list grants to succeed, got %v", err)
+	}
+	if listedEnvironment != domain.EnvironmentTest {
+		t.Fatalf("expected grant listing in test environment, got %s", listedEnvironment)
+	}
+	if len(grants) != 1 || grants[0].Workspace.ID != workspaceID || !grants[0].Granted {
+		t.Fatalf("expected granted workspace %s, got %+v", workspaceID, grants)
 	}
 }

--- a/internal/service/apikey.go
+++ b/internal/service/apikey.go
@@ -28,10 +28,10 @@ func NewAPIKeyService(store port.APIKeyStore, pepper string) *APIKeyService {
 
 // Generate creates a new API key for a workspace.
 // Returns the full key (only shown once) and the persisted domain.APIKey.
-// Format: "senda_live_" + 32 random hex chars = 43 chars total.
-// Storage: SHA-256(fullKey) as KeyHash, first 8 hex chars as KeyPrefix, last 8 chars as KeyHint.
-func (s *APIKeyService) Generate(ctx context.Context, workspaceID uuid.UUID, name string, createdBy uuid.UUID) (string, *domain.APIKey, error) {
-	fullKey, err := generateKey()
+// Format: "senda_<environment>_" + 32 random hex chars.
+// Storage: HMAC-SHA256(fullKey) as KeyHash, persisted prefix metadata as "senda_<environment>", last 8 chars as KeyHint.
+func (s *APIKeyService) Generate(ctx context.Context, workspaceID uuid.UUID, environment domain.Environment, name string, createdBy uuid.UUID) (string, *domain.APIKey, error) {
+	fullKey, err := generateKey(environment)
 	if err != nil {
 		return "", nil, err
 	}
@@ -42,7 +42,7 @@ func (s *APIKeyService) Generate(ctx context.Context, workspaceID uuid.UUID, nam
 		WorkspaceID: workspaceID,
 		Name:        name,
 		KeyHash:     hashKeyHMAC(fullKey, s.pepper),
-		KeyPrefix:   "senda_live",
+		KeyPrefix:   environment.APIKeyPrefix(),
 		KeyHint:     fullKey[len(fullKey)-8:],
 		CreatedBy:   createdBy,
 		CreatedAt:   now,
@@ -96,12 +96,15 @@ func (s *APIKeyService) ListByWorkspace(ctx context.Context, workspaceID uuid.UU
 	return s.store.ListByWorkspace(ctx, workspaceID, opts)
 }
 
-func generateKey() (string, error) {
+func generateKey(environment domain.Environment) (string, error) {
+	if !environment.Valid() {
+		environment = domain.EnvironmentProd
+	}
 	b := make([]byte, 16) // 16 bytes = 32 hex chars
 	if _, err := rand.Read(b); err != nil {
 		return "", err
 	}
-	return "senda_live_" + hex.EncodeToString(b), nil
+	return environment.APIKeyTokenPrefix() + hex.EncodeToString(b), nil
 }
 
 // hashKeyHMAC computes HMAC-SHA256 of the key using the given pepper.

--- a/internal/service/apikey_test.go
+++ b/internal/service/apikey_test.go
@@ -77,14 +77,14 @@ func TestAPIKeyService_Generate_Success(t *testing.T) {
 
 	svc := service.NewAPIKeyService(store, "test-pepper")
 
-	fullKey, key, err := svc.Generate(context.Background(), wsID, "My API Key", memberID)
+	fullKey, key, err := svc.Generate(context.Background(), wsID, domain.EnvironmentProd, "My API Key", memberID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Full key format: "senda_live_" + 32 hex chars = 43 chars total
-	if !strings.HasPrefix(fullKey, "senda_live_") {
-		t.Fatalf("expected prefix 'senda_live_', got %q", fullKey)
+	// Full key format: "senda_prod_" + 32 hex chars = 43 chars total
+	if !strings.HasPrefix(fullKey, "senda_prod_") {
+		t.Fatalf("expected prefix 'senda_prod_', got %q", fullKey)
 	}
 	if len(fullKey) != 43 {
 		t.Fatalf("expected key length 43, got %d", len(fullKey))
@@ -101,9 +101,8 @@ func TestAPIKeyService_Generate_Success(t *testing.T) {
 		t.Fatalf("expected created_by %s, got %s", memberID, key.CreatedBy)
 	}
 
-	// KeyPrefix = literal "senda_live" per TECH_SPEC.
-	if key.KeyPrefix != "senda_live" {
-		t.Fatalf("expected prefix %q, got %q", "senda_live", key.KeyPrefix)
+	if key.KeyPrefix != "senda_prod" {
+		t.Fatalf("expected prefix %q, got %q", "senda_prod", key.KeyPrefix)
 	}
 
 	// KeyHint = last 8 chars of full key.
@@ -134,7 +133,7 @@ func TestAPIKeyService_Generate_StoreError(t *testing.T) {
 
 	svc := service.NewAPIKeyService(store, "test-pepper")
 
-	_, _, err := svc.Generate(context.Background(), uuid.Must(uuid.NewV7()), "key", uuid.Must(uuid.NewV7()))
+	_, _, err := svc.Generate(context.Background(), uuid.Must(uuid.NewV7()), domain.EnvironmentProd, "key", uuid.Must(uuid.NewV7()))
 	if !errors.Is(err, domain.ErrConflict) {
 		t.Fatalf("expected ErrConflict, got %v", err)
 	}
@@ -144,12 +143,12 @@ func TestAPIKeyService_Generate_UniqueKeys(t *testing.T) {
 	store := &mockAPIKeyStore{}
 	svc := service.NewAPIKeyService(store, "test-pepper")
 
-	key1, _, err := svc.Generate(context.Background(), uuid.Must(uuid.NewV7()), "k1", uuid.Must(uuid.NewV7()))
+	key1, _, err := svc.Generate(context.Background(), uuid.Must(uuid.NewV7()), domain.EnvironmentProd, "k1", uuid.Must(uuid.NewV7()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	key2, _, err := svc.Generate(context.Background(), uuid.Must(uuid.NewV7()), "k2", uuid.Must(uuid.NewV7()))
+	key2, _, err := svc.Generate(context.Background(), uuid.Must(uuid.NewV7()), domain.EnvironmentProd, "k2", uuid.Must(uuid.NewV7()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -173,7 +172,7 @@ func TestAPIKeyService_Validate_Success(t *testing.T) {
 	}
 
 	svc := service.NewAPIKeyService(store, "test-pepper")
-	fullKey, _, err := svc.Generate(context.Background(), wsID, "test", uuid.Must(uuid.NewV7()))
+	fullKey, _, err := svc.Generate(context.Background(), wsID, domain.EnvironmentProd, "test", uuid.Must(uuid.NewV7()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -215,7 +214,7 @@ func TestAPIKeyService_Validate_NotFound(t *testing.T) {
 
 	svc := service.NewAPIKeyService(store, "test-pepper")
 
-	_, err := svc.Validate(context.Background(), "senda_live_deadbeefdeadbeefdeadbeefdeadbeef")
+	_, err := svc.Validate(context.Background(), "senda_prod_deadbeefdeadbeefdeadbeefdeadbeef")
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
@@ -234,7 +233,7 @@ func TestAPIKeyService_Validate_Revoked(t *testing.T) {
 
 	svc := service.NewAPIKeyService(store, "test-pepper")
 
-	_, err := svc.Validate(context.Background(), "senda_live_deadbeefdeadbeefdeadbeefdeadbeef")
+	_, err := svc.Validate(context.Background(), "senda_prod_deadbeefdeadbeefdeadbeefdeadbeef")
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound for revoked key, got %v", err)
 	}

--- a/internal/service/onboarding.go
+++ b/internal/service/onboarding.go
@@ -185,12 +185,15 @@ func (s *OnboardingService) Setup(ctx context.Context, claims *port.OIDCClaims, 
 		return nil, fmt.Errorf("add tenant admin role: %w", err)
 	}
 
-	// 5. Create _system workspace.
+	// 5. Create _system logical workspace pair.
+	logicalWorkspaceID := uuid.Must(uuid.NewV7())
 	ws := &domain.Workspace{
 		ID:                                   uuid.Must(uuid.NewV7()),
+		LogicalWorkspaceID:                   logicalWorkspaceID,
 		TenantID:                             tenant.ID,
 		Code:                                 "_system",
 		Name:                                 "System",
+		Environment:                          domain.EnvironmentProd,
 		IsSystem:                             true,
 		IsActive:                             true,
 		AllowWorkspaceLocalTemplates:         true,
@@ -198,31 +201,49 @@ func (s *OnboardingService) Setup(ctx context.Context, claims *port.OIDCClaims, 
 		AllowWorkspaceLocalInjectors:         true,
 		WorkspacePoliciesInitialized:         true,
 	}
-	if err := tx.QueryRow(ctx,
-		`INSERT INTO workspaces (
-		    id, tenant_id, code, name, is_system, is_active, open_tracking_enabled, default_locale,
-		    allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors
-		)
-		 VALUES (
-		    @id, @tenant_id, @code, @name, @is_system, @is_active, @open_tracking_enabled, @default_locale,
-		    @allow_workspace_local_templates, @allow_workspace_inherited_template_forks, @allow_workspace_local_injectors
-		)
-		 RETURNING is_active, created_at, updated_at`,
-		pgx.NamedArgs{
-			"id":                              ws.ID,
-			"tenant_id":                       ws.TenantID,
-			"code":                            ws.Code,
-			"name":                            ws.Name,
-			"is_system":                       ws.IsSystem,
-			"is_active":                       ws.IsActive,
-			"open_tracking_enabled":           false,
-			"default_locale":                  ws.DefaultLocale,
-			"allow_workspace_local_templates": ws.AllowWorkspaceLocalTemplates,
-			"allow_workspace_inherited_template_forks": ws.AllowWorkspaceInheritedTemplateForks,
-			"allow_workspace_local_injectors":          ws.AllowWorkspaceLocalInjectors,
-		},
-	).Scan(&ws.IsActive, &ws.CreatedAt, &ws.UpdatedAt); err != nil {
-		return nil, fmt.Errorf("create system workspace: %w", err)
+	testWS := &domain.Workspace{
+		ID:                                   uuid.Must(uuid.NewV7()),
+		LogicalWorkspaceID:                   logicalWorkspaceID,
+		TenantID:                             tenant.ID,
+		Code:                                 "_system",
+		Name:                                 "System",
+		Environment:                          domain.EnvironmentTest,
+		IsSystem:                             true,
+		IsActive:                             true,
+		AllowWorkspaceLocalTemplates:         true,
+		AllowWorkspaceInheritedTemplateForks: true,
+		AllowWorkspaceLocalInjectors:         true,
+		WorkspacePoliciesInitialized:         true,
+	}
+	for _, currentWorkspace := range []*domain.Workspace{ws, testWS} {
+		if err := tx.QueryRow(ctx,
+			`INSERT INTO workspaces (
+			    id, logical_workspace_id, tenant_id, code, name, environment, is_system, is_active, open_tracking_enabled, default_locale,
+			    allow_workspace_local_templates, allow_workspace_inherited_template_forks, allow_workspace_local_injectors
+			)
+			 VALUES (
+			    @id, @logical_workspace_id, @tenant_id, @code, @name, @environment, @is_system, @is_active, @open_tracking_enabled, @default_locale,
+			    @allow_workspace_local_templates, @allow_workspace_inherited_template_forks, @allow_workspace_local_injectors
+			)
+			 RETURNING is_active, created_at, updated_at`,
+			pgx.NamedArgs{
+				"id":                              currentWorkspace.ID,
+				"logical_workspace_id":            currentWorkspace.LogicalWorkspaceID,
+				"tenant_id":                       currentWorkspace.TenantID,
+				"code":                            currentWorkspace.Code,
+				"name":                            currentWorkspace.Name,
+				"environment":                     currentWorkspace.Environment,
+				"is_system":                       currentWorkspace.IsSystem,
+				"is_active":                       currentWorkspace.IsActive,
+				"open_tracking_enabled":           false,
+				"default_locale":                  currentWorkspace.DefaultLocale,
+				"allow_workspace_local_templates": currentWorkspace.AllowWorkspaceLocalTemplates,
+				"allow_workspace_inherited_template_forks": currentWorkspace.AllowWorkspaceInheritedTemplateForks,
+				"allow_workspace_local_injectors":          currentWorkspace.AllowWorkspaceLocalInjectors,
+			},
+		).Scan(&currentWorkspace.IsActive, &currentWorkspace.CreatedAt, &currentWorkspace.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("create system workspace (%s): %w", currentWorkspace.Environment, err)
+		}
 	}
 
 	// 6. Audit log (best-effort with savepoint — a failed INSERT must not
@@ -230,19 +251,19 @@ func (s *OnboardingService) Setup(ctx context.Context, claims *port.OIDCClaims, 
 	if _, spErr := tx.Exec(ctx, "SAVEPOINT audit_sp"); spErr == nil {
 		changesJSON, _ := json.Marshal(map[string]any{"tenant_code": tenant.Code, "tenant_name": tenant.Name, "member_email": member.Email})
 		_, auditErr := tx.Exec(ctx,
-			`INSERT INTO audit_logs (id, actor_id, actor_email, action, entity_type, entity_id, tenant_id, scope_type, changes, created_at)
-			 VALUES (@id, @actor_id, @actor_email, @action, @entity_type, @entity_id, @tenant_id, @scope_type, @changes::jsonb, @created_at)`,
+			`INSERT INTO audit_logs (id, member_id, member_email, action, resource_type, resource_id, tenant_id, scope_type, changes, created_at)
+			 VALUES (@id, @member_id, @member_email, @action, @resource_type, @resource_id, @tenant_id, @scope_type, @changes::jsonb, @created_at)`,
 			pgx.NamedArgs{
-				"id":          uuid.Must(uuid.NewV7()),
-				"actor_id":    member.ID,
-				"actor_email": member.Email,
-				"action":      domain.AuditCreate,
-				"entity_type": "onboarding",
-				"entity_id":   tenant.ID,
-				"tenant_id":   &tenant.ID,
-				"scope_type":  domain.ScopeGlobal,
-				"changes":     string(changesJSON),
-				"created_at":  now,
+				"id":            uuid.Must(uuid.NewV7()),
+				"member_id":     member.ID,
+				"member_email":  member.Email,
+				"action":        domain.AuditCreate,
+				"resource_type": "onboarding",
+				"resource_id":   tenant.ID,
+				"tenant_id":     &tenant.ID,
+				"scope_type":    domain.ScopeGlobal,
+				"changes":       string(changesJSON),
+				"created_at":    now,
 			},
 		)
 		if auditErr != nil {

--- a/internal/service/onboarding_test.go
+++ b/internal/service/onboarding_test.go
@@ -52,6 +52,7 @@ func (r *mockRow) Scan(dest ...any) error {
 // mockTx with configurable QueryRow for different test scenarios.
 type mockTx struct {
 	queryRowFn func(ctx context.Context, sql string, args ...any) pgx.Row
+	execFn     func(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
 }
 
 func (m *mockTx) Begin(_ context.Context) (pgx.Tx, error) { return &mockTx{}, nil }
@@ -65,7 +66,10 @@ func (m *mockTx) LargeObjects() pgx.LargeObjects                             { r
 func (m *mockTx) Prepare(_ context.Context, _, _ string) (*pgconn.StatementDescription, error) {
 	return nil, nil
 }
-func (m *mockTx) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+func (m *mockTx) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	if m.execFn != nil {
+		return m.execFn(ctx, sql, args...)
+	}
 	return pgconn.NewCommandTag("SELECT 1"), nil
 }
 func (m *mockTx) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) { return nil, nil }
@@ -204,9 +208,9 @@ func (m *mockTenantStoreOnboarding) Purge(ctx context.Context, id uuid.UUID) err
 type mockWorkspaceStoreOnboarding struct {
 	createFn             func(ctx context.Context, ws *domain.Workspace) error
 	getByIDFn            func(ctx context.Context, id uuid.UUID) (*domain.Workspace, error)
-	getByTenantAndCodeFn func(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error)
-	getSystemWorkspaceFn func(ctx context.Context, tenantID uuid.UUID) (*domain.Workspace, error)
-	listByTenantFn       func(ctx context.Context, tenantID uuid.UUID, opts port.ListOptions) ([]*domain.Workspace, string, error)
+	getByTenantAndCodeFn func(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error)
+	getSystemWorkspaceFn func(ctx context.Context, tenantID uuid.UUID, environment domain.Environment) (*domain.Workspace, error)
+	listByTenantFn       func(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, opts port.ListOptions) ([]*domain.Workspace, string, error)
 	updateFn             func(ctx context.Context, ws *domain.Workspace) error
 	softDeleteFn         func(ctx context.Context, id uuid.UUID) error
 }
@@ -217,34 +221,49 @@ func (m *mockWorkspaceStoreOnboarding) Create(ctx context.Context, ws *domain.Wo
 	}
 	return nil
 }
+func (m *mockWorkspaceStoreOnboarding) CreateLogicalPair(ctx context.Context, prod *domain.Workspace, test *domain.Workspace) error {
+	if m.createFn != nil {
+		if err := m.createFn(ctx, prod); err != nil {
+			return err
+		}
+		return m.createFn(ctx, test)
+	}
+	return nil
+}
 func (m *mockWorkspaceStoreOnboarding) GetByID(ctx context.Context, id uuid.UUID) (*domain.Workspace, error) {
 	if m.getByIDFn != nil {
 		return m.getByIDFn(ctx, id)
 	}
 	return nil, nil
 }
-func (m *mockWorkspaceStoreOnboarding) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
+func (m *mockWorkspaceStoreOnboarding) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error) {
 	if m.getByTenantAndCodeFn != nil {
-		return m.getByTenantAndCodeFn(ctx, tenantID, code)
+		return m.getByTenantAndCodeFn(ctx, tenantID, code, environment)
 	}
 	return nil, nil
 }
-func (m *mockWorkspaceStoreOnboarding) GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+func (m *mockWorkspaceStoreOnboarding) GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID, environment domain.Environment) (*domain.Workspace, error) {
 	if m.getSystemWorkspaceFn != nil {
-		return m.getSystemWorkspaceFn(ctx, tenantID)
+		return m.getSystemWorkspaceFn(ctx, tenantID, environment)
 	}
 	return nil, nil
 }
-func (m *mockWorkspaceStoreOnboarding) ListByTenant(ctx context.Context, tenantID uuid.UUID, opts port.ListOptions) ([]*domain.Workspace, string, error) {
+func (m *mockWorkspaceStoreOnboarding) ListByTenant(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, opts port.ListOptions) ([]*domain.Workspace, string, error) {
 	if m.listByTenantFn != nil {
-		return m.listByTenantFn(ctx, tenantID, opts)
+		return m.listByTenantFn(ctx, tenantID, environment, opts)
 	}
 	return nil, "", nil
+}
+func (m *mockWorkspaceStoreOnboarding) UpdateShared(_ context.Context, _ uuid.UUID, _, _, _ string) error {
+	return nil
 }
 func (m *mockWorkspaceStoreOnboarding) Update(ctx context.Context, ws *domain.Workspace) error {
 	if m.updateFn != nil {
 		return m.updateFn(ctx, ws)
 	}
+	return nil
+}
+func (m *mockWorkspaceStoreOnboarding) SoftDeleteLogical(_ context.Context, _ uuid.UUID, _ string) error {
 	return nil
 }
 func (m *mockWorkspaceStoreOnboarding) SoftDelete(ctx context.Context, id uuid.UUID) error {
@@ -374,6 +393,47 @@ func TestOnboardingService_Setup_Success(t *testing.T) {
 	}
 	if result.Workspace.TenantID != result.Tenant.ID {
 		t.Fatal("expected workspace tenant_id to match tenant")
+	}
+}
+
+func TestOnboardingService_Setup_AuditInsertUsesCurrentSchemaColumns(t *testing.T) {
+	var auditInsertSQL string
+	tx := &mockTx{
+		execFn: func(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "INSERT INTO audit_logs") {
+				auditInsertSQL = sql
+			}
+			return pgconn.NewCommandTag("SELECT 1"), nil
+		},
+	}
+
+	ms := &mockMemberStoreOnboarding{}
+	ts := &mockTenantStoreOnboarding{}
+	ws := &mockWorkspaceStoreOnboarding{}
+	as := &mockAuditLogStoreOnboarding{}
+
+	svc := service.NewOnboardingService(&mockTxBeginner{tx: tx}, ms, ts, ws, as)
+
+	req := &service.OnboardingRequest{
+		TenantCode: "acme",
+		TenantName: "Acme",
+	}
+	claims := &port.OIDCClaims{
+		Email:   "owner@example.com",
+		Subject: "oidc-owner",
+	}
+
+	if _, err := svc.Setup(context.Background(), claims, req); err != nil {
+		t.Fatalf("unexpected setup error: %v", err)
+	}
+	if auditInsertSQL == "" {
+		t.Fatal("expected onboarding setup to write an audit log")
+	}
+	if strings.Contains(auditInsertSQL, "actor_id") || strings.Contains(auditInsertSQL, "actor_email") || strings.Contains(auditInsertSQL, "entity_type") {
+		t.Fatalf("expected audit insert to use current schema columns, got %q", auditInsertSQL)
+	}
+	if !strings.Contains(auditInsertSQL, "member_id") || !strings.Contains(auditInsertSQL, "member_email") || !strings.Contains(auditInsertSQL, "resource_type") {
+		t.Fatalf("expected audit insert to reference member/resource columns, got %q", auditInsertSQL)
 	}
 }
 

--- a/internal/service/send.go
+++ b/internal/service/send.go
@@ -232,7 +232,7 @@ func NewSendService(
 // 1. Parse ref → 2. Resolve tenant/workspace → 3. Resolve template →
 // 4. Merge injectors → 5. Resolve adapter → 6. Resolve from_email →
 // 7. Render fields → 8. Create emails → 9. Enqueue jobs
-func (s *SendService) Send(ctx context.Context, req *SendRequest) (*SendResponse, error) { //nolint:gocognit,funlen // multi-step email send orchestration pipeline
+func (s *SendService) Send(ctx context.Context, req *SendRequest) (*SendResponse, error) { //nolint:gocognit,gocyclo,funlen // multi-step email send orchestration pipeline
 	// 1. Parse addressing ref (tenant:workspace:templateType)
 	ref, err := domain.ParseRef(req.Ref)
 	if err != nil {
@@ -245,7 +245,19 @@ func (s *SendService) Send(ctx context.Context, req *SendRequest) (*SendResponse
 		return nil, err
 	}
 
-	ws, err := s.wsStore.GetByTenantAndCode(ctx, tenant.ID, ref.WorkspaceCode)
+	environment := domain.EnvironmentProd
+	if req.AuthWorkspaceID != uuid.Nil {
+		authWorkspace, err := s.wsStore.GetByID(ctx, req.AuthWorkspaceID)
+		if err != nil {
+			return nil, err
+		}
+		environment = authWorkspace.Environment
+		if !environment.Valid() {
+			environment = domain.EnvironmentProd
+		}
+	}
+
+	ws, err := s.wsStore.GetByTenantAndCode(ctx, tenant.ID, ref.WorkspaceCode, environment)
 	if err != nil {
 		return nil, err
 	}
@@ -280,6 +292,7 @@ func (s *SendService) Send(ctx context.Context, req *SendRequest) (*SendResponse
 		req.Ref,
 		req.Variables,
 		tenant.ID, ws.ID,
+		ws.Environment,
 		ref.TemplateType,
 	)
 	injCtx.SetRequestInjectors(req.Injectors)
@@ -335,18 +348,23 @@ func (s *SendService) Send(ctx context.Context, req *SendRequest) (*SendResponse
 	var failCount int
 	var lastErr error
 
-	// Filter CC and BCC through suppression before the recipient loop so that
-	// each email record only carries addresses that are not suppressed.
-	filteredCC, err := s.filterSuppressed(ctx, ws.ID, req.CC)
-	if err != nil {
-		return nil, err
-	}
-	filteredBCC, err := s.filterSuppressed(ctx, ws.ID, req.BCC)
+	effectiveTo, effectiveCC, effectiveBCC, err := applyTestRecipientPolicy(ws, resolved.TemplateType, req.To, req.CC, req.BCC)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, recipient := range req.To {
+	// Filter CC and BCC through suppression before the recipient loop so that
+	// each email record only carries addresses that are not suppressed.
+	filteredCC, err := s.filterSuppressed(ctx, ws.ID, effectiveCC)
+	if err != nil {
+		return nil, err
+	}
+	filteredBCC, err := s.filterSuppressed(ctx, ws.ID, effectiveBCC)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, recipient := range effectiveTo {
 		// Check suppression
 		suppressed, reason, err := s.suppression.IsSuppressed(ctx, ws.ID, recipient)
 		if err != nil {
@@ -432,7 +450,7 @@ func (s *SendService) Send(ctx context.Context, req *SendRequest) (*SendResponse
 	}
 
 	// If ALL recipients failed, return the last error.
-	if failCount == len(req.To) {
+	if failCount == len(effectiveTo) {
 		return nil, fmt.Errorf("all recipients failed: %w", lastErr)
 	}
 
@@ -449,6 +467,42 @@ func effectiveSendSource(source SendSource) SendSource {
 		source.Type = domain.EmailSourceTypeDataPlaneAPIKey
 	}
 	return source
+}
+
+func applyTestRecipientPolicy(
+	ws *domain.Workspace,
+	templateType *domain.TemplateType,
+	to []string,
+	cc []string,
+	bcc []string,
+) ([]string, []string, []string, error) {
+	if ws == nil || ws.Environment != domain.EnvironmentTest {
+		return to, cc, bcc, nil
+	}
+
+	mode := ws.TestRecipientMode
+	if !mode.Valid() {
+		mode = domain.TestRecipientModeReplace
+	}
+	recipients := domain.NormalizeRecipientAddresses(ws.TestRecipientAddresses)
+
+	if templateType != nil && templateType.TestRecipientMode != nil && templateType.TestRecipientMode.Valid() {
+		mode = *templateType.TestRecipientMode
+		recipients = domain.NormalizeRecipientAddresses(templateType.TestRecipientAddresses)
+	}
+
+	if len(recipients) == 0 {
+		return nil, nil, nil, domain.ErrTestRecipientPolicyUnconfigured
+	}
+
+	switch mode {
+	case domain.TestRecipientModeAppend:
+		return append(domain.NormalizeRecipientAddresses(to), recipients...), cc, bcc, nil
+	case domain.TestRecipientModeReplace:
+		fallthrough
+	default:
+		return recipients, nil, nil, nil
+	}
 }
 
 // resolveFromEmail gets the from_email. If senderIdentityID is set, uses that specific identity;

--- a/internal/service/send_test.go
+++ b/internal/service/send_test.go
@@ -43,39 +43,48 @@ func (m *mockTenantStoreSend) SoftDelete(_ context.Context, _ uuid.UUID) error  
 func (m *mockTenantStoreSend) Purge(_ context.Context, _ uuid.UUID) error       { return nil }
 
 type mockWorkspaceStoreSend struct {
-	getByTenantAndCodeFn func(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error)
+	getByTenantAndCodeFn func(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error)
 	getByIDFn            func(ctx context.Context, id uuid.UUID) (*domain.Workspace, error)
-	getSystemWorkspaceFn func(ctx context.Context, tenantID uuid.UUID) (*domain.Workspace, error)
-	listByTenantFn       func(ctx context.Context, tenantID uuid.UUID, opts port.ListOptions) ([]*domain.Workspace, string, error)
+	getSystemWorkspaceFn func(ctx context.Context, tenantID uuid.UUID, environment domain.Environment) (*domain.Workspace, error)
+	listByTenantFn       func(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, opts port.ListOptions) ([]*domain.Workspace, string, error)
 }
 
 func (m *mockWorkspaceStoreSend) Create(_ context.Context, _ *domain.Workspace) error { return nil }
+func (m *mockWorkspaceStoreSend) CreateLogicalPair(_ context.Context, _ *domain.Workspace, _ *domain.Workspace) error {
+	return nil
+}
 func (m *mockWorkspaceStoreSend) GetByID(ctx context.Context, id uuid.UUID) (*domain.Workspace, error) {
 	if m.getByIDFn != nil {
 		return m.getByIDFn(ctx, id)
 	}
 	return nil, domain.ErrNotFound
 }
-func (m *mockWorkspaceStoreSend) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
+func (m *mockWorkspaceStoreSend) GetByTenantAndCode(ctx context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error) {
 	if m.getByTenantAndCodeFn != nil {
-		return m.getByTenantAndCodeFn(ctx, tenantID, code)
+		return m.getByTenantAndCodeFn(ctx, tenantID, code, environment)
 	}
 	return nil, domain.ErrNotFound
 }
-func (m *mockWorkspaceStoreSend) GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+func (m *mockWorkspaceStoreSend) GetSystemWorkspace(ctx context.Context, tenantID uuid.UUID, environment domain.Environment) (*domain.Workspace, error) {
 	if m.getSystemWorkspaceFn != nil {
-		return m.getSystemWorkspaceFn(ctx, tenantID)
+		return m.getSystemWorkspaceFn(ctx, tenantID, environment)
 	}
 	return nil, domain.ErrNotFound
 }
-func (m *mockWorkspaceStoreSend) ListByTenant(ctx context.Context, tenantID uuid.UUID, opts port.ListOptions) ([]*domain.Workspace, string, error) {
+func (m *mockWorkspaceStoreSend) ListByTenant(ctx context.Context, tenantID uuid.UUID, environment domain.Environment, opts port.ListOptions) ([]*domain.Workspace, string, error) {
 	if m.listByTenantFn != nil {
-		return m.listByTenantFn(ctx, tenantID, opts)
+		return m.listByTenantFn(ctx, tenantID, environment, opts)
 	}
 	return nil, "", nil
 }
+func (m *mockWorkspaceStoreSend) UpdateShared(_ context.Context, _ uuid.UUID, _, _, _ string) error {
+	return nil
+}
 func (m *mockWorkspaceStoreSend) Update(_ context.Context, _ *domain.Workspace) error { return nil }
-func (m *mockWorkspaceStoreSend) SoftDelete(_ context.Context, _ uuid.UUID) error     { return nil }
+func (m *mockWorkspaceStoreSend) SoftDeleteLogical(_ context.Context, _ uuid.UUID, _ string) error {
+	return nil
+}
+func (m *mockWorkspaceStoreSend) SoftDelete(_ context.Context, _ uuid.UUID) error { return nil }
 
 type mockEmailStoreSend struct {
 	createFn   func(ctx context.Context, email *domain.Email) error
@@ -100,6 +109,7 @@ func (m *mockEmailStoreSend) GetByTrackingID(_ context.Context, _ string) (*doma
 func (m *mockEmailStoreSend) GetByProviderMessageID(_ context.Context, _ string) (*domain.Email, error) {
 	return nil, nil
 }
+func (m *mockEmailStoreSend) PurgeWorkspaceRuntime(_ context.Context, _ uuid.UUID) error { return nil }
 func (m *mockEmailStoreSend) UpdateStatus(_ context.Context, _ uuid.UUID, _, _ domain.EmailStatus) error {
 	return nil
 }
@@ -517,21 +527,50 @@ func newSendFixture() *sendTestFixture {
 	}
 
 	f.wsStore = &mockWorkspaceStoreSend{
-		getByTenantAndCodeFn: func(_ context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
+		getByTenantAndCodeFn: func(_ context.Context, tenantID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 			if tenantID == f.tenantID && code == "acme" {
-				return &domain.Workspace{ID: f.workspaceID, TenantID: f.tenantID, Code: "acme", Name: "Acme"}, nil
+				return &domain.Workspace{
+					ID:          f.workspaceID,
+					TenantID:    f.tenantID,
+					Code:        "acme",
+					Name:        "Acme",
+					Environment: domain.EnvironmentProd,
+				}, nil
 			}
 			return nil, domain.ErrNotFound
 		},
 		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Workspace, error) {
 			if id == f.workspaceID {
-				return &domain.Workspace{ID: f.workspaceID, TenantID: f.tenantID, Code: "acme", Name: "Acme"}, nil
+				return &domain.Workspace{
+					ID:          f.workspaceID,
+					TenantID:    f.tenantID,
+					Code:        "acme",
+					Name:        "Acme",
+					Environment: domain.EnvironmentProd,
+				}, nil
+			}
+			if id == f.sysWSID {
+				return &domain.Workspace{
+					ID:          f.sysWSID,
+					TenantID:    f.tenantID,
+					Code:        "_system",
+					Name:        "System",
+					IsSystem:    true,
+					Environment: domain.EnvironmentProd,
+				}, nil
 			}
 			return nil, domain.ErrNotFound
 		},
-		getSystemWorkspaceFn: func(_ context.Context, tenantID uuid.UUID) (*domain.Workspace, error) {
+		getSystemWorkspaceFn: func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 			if tenantID == f.tenantID {
-				return &domain.Workspace{ID: f.sysWSID, TenantID: f.tenantID, Code: "_system", Name: "System", IsSystem: true}, nil
+				return &domain.Workspace{
+					ID:          f.sysWSID,
+					TenantID:    f.tenantID,
+					Code:        "_system",
+					Name:        "System",
+					IsSystem:    true,
+					Environment: domain.EnvironmentProd,
+				}, nil
 			}
 			return nil, domain.ErrNotFound
 		},
@@ -888,7 +927,7 @@ func TestSendService_TenantNotFound(t *testing.T) {
 
 func TestSendService_WorkspaceNotFound(t *testing.T) {
 	f := newSendFixture()
-	f.wsStore.getByTenantAndCodeFn = func(_ context.Context, _ uuid.UUID, _ string) (*domain.Workspace, error) {
+	f.wsStore.getByTenantAndCodeFn = func(_ context.Context, _ uuid.UUID, _ string, _ domain.Environment) (*domain.Workspace, error) {
 		return nil, domain.ErrNotFound
 	}
 
@@ -1456,10 +1495,33 @@ func TestSendService_QueuedEvent_MultipleRecipients(t *testing.T) {
 
 func TestSendService_ScopeMismatch(t *testing.T) {
 	f := newSendFixture()
+	otherWorkspaceID := uuid.Must(uuid.NewV7())
+	f.wsStore.getByIDFn = func(_ context.Context, id uuid.UUID) (*domain.Workspace, error) {
+		switch id {
+		case f.workspaceID:
+			return &domain.Workspace{
+				ID:          f.workspaceID,
+				TenantID:    f.tenantID,
+				Code:        "acme",
+				Name:        "Acme",
+				Environment: domain.EnvironmentProd,
+			}, nil
+		case otherWorkspaceID:
+			return &domain.Workspace{
+				ID:          otherWorkspaceID,
+				TenantID:    f.tenantID,
+				Code:        "other",
+				Name:        "Other",
+				Environment: domain.EnvironmentProd,
+			}, nil
+		default:
+			return nil, domain.ErrNotFound
+		}
+	}
 	svc := f.buildService()
 
 	req := f.happyRequest()
-	req.AuthWorkspaceID = uuid.Must(uuid.NewV7())
+	req.AuthWorkspaceID = otherWorkspaceID
 
 	_, err := svc.Send(context.Background(), req)
 	if err == nil {
@@ -1485,7 +1547,7 @@ func TestSendService_ScopeMatch(t *testing.T) {
 
 func TestSendService_SystemWorkspaceBlocked(t *testing.T) {
 	f := newSendFixture()
-	f.wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string) (*domain.Workspace, error) {
+	f.wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID == f.tenantID && code == "_system" {
 			return &domain.Workspace{
 				ID:       f.sysWSID,
@@ -1509,6 +1571,213 @@ func TestSendService_SystemWorkspaceBlocked(t *testing.T) {
 	}
 	if !errors.Is(err, domain.ErrSystemWorkspaceBlocked) {
 		t.Fatalf("expected ErrSystemWorkspaceBlocked, got %v", err)
+	}
+}
+
+func TestSendService_TestEnvironmentWorkspaceRecipientPolicyReplace(t *testing.T) {
+	f := newSendFixture()
+	f.wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error) {
+		if tenantID == f.tenantID && code == "acme" && environment == domain.EnvironmentTest {
+			return &domain.Workspace{
+				ID:                     f.workspaceID,
+				TenantID:               f.tenantID,
+				Code:                   "acme",
+				Name:                   "Acme",
+				Environment:            domain.EnvironmentTest,
+				TestRecipientMode:      domain.TestRecipientModeReplace,
+				TestRecipientAddresses: []string{"qa@example.com"},
+			}, nil
+		}
+		return nil, domain.ErrNotFound
+	}
+	f.wsStore.getByIDFn = func(_ context.Context, id uuid.UUID) (*domain.Workspace, error) {
+		if id == f.workspaceID {
+			return &domain.Workspace{
+				ID:          f.workspaceID,
+				TenantID:    f.tenantID,
+				Code:        "acme",
+				Name:        "Acme",
+				Environment: domain.EnvironmentTest,
+			}, nil
+		}
+		return nil, domain.ErrNotFound
+	}
+
+	svc := f.buildService()
+	req := f.happyRequest()
+	req.AuthWorkspaceID = f.workspaceID
+	req.To = []string{"real.user@example.com"}
+	req.CC = []string{"cc@example.com"}
+	req.BCC = []string{"bcc@example.com"}
+
+	resp, err := svc.Send(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.TrackingIDs) != 1 {
+		t.Fatalf("expected 1 tracking entry, got %d", len(resp.TrackingIDs))
+	}
+	if len(f.emailStore.emails) != 1 {
+		t.Fatalf("expected 1 persisted email, got %d", len(f.emailStore.emails))
+	}
+	if got := f.emailStore.emails[0].RecipientEmail; got != "qa@example.com" {
+		t.Fatalf("expected replaced recipient qa@example.com, got %s", got)
+	}
+	if len(f.emailStore.emails[0].CC) != 0 || len(f.emailStore.emails[0].BCC) != 0 {
+		t.Fatalf("expected replace mode to clear CC/BCC, got CC=%v BCC=%v", f.emailStore.emails[0].CC, f.emailStore.emails[0].BCC)
+	}
+}
+
+func TestSendService_TestEnvironmentWorkspaceRecipientPolicyAppend(t *testing.T) {
+	f := newSendFixture()
+	f.wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error) {
+		if tenantID == f.tenantID && code == "acme" && environment == domain.EnvironmentTest {
+			return &domain.Workspace{
+				ID:                     f.workspaceID,
+				TenantID:               f.tenantID,
+				Code:                   "acme",
+				Name:                   "Acme",
+				Environment:            domain.EnvironmentTest,
+				TestRecipientMode:      domain.TestRecipientModeAppend,
+				TestRecipientAddresses: []string{"qa@example.com"},
+			}, nil
+		}
+		return nil, domain.ErrNotFound
+	}
+	f.wsStore.getByIDFn = func(_ context.Context, id uuid.UUID) (*domain.Workspace, error) {
+		if id == f.workspaceID {
+			return &domain.Workspace{
+				ID:          f.workspaceID,
+				TenantID:    f.tenantID,
+				Code:        "acme",
+				Name:        "Acme",
+				Environment: domain.EnvironmentTest,
+			}, nil
+		}
+		return nil, domain.ErrNotFound
+	}
+
+	svc := f.buildService()
+	req := f.happyRequest()
+	req.AuthWorkspaceID = f.workspaceID
+	req.To = []string{"real.user@example.com"}
+
+	_, err := svc.Send(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.emailStore.emails) != 2 {
+		t.Fatalf("expected 2 persisted emails, got %d", len(f.emailStore.emails))
+	}
+	if got := f.emailStore.emails[0].RecipientEmail; got != "real.user@example.com" {
+		t.Fatalf("expected original recipient first, got %s", got)
+	}
+	if got := f.emailStore.emails[1].RecipientEmail; got != "qa@example.com" {
+		t.Fatalf("expected appended recipient qa@example.com, got %s", got)
+	}
+}
+
+func TestSendService_TestEnvironmentTemplateTypeRecipientPolicyOverride(t *testing.T) {
+	f := newSendFixture()
+	f.wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error) {
+		if tenantID == f.tenantID && code == "acme" && environment == domain.EnvironmentTest {
+			return &domain.Workspace{
+				ID:                     f.workspaceID,
+				TenantID:               f.tenantID,
+				Code:                   "acme",
+				Name:                   "Acme",
+				Environment:            domain.EnvironmentTest,
+				TestRecipientMode:      domain.TestRecipientModeAppend,
+				TestRecipientAddresses: []string{"workspace@example.com"},
+			}, nil
+		}
+		return nil, domain.ErrNotFound
+	}
+	f.wsStore.getByIDFn = func(_ context.Context, id uuid.UUID) (*domain.Workspace, error) {
+		if id == f.workspaceID {
+			return &domain.Workspace{
+				ID:          f.workspaceID,
+				TenantID:    f.tenantID,
+				Code:        "acme",
+				Name:        "Acme",
+				Environment: domain.EnvironmentTest,
+			}, nil
+		}
+		return nil, domain.ErrNotFound
+	}
+	f.templateStore.getTypeBySlugFn = func(_ context.Context, slug string, _ []uuid.NullUUID) (*domain.TemplateType, error) {
+		if slug == "welcome" {
+			overrideMode := domain.TestRecipientModeReplace
+			return &domain.TemplateType{
+				ID:                     f.typeID,
+				Slug:                   "welcome",
+				Name:                   "Welcome Email",
+				AdapterID:              &f.adapterID,
+				TestRecipientMode:      &overrideMode,
+				TestRecipientAddresses: []string{"template@example.com"},
+			}, nil
+		}
+		return nil, domain.ErrTemplateTypeNotFound
+	}
+
+	svc := f.buildService()
+	req := f.happyRequest()
+	req.AuthWorkspaceID = f.workspaceID
+	req.To = []string{"real.user@example.com"}
+
+	_, err := svc.Send(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.emailStore.emails) != 1 {
+		t.Fatalf("expected 1 persisted email, got %d", len(f.emailStore.emails))
+	}
+	if got := f.emailStore.emails[0].RecipientEmail; got != "template@example.com" {
+		t.Fatalf("expected template override recipient, got %s", got)
+	}
+}
+
+func TestSendService_TestEnvironmentWithoutConfiguredPolicyFailsClosed(t *testing.T) {
+	f := newSendFixture()
+	f.wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, environment domain.Environment) (*domain.Workspace, error) {
+		if tenantID == f.tenantID && code == "acme" && environment == domain.EnvironmentTest {
+			return &domain.Workspace{
+				ID:                f.workspaceID,
+				TenantID:          f.tenantID,
+				Code:              "acme",
+				Name:              "Acme",
+				Environment:       domain.EnvironmentTest,
+				TestRecipientMode: domain.TestRecipientModeReplace,
+			}, nil
+		}
+		return nil, domain.ErrNotFound
+	}
+	f.wsStore.getByIDFn = func(_ context.Context, id uuid.UUID) (*domain.Workspace, error) {
+		if id == f.workspaceID {
+			return &domain.Workspace{
+				ID:          f.workspaceID,
+				TenantID:    f.tenantID,
+				Code:        "acme",
+				Name:        "Acme",
+				Environment: domain.EnvironmentTest,
+			}, nil
+		}
+		return nil, domain.ErrNotFound
+	}
+
+	svc := f.buildService()
+	req := f.happyRequest()
+	req.AuthWorkspaceID = f.workspaceID
+	req.To = []string{"real.user@example.com"}
+	req.CC = []string{"cc@example.com"}
+	req.BCC = []string{"bcc@example.com"}
+
+	_, err := svc.Send(context.Background(), req)
+	if !errors.Is(err, domain.ErrTestRecipientPolicyUnconfigured) {
+		t.Fatalf("expected ErrTestRecipientPolicyUnconfigured, got %v", err)
+	}
+	if len(f.emailStore.emails) != 0 {
+		t.Fatalf("expected no persisted emails when policy is missing, got %d", len(f.emailStore.emails))
 	}
 }
 

--- a/internal/service/template_type.go
+++ b/internal/service/template_type.go
@@ -25,7 +25,18 @@ func NewTemplateTypeService(store port.TemplateTypeStore) *TemplateTypeService {
 }
 
 // Create creates a new template type scoped to a workspace (or global if wsID is nil).
-func (s *TemplateTypeService) Create(ctx context.Context, slug, name string, description *string, adapterID, senderIdentityID *uuid.UUID, variableSchema map[string]any, wsID *uuid.UUID) (*domain.TemplateType, error) {
+func (s *TemplateTypeService) Create(
+	ctx context.Context,
+	slug string,
+	name string,
+	description *string,
+	adapterID *uuid.UUID,
+	senderIdentityID *uuid.UUID,
+	variableSchema map[string]any,
+	testRecipientMode *domain.TestRecipientMode,
+	testRecipientAddresses []string,
+	wsID *uuid.UUID,
+) (*domain.TemplateType, error) {
 	existing, err := s.store.FindTypeBySlugInScope(ctx, slug, wsID)
 	if err != nil && !isNotFoundErr(err) {
 		return nil, err
@@ -44,6 +55,8 @@ func (s *TemplateTypeService) Create(ctx context.Context, slug, name string, des
 		AdapterID:        adapterID,
 		SenderIdentityID: senderIdentityID,
 		VariableSchema:   variableSchema,
+		TestRecipientMode: testRecipientMode,
+		TestRecipientAddresses: append([]string(nil), testRecipientAddresses...),
 		CreatedAt:        now,
 		UpdatedAt:        now,
 	}

--- a/internal/service/template_type_test.go
+++ b/internal/service/template_type_test.go
@@ -26,7 +26,7 @@ func TestTemplateTypeService_Create_Success(t *testing.T) {
 
 	wsID := uuid.Must(uuid.NewV7())
 	desc := "Welcome emails"
-	tt, err := svc.Create(context.Background(), "welcome-email", "Welcome Email", &desc, nil, nil, nil, &wsID)
+	tt, err := svc.Create(context.Background(), "welcome-email", "Welcome Email", &desc, nil, nil, nil, nil, nil, &wsID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestTemplateTypeService_Create_Global(t *testing.T) {
 
 	svc := service.NewTemplateTypeService(store)
 
-	tt, err := svc.Create(context.Background(), "password-reset", "Password Reset", nil, nil, nil, nil, nil)
+	tt, err := svc.Create(context.Background(), "password-reset", "Password Reset", nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestTemplateTypeService_Create_DuplicateSlug(t *testing.T) {
 
 	svc := service.NewTemplateTypeService(store)
 
-	_, err := svc.Create(context.Background(), "welcome-email", "Welcome", nil, nil, nil, nil, nil)
+	_, err := svc.Create(context.Background(), "welcome-email", "Welcome", nil, nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for duplicate slug")
 	}
@@ -100,7 +100,7 @@ func TestTemplateTypeService_Create_StoreError(t *testing.T) {
 
 	svc := service.NewTemplateTypeService(store)
 
-	_, err := svc.Create(context.Background(), "test-type", "Test", nil, nil, nil, nil, nil)
+	_, err := svc.Create(context.Background(), "test-type", "Test", nil, nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -124,7 +124,7 @@ func TestTemplateTypeService_Create_WithAdapterAndSchema(t *testing.T) {
 	adapterID := uuid.Must(uuid.NewV7())
 	schema := map[string]any{"type": "object", "properties": map[string]any{"name": map[string]any{"type": "string"}}}
 
-	tt, err := svc.Create(context.Background(), "invoice", "Invoice", nil, &adapterID, nil, schema, nil)
+	tt, err := svc.Create(context.Background(), "invoice", "Invoice", nil, &adapterID, nil, schema, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/service/test_send.go
+++ b/internal/service/test_send.go
@@ -188,7 +188,7 @@ func (s *TestSendService) resolveInjectors(
 		return nil, nil
 	}
 	if workspaceID == nil {
-		injCtx := port.NewInjectorContext(req.Headers, "global::"+templateTypeSlug, req.Variables, uuid.Nil, uuid.Nil, templateTypeSlug)
+		injCtx := port.NewInjectorContext(req.Headers, "global::"+templateTypeSlug, req.Variables, uuid.Nil, uuid.Nil, domain.EnvironmentProd, templateTypeSlug)
 		injCtx.SetRequestInjectors(req.Injectors)
 		injectors, err := s.injectorMerger.ResolveGlobalWithContext(ctx, injCtx)
 		if err != nil {
@@ -212,7 +212,7 @@ func (s *TestSendService) resolveInjectors(
 	}
 
 	ref := fmt.Sprintf("%s:%s:%s", tenant.Code, workspace.Code, templateTypeSlug)
-	injCtx := port.NewInjectorContext(req.Headers, ref, req.Variables, tenant.ID, workspace.ID, templateTypeSlug)
+	injCtx := port.NewInjectorContext(req.Headers, ref, req.Variables, tenant.ID, workspace.ID, workspace.Environment, templateTypeSlug)
 	injCtx.SetRequestInjectors(req.Injectors)
 
 	injectors, err := s.injectorMerger.ResolveWithContext(ctx, workspace.ID, injCtx)

--- a/internal/service/test_send_test.go
+++ b/internal/service/test_send_test.go
@@ -138,7 +138,7 @@ func TestTestSendService_ResolvesInjectorsWithRequestCodeAndDefaultPrecedence(t 
 			}
 			return &domain.Workspace{ID: workspaceID, TenantID: tenantID, Code: "main", Name: "Main"}, nil
 		},
-		getSystemWorkspaceFn: func(_ context.Context, gotTenantID uuid.UUID) (*domain.Workspace, error) {
+		getSystemWorkspaceFn: func(_ context.Context, gotTenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 			if gotTenantID != tenantID {
 				t.Fatalf("unexpected tenant id %s", gotTenantID)
 			}

--- a/migrations/000040_workspace_environments.down.sql
+++ b/migrations/000040_workspace_environments.down.sql
@@ -1,0 +1,32 @@
+ALTER TABLE api_keys
+    ALTER COLUMN key_prefix SET DEFAULT 'senda_live';
+
+DROP INDEX IF EXISTS idx_workspaces_logical_workspace;
+DROP INDEX IF EXISTS idx_workspaces_active_code_lookup;
+DROP INDEX IF EXISTS idx_workspaces_code;
+
+ALTER TABLE workspaces
+    DROP CONSTRAINT IF EXISTS workspaces_one_system_per_tenant_environment,
+    DROP CONSTRAINT IF EXISTS workspaces_code_per_tenant_environment,
+    DROP CONSTRAINT IF EXISTS workspaces_environment_valid;
+
+DELETE FROM workspaces
+WHERE environment = 'test';
+
+ALTER TABLE workspaces
+    DROP COLUMN IF EXISTS environment,
+    DROP COLUMN IF EXISTS logical_workspace_id;
+
+ALTER TABLE workspaces
+    ADD CONSTRAINT workspaces_code_per_tenant UNIQUE (tenant_id, code),
+    ADD CONSTRAINT workspaces_one_system_per_tenant
+        EXCLUDE USING btree (tenant_id WITH =)
+        WHERE (is_system = true AND deleted_at IS NULL);
+
+CREATE INDEX idx_workspaces_code
+    ON workspaces (tenant_id, code)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX idx_workspaces_active_code_lookup
+    ON workspaces (tenant_id, code)
+    WHERE deleted_at IS NULL AND is_active = true;

--- a/migrations/000040_workspace_environments.up.sql
+++ b/migrations/000040_workspace_environments.up.sql
@@ -1,0 +1,82 @@
+ALTER TABLE workspaces
+    ADD COLUMN logical_workspace_id UUID,
+    ADD COLUMN environment VARCHAR(10);
+
+UPDATE workspaces
+SET logical_workspace_id = id
+WHERE logical_workspace_id IS NULL;
+
+UPDATE workspaces
+SET environment = 'prod'
+WHERE environment IS NULL;
+
+ALTER TABLE workspaces
+    DROP CONSTRAINT workspaces_code_per_tenant,
+    DROP CONSTRAINT workspaces_one_system_per_tenant;
+
+DROP INDEX IF EXISTS idx_workspaces_code;
+DROP INDEX IF EXISTS idx_workspaces_active_code_lookup;
+
+INSERT INTO workspaces (
+    id,
+    logical_workspace_id,
+    tenant_id,
+    code,
+    name,
+    environment,
+    is_system,
+    is_active,
+    open_tracking_enabled,
+    default_locale,
+    allow_workspace_local_templates,
+    allow_workspace_inherited_template_forks,
+    allow_workspace_local_injectors,
+    created_at,
+    updated_at,
+    deleted_at
+)
+SELECT
+    gen_random_uuid(),
+    logical_workspace_id,
+    tenant_id,
+    code,
+    name,
+    'test',
+    is_system,
+    is_active,
+    open_tracking_enabled,
+    default_locale,
+    allow_workspace_local_templates,
+    allow_workspace_inherited_template_forks,
+    allow_workspace_local_injectors,
+    created_at,
+    updated_at,
+    deleted_at
+FROM workspaces
+WHERE environment = 'prod';
+
+ALTER TABLE workspaces
+    ALTER COLUMN logical_workspace_id SET NOT NULL,
+    ALTER COLUMN environment SET NOT NULL;
+
+ALTER TABLE workspaces
+    ADD CONSTRAINT workspaces_environment_valid CHECK (environment IN ('prod', 'test')),
+    ADD CONSTRAINT workspaces_code_per_tenant_environment UNIQUE (tenant_id, code, environment),
+    ADD CONSTRAINT workspaces_one_system_per_tenant_environment
+        EXCLUDE USING btree (tenant_id WITH =, environment WITH =)
+        WHERE (is_system = true AND deleted_at IS NULL);
+
+CREATE INDEX idx_workspaces_code
+    ON workspaces (tenant_id, code, environment)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX idx_workspaces_active_code_lookup
+    ON workspaces (tenant_id, code, environment)
+    WHERE deleted_at IS NULL AND is_active = true;
+
+CREATE INDEX idx_workspaces_logical_workspace
+    ON workspaces (logical_workspace_id, environment)
+    WHERE deleted_at IS NULL;
+
+ALTER TABLE api_keys
+    ALTER COLUMN key_prefix SET DEFAULT 'senda_prod';

--- a/migrations/000041_test_recipient_policies.down.sql
+++ b/migrations/000041_test_recipient_policies.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE template_types
+    DROP CONSTRAINT IF EXISTS template_types_test_recipient_mode_check,
+    DROP COLUMN IF EXISTS test_recipient_addresses,
+    DROP COLUMN IF EXISTS test_recipient_mode;
+
+ALTER TABLE workspaces
+    DROP CONSTRAINT IF EXISTS workspaces_test_recipient_mode_check,
+    DROP COLUMN IF EXISTS test_recipient_addresses,
+    DROP COLUMN IF EXISTS test_recipient_mode;

--- a/migrations/000041_test_recipient_policies.up.sql
+++ b/migrations/000041_test_recipient_policies.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE workspaces
+    ADD COLUMN test_recipient_mode VARCHAR(16) NOT NULL DEFAULT 'replace',
+    ADD COLUMN test_recipient_addresses TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    ADD CONSTRAINT workspaces_test_recipient_mode_check
+        CHECK (test_recipient_mode IN ('replace', 'append'));
+
+ALTER TABLE template_types
+    ADD COLUMN test_recipient_mode VARCHAR(16),
+    ADD COLUMN test_recipient_addresses TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    ADD CONSTRAINT template_types_test_recipient_mode_check
+        CHECK (test_recipient_mode IS NULL OR test_recipient_mode IN ('replace', 'append'));

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rendis/senda/internal/domain"
 	"github.com/rendis/senda/sdk"
 )
 
@@ -91,7 +92,7 @@ func TestEngineFluentAPI(t *testing.T) {
 }
 
 func TestInjectorContext_NilHeaders(t *testing.T) {
-	ctx := sdk.NewInjectorContext(nil, "", nil, [16]byte{}, [16]byte{}, "")
+	ctx := sdk.NewInjectorContext(nil, "", nil, [16]byte{}, [16]byte{}, domain.EnvironmentProd, "")
 
 	// Should not panic.
 	if got := ctx.Header("X-Anything"); got != "" {
@@ -106,7 +107,7 @@ func TestInjectorContext_NilHeaders(t *testing.T) {
 
 func TestInjectorContext_HeadersCopy(t *testing.T) {
 	original := map[string]string{"Key": "value"}
-	ctx := sdk.NewInjectorContext(original, "", nil, [16]byte{}, [16]byte{}, "")
+	ctx := sdk.NewInjectorContext(original, "", nil, [16]byte{}, [16]byte{}, domain.EnvironmentProd, "")
 
 	// Modify the returned copy.
 	copy := ctx.Headers()
@@ -123,7 +124,7 @@ func TestInjectorContext_HeadersCopy(t *testing.T) {
 }
 
 func TestInjectorContext_Concurrency(t *testing.T) {
-	ctx := sdk.NewInjectorContext(nil, "ref", nil, [16]byte{1}, [16]byte{2}, "type")
+	ctx := sdk.NewInjectorContext(nil, "ref", nil, [16]byte{1}, [16]byte{2}, domain.EnvironmentProd, "type")
 
 	done := make(chan struct{})
 	go func() {
@@ -148,6 +149,7 @@ func TestInjectorContext(t *testing.T) {
 		"tenant:workspace:welcome",
 		map[string]any{"name": "Jane"},
 		[16]byte{1}, [16]byte{2},
+		domain.EnvironmentProd,
 		"welcome",
 	)
 
@@ -166,6 +168,9 @@ func TestInjectorContext(t *testing.T) {
 
 	if got := ctx.TemplateType(); got != "welcome" {
 		t.Errorf("TemplateType() = %q, want %q", got, "welcome")
+	}
+	if got := ctx.Environment(); got != domain.EnvironmentProd {
+		t.Errorf("Environment() = %q, want %q", got, domain.EnvironmentProd)
 	}
 
 	// InitData starts nil.

--- a/skills/senda/SKILL.md
+++ b/skills/senda/SKILL.md
@@ -1,318 +1,214 @@
 ---
 name: senda
 description: >-
-  Interact with the Senda email orchestration API via MCP tools.
-  Manage tenants, workspaces, members, email adapters, templates,
-  injectors, webhooks, API keys, and send emails.
-  Trigger: When working with senda, email orchestration, email templates,
-  email sending, or managing email provider adapters.
+  Operate and extend the Senda email orchestration platform via MCP and the Go SDK.
+  Use this skill when working with tenants, workspaces, templates, injectors, adapters,
+  external integrations, API keys, or when embedding Senda as a library from another repo.
 allowed-tools:
   - mcp__senda__*
 ---
 
-# Senda MCP
+# Senda
 
-MCP integration for Senda — a multi-tenant email orchestration platform with MJML templates, provider abstraction (SES, Gmail, SMTP), RBAC, audit trails, and webhooks.
+Operational skill for agents working with **Senda** as a product API **and** as an embeddable Go library.
 
-Uses [mcp-openapi-proxy](https://github.com/rendis/mcp-openapi-proxy) to auto-generate MCP tools from the OpenAPI spec. Each API endpoint becomes a callable tool.
+This skill is intentionally self-contained. Do not depend on repo docs to understand the platform.
+If you need deeper detail, load the bundled references from this skill package.
 
-**Repository**: https://github.com/rendis/senda
-**Install proxy**: `go install github.com/rendis/mcp-openapi-proxy/cmd/mcp-openapi-proxy@latest`
+## What Senda is
 
-## Setup
+Senda is a multi-tenant email orchestration platform with four operational surfaces:
 
-### Claude Code
+1. **Management plane** — OIDC-authenticated CRUD for tenants, workspaces, templates, injectors, adapters, API keys, policies, and configuration.
+2. **Data plane** — workspace-scoped sending and email query using raw API keys.
+3. **External integration surface** — embeddable builder/editor APIs protected by custom auth methods and workspace resolvers.
+4. **Go SDK / embedder mode** — register code injectors, per-request init, external auth methods, external workspace resolvers, and lifecycle hooks.
 
-The project includes `.mcp.json` — Claude Code auto-detects it. No manual setup needed.
+## Use this skill when
 
-```bash
-make dev          # Start API on port 8081 (docker-compose: postgres + keycloak + senda)
-# MCP auto-configured via .mcp.json
-```
+- operating Senda through MCP tools
+- creating or managing tenants, workspaces, templates, template versions, adapters, injectors, API keys, webhooks, or members
+- sending emails or querying delivery/event history
+- working with workspace environments `prod` / `test`
+- integrating an external builder or portal against Senda
+- embedding Senda in another Go repo and registering extensions
 
-Verify: `claude mcp list` → should show `senda` connected.
+## Mental model
 
-### OpenAI Codex
+### Scope hierarchy
 
-Edit `~/.codex/config.toml`:
+Resolution is hierarchical:
 
-```toml
-[mcp_servers.senda]
-command = "mcp-openapi-proxy"
-args = []
+`global -> tenant -> tenant _system workspace -> workspace`
 
-[mcp_servers.senda.env]
-MCP_SPEC = "https://raw.githubusercontent.com/rendis/senda/main/cmd/senda/docs/openapi.yaml"
-MCP_BASE_URL = "<your-api-url>"
-MCP_TOOL_PREFIX = "senda"
-```
+Key rules:
 
-### Gemini CLI
+- `_system` is a special workspace owned by a tenant and used for tenant-wide defaults and selective sharing.
+- Regular workspaces can inherit from `_system` and global.
+- Resolution is generally **workspace > _system > global**.
+- Shared resources are not the same as owned resources. Track whether something is owned, inherited, or shared.
 
-Edit `~/.gemini/settings.json` (global) or `.gemini/settings.json` (project):
+For the detailed inheritance and sharing rules, load:
+- `references/resolution-and-inheritance.md`
 
-```json
-{
-  "mcpServers": {
-    "senda": {
-      "command": "mcp-openapi-proxy",
-      "args": [],
-      "env": {
-        "MCP_SPEC": "https://raw.githubusercontent.com/rendis/senda/main/cmd/senda/docs/openapi.yaml",
-        "MCP_BASE_URL": "<your-api-url>",
-        "MCP_TOOL_PREFIX": "senda"
-      }
-    }
-  }
-}
-```
+### Environment model
 
-### OIDC Authentication (production)
+Each logical workspace has two operational environments:
 
-```bash
-mcp-openapi-proxy login     # browser-based OIDC PKCE login
-mcp-openapi-proxy status    # check auth status
-mcp-openapi-proxy logout    # clear stored tokens
-```
+- `prod`
+- `test`
 
-## Available MCP Tools
+The environment is not a label; it changes runtime behavior and routing.
 
-Tool naming: `senda_{method}_{path}`. Use `senda_list_endpoints` to discover all.
+Key rules:
 
-### Key Tools
+- Do **not** put the environment into the send `ref`.
+- Management routes can be shared or environment-scoped.
+- Data-plane environment is determined by the API key prefix.
+- External integration environment is provided explicitly through `X-Senda-Environment`.
+- `test` has isolated runtime state and recipient safety controls.
 
-| Tool | Purpose |
-|------|---------|
-| `senda_get_health` | Health check |
-| `senda_post_api_v1_send` | Send an email (async, 202) |
-| `senda_get_api_v1_emails` | List sent emails |
-| `senda_get_api_v1_onboarding_status` | Check if onboarding needed |
-| `senda_post_api_v1_onboarding_setup` | Run first-time setup |
-| `senda_post_api_v1_manage_tenants` | Create tenant |
-| `senda_get_api_v1_manage_tenants` | List tenants |
-| `senda_post_api_v1_manage_tenants_tc_workspaces` | Create workspace |
-| `senda_get_api_v1_manage_members` | List members |
-| `senda_post_api_v1_manage_members` | Create member |
-| `senda_post_api_v1_manage_tenants_tc_workspaces_wc_adapters` | Create email adapter |
-| `senda_post_api_v1_manage_tenants_tc_workspaces_wc_templates` | Create template |
-| `senda_post_api_v1_manage_tenants_tc_workspaces_wc_api_keys` | Create API key |
+For the detailed model, load:
+- `references/environment-model.md`
 
-## Quick Start Workflow
+## Golden rules
 
-```
-1. senda_get_api_v1_onboarding_status       → check if setup needed
-2. senda_post_api_v1_onboarding_setup       → create tenant + member (first time)
-3. senda_get_api_v1_manage_tenants          → list tenants
-4. senda_post_api_v1_manage_tenants_tc_workspaces  → create workspace
-5. senda_post_api_v1_manage_tenants_tc_workspaces_wc_adapters  → add email provider
-6. senda_put_api_v1_manage_tenants_tc_workspaces_wc_adapters_id_workspace_access  → grant a Gmail adapter from tenant `_system` to selected workspaces (optional)
-7. senda_put_api_v1_manage_tenants_tc_workspaces_wc_adapters_id_identities_identity_id_workspace_access → grant an SES email identity from tenant `_system` to selected workspaces (optional)
-8. senda_post_api_v1_manage_tenants_tc_workspaces_wc_templates → create template
-9. senda_post_api_v1_manage_tenants_tc_workspaces_wc_api_keys  → create API key
-10. senda_post_api_v1_send                   → send email with API key
-11. senda_get_api_v1_emails                  → check delivery status
-```
+- **Use only the environment-aware raw API key prefixes** `senda_prod_` and `senda_test_`.
+- **Never infer environment from workspace code or name.** Use the route/header/token source of truth.
+- **Never put environment into `ref`.** `ref` stays `tenant:workspace:templateType`.
+- **Always distinguish shared routes from environment-scoped routes.**
+- **Treat `_system` as a special control workspace**, not a normal business workspace.
+- **Use `X-Senda-Environment` for external integration requests.**
+- **Runtime reset is test-only.** It is available only on the management environment-scoped test surface.
+- **Test recipient policies are test-only.** Do not assume they exist in prod.
 
-## API Groups
+## MCP operating playbooks
 
-### Public (no auth)
+### 1) Discover what exists
 
-- `GET /health` — health check
-- `GET /healthz` — full health (pinger)
-- `GET /metrics` — Prometheus metrics
-- `GET /t/o/{tracking_id}` — email open-tracking pixel
-- `GET /public/video-thumbnail` — video thumbnail composite
-- `GET /api/v1/onboarding/status` — check setup status
+Start with endpoint discovery, then inspect or call only the relevant endpoints.
 
-### Data Plane (WorkspaceAPIKeyBearer)
+Typical sequence:
 
-Auth: `Authorization: Bearer senda_live_...` (workspace API key)
+1. `senda_list_endpoints`
+2. `senda_describe_endpoint`
+3. `senda_call_endpoint`
 
-- `POST /api/v1/send` — send email (202 Accepted, async)
-- `GET /api/v1/emails` — list emails (cursor pagination)
-- `GET /api/v1/emails/{tracking_id}` — get email details
-- `GET /api/v1/emails/{tracking_id}/events` — get email events
-- `GET /api/v1/emails/export` — export emails (CSV/JSON)
+### 2) Choose the right plane
 
-### Webhooks Inbound (no auth, SNS signature)
+- **Management plane** — humans/admin workflows, OIDC auth, CRUD, configuration, environment-scoped workspace operations.
+- **Data plane** — send/query with `Authorization: Bearer senda_prod_...` or `senda_test_...`.
+- **External integration surface** — `/api/v1/external/:profile_slug/...`, custom auth + workspace resolver, header `X-Senda-Environment` required.
 
-- `POST /api/v1/webhooks/ses/inbound` — SES/SNS event ingestion
+### 3) Common MCP flows
 
-### Management API (ManagementBearer — OIDC JWT)
+Load this reference when you need ready-to-run workflows:
+- `references/mcp-workflows.md`
 
-Auth: `Authorization: Bearer <keycloak-jwt>`
+That reference covers:
 
-All routes under `/api/v1/manage/` require OIDC JWT + role-based access.
+- onboarding
+- tenant/workspace CRUD
+- environment-scoped workspace operations
+- API key creation and usage
+- send + send batch + email query
+- external bootstrap/session and builder flows
+- config and external integration profile management
 
-#### Tenants (Superadmin)
-- `POST/GET /api/v1/manage/tenants`
-- `GET/PUT/DELETE /api/v1/manage/tenants/{tenant_code}`
+## SDK / embedder playbook
 
-#### Workspaces (TenantAdmin+)
-- `POST/GET /api/v1/manage/tenants/{tc}/workspaces`
-- `GET/PUT/DELETE /api/v1/manage/tenants/{tc}/workspaces/{wc}`
+Use the Go SDK when another repo needs to run Senda and add business-specific behavior.
 
-#### Members (Superadmin)
-- `GET/POST /api/v1/manage/members`
-- `GET /api/v1/manage/members/{id}`
-- `POST /api/v1/manage/members/{id}/roles`
-- `DELETE /api/v1/manage/members/{id}/roles/{role_id}`
-
-#### Workspace Resources (under `.../workspaces/{wc}/`)
-
-| Resource | Create | List | Get | Update | Delete | Test |
-|----------|--------|------|-----|--------|--------|------|
-| Adapters | POST | GET | GET /{id} | PUT /{id} | DELETE /{id} | POST /{id}/test |
-| Adapter Identities | POST | GET | — | — | DELETE /{id} | — |
-| Templates | POST | GET | GET /{id} | — | — | POST /{id}/test-send |
-| Template Versions | POST | GET | GET /{vid} | PUT /{vid} | — | POST /{vid}/publish |
-| Template Locales | POST | GET | GET /{loc} | PUT /{loc} | DELETE /{loc} | — |
-| Template Types | POST | GET | GET /{slug} | — | — | — |
-| Injectors | POST | GET | GET /{name} | PUT /{name}/values | — | — |
-| API Keys | POST | GET | — | — | DELETE /{id} | — |
-| Webhooks | POST | GET | GET /{id} | PUT /{id} | DELETE /{id} | POST /{id}/test |
-| Emails | — | GET | GET /{tid} | — | — | — |
-| Suppression | POST | GET /{email} | — | — | DELETE /{email} | — |
-| Audit Log | — | GET | — | — | — | — |
-| Dashboard Stats | — | GET | — | — | — | — |
-
-#### Shared adapters from tenant `_system`
-
-- `GET/PUT /api/v1/manage/tenants/{tc}/workspaces/{wc}/adapters/{id}/workspace-access`
-  - only valid when `{wc}` resolves to the tenant `_system` workspace
-  - manages **Gmail adapter** visibility by workspace
-- `GET/PUT /api/v1/manage/tenants/{tc}/workspaces/{wc}/adapters/{id}/identities/{identity_id}/workspace-access`
-  - only valid when `{wc}` resolves to the tenant `_system` workspace
-  - manages **SES email identity** visibility by workspace
-  - SES identities of type `domain` are **not** shareable
-- Regular workspaces list both owned adapters and visible shared adapters; shared entries are **read-only**
-- For template types in a child workspace:
-  - shared Gmail adapters can be selected directly
-  - shared SES adapters require `sender_identity_id`
-  - that `sender_identity_id` must be an **email identity granted to that workspace**
-
-#### Global Scope (Superadmin, under `/api/v1/manage/global/`)
-Same resources as workspace-scoped but for system-wide configuration.
-
-#### Config (Superadmin)
-- `GET/PUT /api/v1/manage/config`
-
-#### Current User
-- `GET /api/v1/members/me` — get authenticated member profile (OIDC only)
-
-## Auth Schemes
-
-| Scheme | Type | Format | Used by |
-|--------|------|--------|---------|
-| ManagementBearer | HTTP Bearer | JWT from OIDC (Keycloak) | Management API (`/api/v1/manage/*`) |
-| WorkspaceAPIKeyBearer | HTTP Bearer | `senda_live_...` | Data Plane (`/api/v1/send`, `/api/v1/emails`) |
-
-## RBAC Roles
-
-| Role | Scope | Access |
-|------|-------|--------|
-| Superadmin | Global | All operations, tenant/member management, global config |
-| TenantAdmin | Tenant | Workspace CRUD, tenant settings |
-| WorkspaceAdmin | Workspace | Adapters, API keys, webhooks, template publish, suppression |
-| WorkspaceEditor | Workspace | Template versions/locales, injector values, test-send |
-| WorkspaceViewer | Workspace | Read-only access to all workspace resources |
-
-## Go SDK (for embedders)
-
-Senda can be embedded as a library via the `sdk` package:
+### Engine entry point
 
 ```go
-import "github.com/rendis/senda/sdk"
-
-engine := sdk.NewWithConfig("config.yaml")
-engine.RegisterInjector(&MyInjector{})      // custom template variables
-engine.SetInitFunc(myInit)                   // per-request init
-engine.OnStart(func(ctx context.Context) error { return nil })
-engine.OnShutdown(func(ctx context.Context) error { return nil })
-engine.Run()
+engine := sdk.NewWithConfig("settings/config.yaml")
 ```
 
-### Injector Interface
+Then register extensions before `Run()`.
 
-```go
-type Injector interface {
-    Code() string                                           // unique name
-    Resolve() (ResolveFunc, []string)                       // resolver + dependencies
-    IsCritical() bool                                       // true = failure aborts send
-    Timeout() time.Duration                                 // max resolution time (0 = 30s)
-}
-type ResolveFunc func(ctx context.Context, injCtx *InjectorContext) (map[string]any, error)
-```
+### Public registration points
 
-Templates access injected values as `{{ injector.CODE.fieldName }}`.
+| Method | What it registers | Multiplicity | When it runs |
+|---|---|---:|---|
+| `RegisterInjector(...)` | Code injector | many | during send resolution |
+| `SetInitFunc(...)` | Per-request init function | one (last wins) | before code injectors |
+| `RegisterExternalAuthMethod(...)` | External integration auth method | many | on external integration requests |
+| `RegisterExternalWorkspaceResolver(...)` | External workspace resolver | many | after external auth succeeds |
+| `OnStart(...)` | Startup hook | many | after bootstrap, before serving |
+| `OnShutdown(...)` | Shutdown hook | many | during shutdown, reverse order |
+| `Run()` | Starts Senda | one | blocks until shutdown |
 
-## Key Configuration
+### Operational guidance
 
-| Config | Env Var | Required | Purpose |
-|--------|---------|----------|---------|
-| Database URL | `SENDA_DATABASE_URL` | Yes | PostgreSQL 16 connection |
-| Master Key | `SENDA_MASTER_KEY` | Yes | AES-256-GCM encryption (32+ chars) |
-| OIDC Discovery | `SENDA_OIDC_DISCOVERY_URL` | Yes | Keycloak .well-known URL |
-| OIDC Client ID | `SENDA_OIDC_CLIENT_ID` | Yes | OIDC client identifier |
-| OIDC Client Secret | `SENDA_OIDC_CLIENT_SECRET` | Yes | OIDC client secret |
-| Port | `SENDA_PORT` | No | HTTP port (default: 8080) |
-| Log Level | `SENDA_LOG_LEVEL` | No | debug, info, warn, error |
-| Environment | `SENDA_ENVIRONMENT` | No | production, development |
+- `InitFunc` is for per-request shared context.
+- `Injector` is for code-provided template fields.
+- `ExternalAuthMethod` validates an external request and returns normalized permissions/context.
+- `ExternalWorkspaceResolver` maps that normalized request to a workspace or read-only fallback.
+- `OnStart` / `OnShutdown` are for infrastructure lifecycle, not request logic.
 
-## SES Adapter Lifecycle
+Load this reference when implementing or reviewing embedder code:
+- `references/sdk-extension-points.md`
 
-### Provisioning Flow (6 steps)
+## Real execution flows
 
-Auto-provisions SES tracking resources when `SENDA_TRACKING_BASE_URL` is set.
-Tracked in `adapter_provisioning_steps` table. Each step is idempotent.
+### Send flow
 
-| Step | Name | AWS Operation |
-|------|------|---------------|
-| 1 | create_configuration_set | ses:CreateConfigurationSet |
-| 2 | create_sns_topic | sns:CreateTopic |
-| 3 | create_event_destination | ses:CreateConfigurationSetEventDestination |
-| 4 | subscribe_webhook | sns:Subscribe (HTTPS) |
-| 5 | save_configuration | DB only (persist config set name) |
-| 6 | verify_subscription | sns:GetSubscriptionAttributes (polling, 15s timeout) |
+1. request enters the send pipeline
+2. tenant/workspace/template type are resolved
+3. `InjectorContext` is created
+4. DB injectors are resolved and seeded
+5. `InitFunc` runs once
+6. code injectors run in dependency order
+7. values merge with precedence rules
+8. template renders and dispatch continues
 
-Resource naming:
-- ConfigSet: `senda-{id[:8]}`
-- Topic: `senda-ses-events-{id[:8]}`
-- EventDest: `senda-events` (fixed)
-- Webhook: `{baseURL}/api/v1/webhooks/ses/inbound`
+### External integration flow
 
-### Deprovision Flow (4 steps)
+1. external profile loads by slug
+2. required headers and `X-Senda-Environment` are validated
+3. registered auth method authenticates
+4. registered workspace resolver returns effective workspace or read-only fallback
+5. effective permissions are computed
+6. the request proceeds against the external builder surface
 
-Executes on adapter soft-delete (SES type only). Best-effort -- failure does not block deletion.
-Tracked in same `adapter_provisioning_steps` table with `deprov_` prefix.
+### Resolution flow
 
-| Step | Name | AWS Operation |
-|------|------|---------------|
-| 10 | deprov_unsubscribe_webhook | sns:Unsubscribe |
-| 11 | deprov_delete_event_destination | ses:DeleteConfigurationSetEventDestination |
-| 12 | deprov_delete_sns_topic | sns:DeleteTopic |
-| 13 | deprov_delete_configuration_set | ses:DeleteConfigurationSet |
+1. workspace scope is checked first
+2. tenant `_system` fallback is checked next
+3. global fallback is checked last
+4. shared/default/forked resources participate according to their own rules
 
-### AWS IAM Permissions (full lifecycle)
+For detailed flow explanations, load:
+- `references/external-integration-flow.md`
+- `references/resolution-and-inheritance.md`
 
-**Sending (required)**:
-- `ses:SendEmail`, `ses:SendRawEmail` -- Send emails
-- `ses:ListEmailIdentities` -- Sync verified sender identities
-- `ses:GetAccount` -- Check sandbox/production status
+## Public contracts you must understand
 
-**Event Tracking Provisioning (required if `SENDA_TRACKING_BASE_URL` set)**:
-- `ses:CreateConfigurationSet` -- Create tracking ConfigSet
-- `ses:CreateConfigurationSetEventDestination` -- Link ConfigSet to SNS
-- `ses:ListConfigurationSets` -- List existing ConfigSets
-- `sns:CreateTopic` -- Create SNS Topic
-- `sns:Subscribe` -- Subscribe webhook
-- `sns:GetSubscriptionAttributes` -- Verify subscription confirmed
-- `sns:ListTopics` -- List existing Topics
+These are the primary public contracts for agents and embedders:
 
-**Cleanup on Adapter Deletion (recommended)**:
-- `ses:DeleteConfigurationSet` -- Remove ConfigSet on adapter delete
-- `ses:DeleteConfigurationSetEventDestination` -- Remove EventDest on adapter delete
-- `sns:Unsubscribe` -- Cancel subscription on adapter delete
-- `sns:DeleteTopic` -- Remove Topic on adapter delete
+- `sdk.Engine`
+- `sdk.Injector`
+- `sdk.ResolveFunc`
+- `sdk.InitFunc`
+- `sdk.ExternalAuthMethod`
+- `sdk.ExternalWorkspaceResolver`
+- `sdk.ExternalIntegrationRequest`
+- `sdk.ExternalAuthResult`
+- `sdk.ExternalWorkspaceResolution`
+- `sdk.InjectorContext`
 
-Permissions validated by `ValidateCredentials()` (`validator.go`) -- cleanup checks are non-blocking.
+Important runtime facts:
+
+- `InjectorContext.Environment()` tells injectors/init whether the request is in `prod` or `test`.
+- `ExternalIntegrationRequest.Environment` is the normalized environment from the external request.
+- Data plane uses API key prefix as environment selector.
+- Management plane uses route path for environment-scoped workspace operations.
+
+## Which reference to load next
+
+- **Need exact MCP workflows or endpoint usage** → `references/mcp-workflows.md`
+- **Need to register SDK functions or understand interfaces** → `references/sdk-extension-points.md`
+- **Need to understand `prod/test` behavior** → `references/environment-model.md`
+- **Need external embed/bootstrap/session/auth/resolver details** → `references/external-integration-flow.md`
+- **Need `_system`, sharing, defaults, forks, inheritance** → `references/resolution-and-inheritance.md`

--- a/skills/senda/references/environment-model.md
+++ b/skills/senda/references/environment-model.md
@@ -1,0 +1,103 @@
+
+# Environment Model
+
+Senda supports exactly two operational environments per logical workspace:
+
+- `prod`
+- `test`
+
+## Core idea
+
+A logical workspace is edited once for shared identity (`name`, `code`) but operates as two real environment-specific workspaces for runtime behavior.
+
+Environment-specific state includes:
+
+- templates / versions / locales
+- adapters and identities
+- injectors
+- API keys
+- metrics and business history
+- workspace policies
+- test-recipient safety settings
+
+## Where environment comes from
+
+### Management plane
+
+Environment-scoped workspace operations use path routing:
+
+`/api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code/...`
+
+Shared workspace CRUD still exists without the environment segment:
+
+`/api/v1/manage/tenants/:tenant_code/workspaces/...`
+
+Use the shared routes for logical workspace identity. Use environment-scoped routes for environment runtime state.
+
+### Data plane
+
+Environment comes from the API key prefix:
+
+- `senda_prod_...`
+- `senda_test_...`
+
+The send `ref` stays:
+
+`tenant:workspace:templateType`
+
+Do not add `prod` or `test` to `ref`.
+
+### External integration surface
+
+Environment comes from:
+
+`X-Senda-Environment: prod|test`
+
+Requests without that header are invalid.
+
+## Test environment behavior
+
+`test` is not cosmetic. It changes behavior.
+
+### Test recipient policy
+
+Workspace test env supports:
+
+- `replace` (default)
+- `append`
+
+and a safe recipient list.
+
+Template types in the test environment can override the workspace default recipient policy.
+
+Rules:
+
+- recipient policy is test-only
+- prod must not expose these controls
+- recipient addresses are validated and deduplicated
+
+### Runtime reset
+
+Only the test environment supports runtime reset:
+
+`POST /api/v1/manage/environments/test/tenants/:tenant_code/workspaces/:workspace_code/runtime/reset`
+
+It clears runtime/business history for that test workspace. It does not delete functional configuration such as templates, adapters, injectors, or API keys.
+
+## Propagation into public contexts
+
+Environment is propagated into public extension contexts.
+
+### For send/init/injectors
+
+Use:
+
+- `injCtx.Environment()`
+
+### For external integrations
+
+Use:
+
+- `req.Environment`
+
+Avoid custom booleans like `is_test`; the enum is the source of truth.

--- a/skills/senda/references/external-integration-flow.md
+++ b/skills/senda/references/external-integration-flow.md
@@ -1,0 +1,112 @@
+
+# External Integration Flow
+
+Senda exposes an embeddable external builder/editor surface under:
+
+`/api/v1/external/:profile_slug/...`
+
+This is separate from the management plane and does not use OIDC for normal request auth.
+
+## Building blocks
+
+### External profile
+
+Configured in global config. A profile defines:
+
+- `slug`
+- `auth_method_name`
+- `resolver_name`
+- `allowed_origins`
+- `allowed_headers`
+- `required_headers`
+- capability flags
+- enabled/disabled status
+
+### Bootstrap endpoints
+
+Public bootstrap endpoints:
+
+- `GET /api/v1/external/:profile_slug/bootstrap`
+- `GET /api/v1/external/:profile_slug/environments/:environment/bootstrap`
+
+Use them to obtain frame ancestry / embed bootstrapping metadata.
+
+### Authenticated external workspace surface
+
+Base path:
+
+`/api/v1/external/:profile_slug/tenants/:tenant_code/workspaces/:workspace_code/...`
+
+Key endpoints include:
+
+- `/session`
+- template type reads
+- template version reads/updates/publish
+- locale CRUD
+- MJML preview
+- test-send
+- injector reads
+- workspace policy read
+
+## Required header
+
+Every authenticated external integration request must include:
+
+`X-Senda-Environment: prod|test`
+
+If the header is missing or invalid, the request is rejected.
+
+## Request pipeline
+
+1. profile slug resolves
+2. profile must be enabled
+3. required headers are validated
+4. `X-Senda-Environment` is validated and normalized
+5. configured auth method authenticates
+6. configured workspace resolver maps the request to a workspace
+7. effective permissions are combined from profile + auth result
+8. request continues against the external surface
+
+## Auth method responsibilities
+
+An auth method should:
+
+- validate the external caller's credentials/token
+- normalize permissions
+- return caller context if needed by the resolver
+
+It should **not** decide the final workspace.
+
+## Workspace resolver responsibilities
+
+A workspace resolver should:
+
+- map the normalized request + auth result to a workspace
+- optionally force read-only fallback
+
+Return rules:
+
+- `WorkspaceCode` + `ReadOnly=false` → normal workspace access
+- `ReadOnly=true` → middleware forces effective workspace `_system`
+
+## Permissions model
+
+Available capability flags include:
+
+- `ListTemplates`
+- `ViewVersions`
+- `EditVersions`
+- `PublishVersions`
+- `TestSend`
+- `BuilderAccess`
+- `MetadataAccess`
+- `LocaleAccess`
+
+External routes are individually guarded by these capabilities.
+
+## Agent rules
+
+- Do not assume OIDC on the external surface.
+- Do not assume the path workspace is the effective workspace; the resolver may override or force read-only fallback.
+- Always send `X-Senda-Environment`.
+- Use `/session` to understand effective permissions and whether the request is read-only.

--- a/skills/senda/references/mcp-workflows.md
+++ b/skills/senda/references/mcp-workflows.md
@@ -1,0 +1,89 @@
+
+# MCP Workflows
+
+This reference provides operational workflows for Senda MCP usage.
+
+## Auth selection
+
+### Management plane
+
+Use OIDC bearer token for:
+
+- `/api/v1/manage/...`
+- `/api/v1/members/me`
+- onboarding setup
+
+### Data plane
+
+Use raw API key for:
+
+- `/api/v1/send`
+- `/api/v1/send/batch`
+- `/api/v1/emails...`
+
+Prefixes:
+
+- `senda_prod_...`
+- `senda_test_...`
+
+### External integration surface
+
+Use the external profile routes and include:
+
+- `X-Senda-Environment: prod|test`
+- any required profile headers
+- whatever token/header scheme the custom auth method expects
+
+## Typical workflows
+
+### 1) First-time setup
+
+1. check onboarding status
+2. run onboarding setup if needed
+3. list tenants
+4. create workspace(s)
+
+### 2) Create a sending workspace
+
+1. create logical workspace
+2. list/get the environment-scoped workspace you want (`prod` or `test`)
+3. create adapter
+4. create template type
+5. create template
+6. create version
+7. publish version
+8. create API key
+
+### 3) Send and inspect
+
+1. use a raw API key bearer token
+2. call `/api/v1/send` or `/api/v1/send/batch`
+3. inspect `/api/v1/emails`
+4. inspect `/api/v1/emails/:tracking_id/events`
+
+### 4) Work with environment-scoped management state
+
+Use routes like:
+
+`/api/v1/manage/environments/:environment/tenants/:tenant_code/workspaces/:workspace_code/...`
+
+Use these for:
+
+- environment-specific workspace reads/updates
+- runtime reset in `test`
+- environment-specific resources such as templates/adapters/injectors/API keys
+
+### 5) External builder/embed flow
+
+1. bootstrap profile
+2. bootstrap environment-specific embed path if needed
+3. call `/session` on the scoped external route
+4. use template/template-version/injector/policy endpoints according to granted capabilities
+
+## Operational reminders
+
+- Use `senda_list_endpoints` when unsure which operation exists.
+- Use `senda_describe_endpoint` before crafting a complex request body.
+- Prefer management shared routes for logical workspace identity and environment-scoped routes for runtime state.
+- External requests must include `X-Senda-Environment`.
+- Do not put environment into `ref`.

--- a/skills/senda/references/resolution-and-inheritance.md
+++ b/skills/senda/references/resolution-and-inheritance.md
@@ -1,0 +1,85 @@
+
+# Resolution and Inheritance
+
+This reference explains how Senda resolves configuration across scopes and environments.
+
+## Scope chain
+
+For most workspace runtime resolution, the chain is:
+
+1. workspace
+2. tenant `_system` workspace
+3. global
+
+The first applicable match wins unless the resource type explicitly merges field-by-field.
+
+## `_system` workspace
+
+Each tenant has a special `_system` workspace.
+
+Purpose:
+
+- tenant-wide defaults
+- selective sharing
+- parent for workspace inheritance
+
+Do not treat `_system` as a normal business workspace.
+
+## Owned vs inherited vs shared
+
+Agents must distinguish three states:
+
+- **owned** — created directly in the current scope
+- **inherited** — resolved from a parent scope by normal hierarchy
+- **shared** — exposed intentionally from `_system` to a child workspace
+
+These are not interchangeable.
+
+## Shared defaults and forks
+
+Recent template/workspace behavior includes:
+
+- `_system` defaults visible to child workspaces
+- explicit forks where a child workspace copies inherited content to own it locally
+- exact version cloning for template versions
+
+When working with templates:
+
+- use forking when a child workspace needs its own copy of inherited behavior
+- use exact version cloning when you need a new draft that exactly copies one version and its locales
+
+## Selective sharing
+
+### Gmail
+
+Shared at the adapter level from tenant `_system` to selected workspaces.
+
+### SES
+
+Shared at the **email identity** level, not entire domain identities.
+
+Rules:
+
+- domain identities are not shareable
+- child workspaces can only use SES email identities explicitly granted to them
+- shared resources appear as read-only in child workspaces
+
+## Injector and template precedence
+
+### Injectors
+
+- DB injectors resolve through scope chain
+- code injectors merge into the same namespace
+- request-body injector overrides may apply per field according to runtime policy
+
+### Templates
+
+- template types and templates resolve through visible scope
+- versions/locales belong to the resolved template
+- exact version cloning creates a new draft copy of a source version and all its locales
+
+## Agent rules
+
+- Do not collapse inherited and shared into the same concept.
+- When a resource is inherited/shared, verify whether mutation is allowed before calling update/delete actions.
+- When using `_system`, remember it is the control point for tenant-wide defaults and sharing policies.

--- a/skills/senda/references/sdk-extension-points.md
+++ b/skills/senda/references/sdk-extension-points.md
@@ -1,0 +1,227 @@
+
+# SDK Extension Points
+
+This reference explains how to embed Senda as a Go library and how each extension point behaves.
+
+## Engine lifecycle
+
+Typical bootstrap:
+
+```go
+engine := sdk.NewWithConfig("settings/config.yaml")
+
+engine.RegisterInjector(&MyInjector{})
+engine.SetInitFunc(myInit)
+engine.RegisterExternalAuthMethod(&PortalAuthMethod{})
+engine.RegisterExternalWorkspaceResolver(&PortalWorkspaceResolver{})
+engine.OnStart(func(ctx context.Context) error { return nil })
+engine.OnShutdown(func(ctx context.Context) error { return nil })
+
+if err := engine.Run(); err != nil {
+    panic(err)
+}
+```
+
+`Run()` performs, in order:
+
+1. load config (`SENDA_CONFIG` overrides constructor path)
+2. setup logger + metrics
+3. bootstrap app internals
+4. run `OnStart` hooks in registration order
+5. start River workers
+6. start HTTP server
+7. on shutdown, run `OnShutdown` hooks in reverse order
+
+## Registration points
+
+### `RegisterInjector(...)`
+
+Registers a code injector implementing `sdk.Injector`.
+
+```go
+type Injector interface {
+    Code() string
+    Resolve() (sdk.ResolveFunc, []string)
+    IsCritical() bool
+    Timeout() time.Duration
+}
+```
+
+Use it when your repo needs business-specific template fields from code.
+
+Behavior:
+
+- many allowed
+- duplicate codes: last registered code injector wins over previous code injectors
+- if a code injector and DB injector share the same code, the code injector wins for that injector namespace
+- injector values merge into the same `injector.<code>.<field>` namespace used by DB injectors
+
+### `SetInitFunc(...)`
+
+Registers a per-request init function.
+
+```go
+type InitFunc func(ctx context.Context, injCtx *sdk.InjectorContext) (any, error)
+```
+
+Use it when multiple injectors need the same request-scoped data.
+
+Behavior:
+
+- only one active init func; last call wins
+- runs once per send request
+- runs after workspace/template resolution and before code injectors
+- return value is stored in `injCtx.InitData()`
+
+### `RegisterExternalAuthMethod(...)`
+
+Registers a custom auth method for external integrations.
+
+```go
+type ExternalAuthMethod interface {
+    Name() string
+    Description() string
+    Authenticate(ctx context.Context, req *sdk.ExternalIntegrationRequest) (*sdk.ExternalAuthResult, error)
+}
+```
+
+Use it when an external portal, iframe, or embedded builder needs its own auth scheme.
+
+Behavior:
+
+- many allowed
+- the active one is selected by profile config (`auth_method_name`)
+- should validate the incoming request and return normalized permissions/context
+- should not resolve the workspace; that belongs to the workspace resolver
+
+### `RegisterExternalWorkspaceResolver(...)`
+
+Registers a workspace resolver for external integrations.
+
+```go
+type ExternalWorkspaceResolver interface {
+    Name() string
+    Description() string
+    ResolveWorkspace(ctx context.Context, req *sdk.ExternalIntegrationRequest, auth *sdk.ExternalAuthResult) (*sdk.ExternalWorkspaceResolution, error)
+}
+```
+
+Use it when external access needs tenant/workspace mapping rules that differ from the normal management/data-plane model.
+
+Behavior:
+
+- many allowed
+- the active one is selected by profile config (`resolver_name`)
+- runs after auth succeeds
+- may return a direct workspace or a read-only fallback
+
+### `OnStart(...)` and `OnShutdown(...)`
+
+Lifecycle hooks for external resources.
+
+Use them for:
+
+- opening database/API clients external to Senda
+- loading caches or clients needed by your injectors/auth/resolvers
+- closing those resources cleanly
+
+Do not use them for request-scoped behavior.
+
+## InjectorContext
+
+`InjectorContext` is the read-only runtime context for init/injectors.
+
+Important methods:
+
+| Method | Purpose |
+|---|---|
+| `Header(key)` / `Headers()` | request headers |
+| `Ref()` | `tenant:workspace:templateType` |
+| `Variables()` | caller-provided send variables |
+| `RequestInjectors()` | request-body injector overrides |
+| `InitData()` | output from `InitFunc` |
+| `TenantID()` | resolved tenant UUID |
+| `WorkspaceID()` | resolved workspace UUID |
+| `Environment()` | `prod` or `test` |
+| `TemplateType()` | resolved template type slug |
+| `GetResolved(code)` | already-resolved injector values |
+| `AllResolved()` | merged injector values |
+
+Important behavior:
+
+- `Environment()` is the runtime source of truth for init/injectors.
+- `RequestInjectors()` exposes request-level runtime overrides.
+- DB injectors are seeded before code injectors run.
+
+## External request contracts
+
+### `ExternalIntegrationRequest`
+
+Carries the request context for external auth and workspace resolution.
+
+Fields you should rely on:
+
+- `ProfileSlug`
+- `Environment`
+- `TenantCode`
+- `WorkspaceCodes`
+- `Token`
+- `Headers`
+- `QueryParams`
+- `Path`
+- `Method`
+
+The environment is already normalized from `X-Senda-Environment`.
+
+### `ExternalAuthResult`
+
+Returned by the auth method.
+
+Use it to return:
+
+- capability flags (`ListTemplates`, `ViewVersions`, `EditVersions`, etc.)
+- normalized auth context via `Context map[string]any`
+
+### `ExternalWorkspaceResolution`
+
+Returned by the workspace resolver.
+
+Fields:
+
+- `WorkspaceCode`
+- `ReadOnly`
+
+Rules:
+
+- when `ReadOnly=true`, the external middleware forces `_system` as the effective workspace
+- external callers must not mutate in read-only fallback mode
+
+## Example registration from a consumer repo
+
+```go
+func Register(engine *sdk.Engine) {
+    engine.SetInitFunc(MyInit())
+
+    engine.RegisterInjector(&StudentInjector{})
+    engine.RegisterInjector(&SummaryInjector{})
+
+    engine.RegisterExternalAuthMethod(&PortalAuthMethod{})
+    engine.RegisterExternalWorkspaceResolver(&PortalWorkspaceResolver{})
+
+    engine.OnStart(func(ctx context.Context) error {
+        return connectExternalClients(ctx)
+    })
+
+    engine.OnShutdown(func(ctx context.Context) error {
+        return closeExternalClients(ctx)
+    })
+}
+```
+
+## Design guidance for embedders
+
+- Put registration in a single `extensions.Register(engine)` function.
+- Keep auth methods and workspace resolvers separate: auth authenticates, resolver maps.
+- Use `InitFunc` for shared request-scoped loads instead of repeating the same call in multiple injectors.
+- Use `Environment()` rather than ad-hoc flags or workspace naming conventions.
+- Keep provider adapters, queues, crypto, auth middleware, and internal stores inside Senda config; do not try to re-register those through the SDK.

--- a/test/e2e/crud_coverage_test.go
+++ b/test/e2e/crud_coverage_test.go
@@ -170,7 +170,9 @@ func TestCRUD_Workspace_StatusAndSystemProtection(t *testing.T) {
 	require.True(t, created.IsActive)
 
 	t.Run("deactivate_and_reactivate", func(t *testing.T) {
-		resp := c.Put(tenantPath()+"/workspaces/"+code, map[string]any{
+		prodWorkspacePath := managementEnvironmentWorkspacePath("prod", TenantCode, code)
+
+		resp := c.Put(prodWorkspacePath, map[string]any{
 			"name":      "Toggle Workspace Disabled",
 			"is_active": false,
 		})
@@ -185,7 +187,7 @@ func TestCRUD_Workspace_StatusAndSystemProtection(t *testing.T) {
 		require.Equal(t, "Toggle Workspace Disabled", updated.Name)
 		require.False(t, updated.IsActive)
 
-		getResp := c.Get(tenantPath() + "/workspaces/" + code)
+		getResp := c.Get(prodWorkspacePath)
 		defer getResp.Body.Close()
 		RequireStatus(t, getResp, http.StatusOK)
 
@@ -195,7 +197,7 @@ func TestCRUD_Workspace_StatusAndSystemProtection(t *testing.T) {
 		ParseJSONResponse(t, getResp, &fetched)
 		require.False(t, fetched.IsActive)
 
-		reactivateResp := c.Put(tenantPath()+"/workspaces/"+code, map[string]any{
+		reactivateResp := c.Put(prodWorkspacePath, map[string]any{
 			"name":      "Toggle Workspace Active",
 			"is_active": true,
 		})
@@ -210,7 +212,7 @@ func TestCRUD_Workspace_StatusAndSystemProtection(t *testing.T) {
 	})
 
 	t.Run("system_workspace_is_protected", func(t *testing.T) {
-		resp := c.Put(tenantPath()+"/workspaces/_system", map[string]any{
+		resp := c.Put(managementEnvironmentWorkspacePath("prod", TenantCode, "_system"), map[string]any{
 			"name":      "Should Fail",
 			"is_active": false,
 		})
@@ -911,11 +913,12 @@ func TestCRUD_Members(t *testing.T) {
 
 	var memberID string
 	email := fmt.Sprintf("member-%d@test.example.com", time.Now().UnixNano()%100000)
+	createMember := func(t *testing.T, displayName string) string {
+		t.Helper()
 
-	t.Run("create", func(t *testing.T) {
 		resp := c.Post(mgmtPath()+"/members", map[string]interface{}{
 			"email":        email,
-			"display_name": "E2E Test Member",
+			"display_name": displayName,
 		})
 		defer resp.Body.Close()
 		RequireStatus(t, resp, http.StatusCreated)
@@ -924,17 +927,39 @@ func TestCRUD_Members(t *testing.T) {
 			ID string `json:"id"`
 		}
 		ParseJSONResponse(t, resp, &body)
-		memberID = body.ID
-		require.NotEmpty(t, memberID)
+		require.NotEmpty(t, body.ID)
+		return body.ID
+	}
+
+	t.Run("create", func(t *testing.T) {
+		memberID = createMember(t, "E2E Test Member")
 	})
 
-	t.Run("create_duplicate", func(t *testing.T) {
+	t.Run("create_duplicate_reuses_existing_member", func(t *testing.T) {
+		if memberID == "" {
+			memberID = createMember(t, "E2E Test Member")
+		}
+
 		resp := c.Post(mgmtPath()+"/members", map[string]interface{}{
 			"email":        email,
 			"display_name": "Duplicate",
 		})
 		defer resp.Body.Close()
-		RequireStatus(t, resp, http.StatusConflict)
+
+		RequireStatus(t, resp, http.StatusCreated)
+
+		var body struct {
+			ID          string  `json:"id"`
+			Email       string  `json:"email"`
+			DisplayName *string `json:"display_name"`
+			Roles       []any   `json:"roles"`
+		}
+		ParseJSONResponse(t, resp, &body)
+		require.Equal(t, memberID, body.ID)
+		require.Equal(t, email, body.Email)
+		require.NotNil(t, body.DisplayName)
+		require.Equal(t, "E2E Test Member", *body.DisplayName)
+		require.Empty(t, body.Roles)
 	})
 
 	t.Run("list", func(t *testing.T) {

--- a/test/e2e/environment_modes_test.go
+++ b/test/e2e/environment_modes_test.go
@@ -1,0 +1,713 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type environmentWorkspaceResponse struct {
+	ID                     string   `json:"id"`
+	LogicalWorkspaceID     string   `json:"logical_workspace_id"`
+	TenantID               string   `json:"tenant_id"`
+	Code                   string   `json:"code"`
+	Name                   string   `json:"name"`
+	Environment            string   `json:"environment"`
+	IsActive               bool     `json:"is_active"`
+	DefaultLocale          *string  `json:"default_locale"`
+	TestRecipientMode      string   `json:"test_recipient_mode"`
+	TestRecipientAddresses []string `json:"test_recipient_addresses"`
+}
+
+type environmentWorkspaceListResponse struct {
+	Items []environmentWorkspaceResponse `json:"items"`
+}
+
+type environmentSendResponse struct {
+	Status           string `json:"status"`
+	TemplateResolved string `json:"template_resolved"`
+	TrackingIDs      []struct {
+		To         string `json:"to"`
+		TrackingID string `json:"tracking_id"`
+		Status     string `json:"status"`
+		Error      string `json:"error"`
+	} `json:"tracking_ids"`
+}
+
+type environmentEmailListResponse struct {
+	Items []struct {
+		TrackingID       string `json:"tracking_id"`
+		RecipientEmail   string `json:"recipient_email"`
+		TemplateTypeSlug string `json:"template_type_slug"`
+		Status           string `json:"status"`
+	} `json:"items"`
+}
+
+type environmentTemplateSetup struct {
+	TemplateTypeID string
+	TemplateID     string
+	VersionID      string
+	AdapterID      string
+}
+
+type environmentTemplatePolicy struct {
+	Mode      *string
+	Addresses []string
+}
+
+func managementTenantWorkspacesPath(tenantCode string) string {
+	return fmt.Sprintf("/api/v1/manage/tenants/%s/workspaces", tenantCode)
+}
+
+func managementWorkspacePath(tenantCode, workspaceCode string) string {
+	return fmt.Sprintf("/api/v1/manage/tenants/%s/workspaces/%s", tenantCode, workspaceCode)
+}
+
+func managementEnvironmentTenantWorkspacesPath(environment, tenantCode string) string {
+	return fmt.Sprintf("/api/v1/manage/environments/%s/tenants/%s/workspaces", environment, tenantCode)
+}
+
+func managementEnvironmentWorkspacePath(environment, tenantCode, workspaceCode string) string {
+	return fmt.Sprintf("/api/v1/manage/environments/%s/tenants/%s/workspaces/%s", environment, tenantCode, workspaceCode)
+}
+
+func ensureEnvironmentBaseline(t *testing.T) {
+	t.Helper()
+	WaitForServer(t, 30*time.Second)
+	WaitForMailpit(t, 30*time.Second)
+
+	client := NewTestClient(t)
+	client.LoginAs(SuperadminEmail)
+
+	onboardingResp := client.Post("/api/v1/onboarding/setup", map[string]string{
+		"tenant_code": TenantCode,
+		"tenant_name": TenantName,
+	})
+	require.Contains(t, []int{http.StatusCreated, http.StatusConflict}, onboardingResp.StatusCode,
+		"expected 201 or 409 onboarding setup, got %d: %s", onboardingResp.StatusCode, ReadResponseBody(t, onboardingResp))
+	onboardingResp.Body.Close()
+}
+
+func mustCreateLogicalWorkspacePair(t *testing.T, client *TestClient, code, name string) environmentWorkspaceResponse {
+	t.Helper()
+
+	resp := client.Post(managementTenantWorkspacesPath(TenantCode), map[string]any{
+		"code": code,
+		"name": name,
+	})
+	defer resp.Body.Close()
+	RequireStatus(t, resp, http.StatusCreated)
+
+	var body environmentWorkspaceResponse
+	ParseJSONResponse(t, resp, &body)
+	return body
+}
+
+func mustGetWorkspace(t *testing.T, client *TestClient, path string) environmentWorkspaceResponse {
+	t.Helper()
+
+	resp := client.Get(path)
+	defer resp.Body.Close()
+	RequireStatus(t, resp, http.StatusOK)
+
+	var body environmentWorkspaceResponse
+	ParseJSONResponse(t, resp, &body)
+	return body
+}
+
+func mustFindWorkspaceInList(t *testing.T, client *TestClient, path, code string) environmentWorkspaceResponse {
+	t.Helper()
+
+	resp := client.Get(path)
+	defer resp.Body.Close()
+	RequireStatus(t, resp, http.StatusOK)
+
+	var body environmentWorkspaceListResponse
+	ParseJSONResponse(t, resp, &body)
+	for _, item := range body.Items {
+		if item.Code == code {
+			return item
+		}
+	}
+
+	t.Fatalf("workspace %q not found in %s", code, path)
+	return environmentWorkspaceResponse{}
+}
+
+func mustCreateAPIKeyAtWorkspacePath(t *testing.T, client *TestClient, workspacePath, suffix string) string {
+	t.Helper()
+
+	resp := client.Post(workspacePath+"/api-keys", APIKeyRequest{
+		Name: fmt.Sprintf("%s%s-%d", APIKeyNamePrefix, suffix, time.Now().UnixNano()),
+	})
+	defer resp.Body.Close()
+	RequireStatus(t, resp, http.StatusCreated)
+
+	var body struct {
+		Key   string `json:"key"`
+		Token string `json:"token"`
+	}
+	ParseJSONResponse(t, resp, &body)
+	if body.Key != "" {
+		return body.Key
+	}
+	require.NotEmpty(t, body.Token)
+	return body.Token
+}
+
+func mustCreateEnvironmentTemplateSetup(t *testing.T, client *TestClient, workspacePath, slug, name string, policy *environmentTemplatePolicy) environmentTemplateSetup {
+	t.Helper()
+
+	adapterResp := client.Post(workspacePath+"/adapters", AdapterRequest{
+		AdapterType:        AdapterType,
+		Name:               fmt.Sprintf("%s-adapter-%d", slug, time.Now().UnixNano()),
+		RateLimitPerSecond: 100,
+		Config: map[string]interface{}{
+			"region":     "us-east-1",
+			"access_key": "test",
+			"secret_key": "test",
+		},
+	})
+	defer adapterResp.Body.Close()
+	RequireStatus(t, adapterResp, http.StatusCreated)
+
+	var adapterBody struct {
+		ID string `json:"id"`
+	}
+	ParseJSONResponse(t, adapterResp, &adapterBody)
+	require.NotEmpty(t, adapterBody.ID)
+	EnsureDefaultAdapterIdentity(t, adapterBody.ID, TestFromEmail)
+
+	templateTypeBody := map[string]any{
+		"slug":            slug,
+		"name":            name,
+		"description":     fmt.Sprintf("Template type for %s", slug),
+		"adapter_id":      adapterBody.ID,
+		"variable_schema": DefaultVariableSchema(),
+	}
+	if policy != nil {
+		if policy.Mode != nil {
+			templateTypeBody["test_recipient_mode"] = *policy.Mode
+		}
+		if policy.Addresses != nil {
+			templateTypeBody["test_recipient_addresses"] = policy.Addresses
+		}
+	}
+
+	templateTypeResp := client.Post(workspacePath+"/template-types", templateTypeBody)
+	defer templateTypeResp.Body.Close()
+	RequireStatus(t, templateTypeResp, http.StatusCreated)
+
+	var templateType struct {
+		ID string `json:"id"`
+	}
+	ParseJSONResponse(t, templateTypeResp, &templateType)
+	require.NotEmpty(t, templateType.ID)
+
+	templateResp := client.Post(workspacePath+"/templates", map[string]any{
+		"template_type_id": templateType.ID,
+	})
+	defer templateResp.Body.Close()
+	RequireStatus(t, templateResp, http.StatusCreated)
+
+	var templateBody struct {
+		ID string `json:"id"`
+	}
+	ParseJSONResponse(t, templateResp, &templateBody)
+	require.NotEmpty(t, templateBody.ID)
+
+	versionResp := client.Post(fmt.Sprintf("%s/templates/%s/versions", workspacePath, templateBody.ID), CreateVersionRequest{
+		Subject:       fmt.Sprintf("Subject %s", slug),
+		PreviewText:   fmt.Sprintf("Preview %s", slug),
+		FromEmail:     TestFromEmail,
+		FromName:      TestFromName,
+		BodyMJML:      SampleMJML(),
+		DefaultLocale: "en",
+	})
+	defer versionResp.Body.Close()
+	RequireStatus(t, versionResp, http.StatusCreated)
+
+	var versionBody struct {
+		ID string `json:"id"`
+	}
+	ParseJSONResponse(t, versionResp, &versionBody)
+	require.NotEmpty(t, versionBody.ID)
+
+	publishResp := client.Post(fmt.Sprintf("%s/templates/%s/versions/%s/publish", workspacePath, templateBody.ID, versionBody.ID), nil)
+	defer publishResp.Body.Close()
+	require.Equal(t, http.StatusNoContent, publishResp.StatusCode, "publish should succeed: %s", ReadResponseBody(t, publishResp))
+
+	return environmentTemplateSetup{
+		TemplateTypeID: templateType.ID,
+		TemplateID:     templateBody.ID,
+		VersionID:      versionBody.ID,
+		AdapterID:      adapterBody.ID,
+	}
+}
+
+func mustConfigureWorkspaceTestRecipients(t *testing.T, client *TestClient, workspacePath, mode string, addresses []string) {
+	t.Helper()
+
+	resp := client.Put(workspacePath, map[string]any{
+		"test_recipient_mode":      mode,
+		"test_recipient_addresses": addresses,
+	})
+	defer resp.Body.Close()
+	RequireStatus(t, resp, http.StatusOK)
+}
+
+func mustSendInEnvironment(t *testing.T, apiKey, ref string, recipients ...string) environmentSendResponse {
+	t.Helper()
+
+	sendClient := NewTestClient(t)
+	sendClient.SetAPIKey(apiKey)
+
+	resp := sendClient.Post("/api/v1/send", SendRequest{
+		Ref: ref,
+		To:  recipients,
+		Variables: map[string]interface{}{
+			"first_name":   "Env",
+			"company_name": "Senda",
+		},
+	})
+	defer resp.Body.Close()
+	RequireStatus(t, resp, http.StatusAccepted)
+
+	var body environmentSendResponse
+	ParseJSONResponse(t, resp, &body)
+	require.Equal(t, "accepted", body.Status)
+	require.NotEmpty(t, body.TrackingIDs)
+	return body
+}
+
+func mustWaitForEmailStatusInEnvironment(t *testing.T, client *TestClient, environment, tenantCode, workspaceCode, trackingID, expectedStatus string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		path := managementWorkspacePath(tenantCode, workspaceCode) + "/emails/" + trackingID
+		if environment != "" {
+			path = managementEnvironmentWorkspacePath(environment, tenantCode, workspaceCode) + "/emails/" + trackingID
+		}
+
+		resp := client.Get(path)
+		if resp.StatusCode == http.StatusOK {
+			var body struct {
+				Status string `json:"status"`
+			}
+			ParseJSONResponse(t, resp, &body)
+			resp.Body.Close()
+			if body.Status == expectedStatus {
+				return
+			}
+		} else {
+			resp.Body.Close()
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	t.Fatalf("timeout waiting for %s email %s to reach %s", environment, trackingID, expectedStatus)
+}
+
+func mustListEmailsInEnvironment(t *testing.T, client *TestClient, environment, tenantCode, workspaceCode string) environmentEmailListResponse {
+	t.Helper()
+
+	path := managementWorkspacePath(tenantCode, workspaceCode) + "/emails"
+	if environment != "" {
+		path = managementEnvironmentWorkspacePath(environment, tenantCode, workspaceCode) + "/emails"
+	}
+
+	resp := client.Get(path)
+	defer resp.Body.Close()
+	RequireStatus(t, resp, http.StatusOK)
+
+	var body environmentEmailListResponse
+	ParseJSONResponse(t, resp, &body)
+	return body
+}
+
+func mustListDataPlaneEmails(t *testing.T, apiKey, query string) environmentEmailListResponse {
+	t.Helper()
+
+	client := NewTestClient(t)
+	client.SetAPIKey(apiKey)
+
+	path := "/api/v1/emails"
+	if query != "" {
+		path += "?" + query
+	}
+	resp := client.Get(path)
+	defer resp.Body.Close()
+	RequireStatus(t, resp, http.StatusOK)
+
+	var body environmentEmailListResponse
+	ParseJSONResponse(t, resp, &body)
+	return body
+}
+
+func TestEnv01_WorkspaceLogicalPair_SharedAndIsolatedManagement(t *testing.T) {
+	ensureEnvironmentBaseline(t)
+
+	client := NewTestClient(t)
+	client.LoginAs(SuperadminEmail)
+
+	code := fmt.Sprintf("envpair-%d", time.Now().UnixNano()%1000000)
+	name := "Environment Pair Workspace"
+	created := mustCreateLogicalWorkspacePair(t, client, code, name)
+
+	require.Equal(t, code, created.Code)
+	require.Equal(t, name, created.Name)
+	require.Equal(t, "prod", created.Environment)
+	require.NotEmpty(t, created.LogicalWorkspaceID)
+	require.Equal(t, "replace", created.TestRecipientMode)
+	require.Empty(t, created.TestRecipientAddresses)
+
+	prodListItem := mustFindWorkspaceInList(t, client, managementTenantWorkspacesPath(TenantCode), code)
+	testListItem := mustFindWorkspaceInList(t, client, managementEnvironmentTenantWorkspacesPath("test", TenantCode), code)
+	require.Equal(t, "prod", prodListItem.Environment)
+	require.Equal(t, "test", testListItem.Environment)
+	require.Equal(t, created.LogicalWorkspaceID, prodListItem.LogicalWorkspaceID)
+	require.Equal(t, created.LogicalWorkspaceID, testListItem.LogicalWorkspaceID)
+	require.NotEqual(t, prodListItem.ID, testListItem.ID)
+
+	newCode := code + "-renamed"
+	newName := "Environment Pair Workspace Renamed"
+	updateResp := client.Put(managementWorkspacePath(TenantCode, code), map[string]any{
+		"code": newCode,
+		"name": newName,
+	})
+	defer updateResp.Body.Close()
+	RequireStatus(t, updateResp, http.StatusOK)
+
+	prodWorkspace := mustGetWorkspace(t, client, managementWorkspacePath(TenantCode, newCode))
+	testWorkspace := mustGetWorkspace(t, client, managementEnvironmentWorkspacePath("test", TenantCode, newCode))
+	require.Equal(t, newCode, prodWorkspace.Code)
+	require.Equal(t, newCode, testWorkspace.Code)
+	require.Equal(t, newName, prodWorkspace.Name)
+	require.Equal(t, newName, testWorkspace.Name)
+	require.Equal(t, prodWorkspace.LogicalWorkspaceID, testWorkspace.LogicalWorkspaceID)
+
+	oldProdResp := client.Get(managementWorkspacePath(TenantCode, code))
+	defer oldProdResp.Body.Close()
+	require.Equal(t, http.StatusForbidden, oldProdResp.StatusCode, "old prod code should be rejected by scope resolution: %s", ReadResponseBody(t, oldProdResp))
+	oldProdErr := AssertError(t, oldProdResp, "FORBIDDEN")
+	require.Equal(t, "invalid workspace", oldProdErr.Error.Message)
+
+	oldTestResp := client.Get(managementEnvironmentWorkspacePath("test", TenantCode, code))
+	defer oldTestResp.Body.Close()
+	require.Equal(t, http.StatusForbidden, oldTestResp.StatusCode, "old test code should be rejected by scope resolution: %s", ReadResponseBody(t, oldTestResp))
+	oldTestErr := AssertError(t, oldTestResp, "FORBIDDEN")
+	require.Equal(t, "invalid workspace", oldTestErr.Error.Message)
+
+	testPolicyRecipient := fmt.Sprintf("sandbox-%d@test.example.com", time.Now().UnixNano()%1000000)
+	testUpdateResp := client.Put(managementEnvironmentWorkspacePath("test", TenantCode, newCode), map[string]any{
+		"is_active":                false,
+		"default_locale":           "es-CL",
+		"test_recipient_mode":      "append",
+		"test_recipient_addresses": []string{testPolicyRecipient},
+	})
+	defer testUpdateResp.Body.Close()
+	RequireStatus(t, testUpdateResp, http.StatusOK)
+
+	updatedTest := mustGetWorkspace(t, client, managementEnvironmentWorkspacePath("test", TenantCode, newCode))
+	updatedProd := mustGetWorkspace(t, client, managementEnvironmentWorkspacePath("prod", TenantCode, newCode))
+	require.False(t, updatedTest.IsActive)
+	require.Equal(t, "append", updatedTest.TestRecipientMode)
+	require.Equal(t, []string{testPolicyRecipient}, updatedTest.TestRecipientAddresses)
+	require.NotNil(t, updatedTest.DefaultLocale)
+	require.Equal(t, "es-CL", *updatedTest.DefaultLocale)
+
+	require.True(t, updatedProd.IsActive)
+	require.Equal(t, "replace", updatedProd.TestRecipientMode)
+	require.Empty(t, updatedProd.TestRecipientAddresses)
+	require.Nil(t, updatedProd.DefaultLocale)
+
+	invalidProdPolicyResp := client.Put(managementEnvironmentWorkspacePath("prod", TenantCode, newCode), map[string]any{
+		"test_recipient_mode":      "replace",
+		"test_recipient_addresses": []string{"should-not-work@test.example.com"},
+	})
+	defer invalidProdPolicyResp.Body.Close()
+	RequireStatus(t, invalidProdPolicyResp, http.StatusUnprocessableEntity)
+	AssertError(t, invalidProdPolicyResp, "VALIDATION_ERROR")
+}
+
+func TestEnv02_APIKeyPrefixesAndDataPlaneEnvironmentIsolation(t *testing.T) {
+	ensureEnvironmentBaseline(t)
+
+	client := NewTestClient(t)
+	client.LoginAs(SuperadminEmail)
+
+	workspaceCode := fmt.Sprintf("envdata-%d", time.Now().UnixNano()%1000000)
+	mustCreateLogicalWorkspacePair(t, client, workspaceCode, "Environment Data Plane")
+
+	templateSlug := fmt.Sprintf("envdata-type-%d", time.Now().UnixNano()%1000000)
+	prodPath := managementWorkspacePath(TenantCode, workspaceCode)
+	testPath := managementEnvironmentWorkspacePath("test", TenantCode, workspaceCode)
+	mustCreateEnvironmentTemplateSetup(t, client, prodPath, templateSlug, "Environment Prod Template", nil)
+	mustCreateEnvironmentTemplateSetup(t, client, testPath, templateSlug, "Environment Test Template", nil)
+	testSandboxRecipient := fmt.Sprintf("sandbox-dataplane-%d@test.example.com", time.Now().UnixNano()%1000000)
+	mustConfigureWorkspaceTestRecipients(t, client, testPath, "replace", []string{testSandboxRecipient})
+
+	prodKey := mustCreateAPIKeyAtWorkspacePath(t, client, prodPath, "prod")
+	testKey := mustCreateAPIKeyAtWorkspacePath(t, client, testPath, "test")
+	require.True(t, strings.HasPrefix(prodKey, "senda_prod_"), "expected prod API key prefix, got %q", prodKey)
+	require.True(t, strings.HasPrefix(testKey, "senda_test_"), "expected test API key prefix, got %q", testKey)
+
+	ref := fmt.Sprintf("%s:%s:%s", TenantCode, workspaceCode, templateSlug)
+	prodRecipient := fmt.Sprintf("prod-dataplane-%d@test.example.com", time.Now().UnixNano()%1000000)
+	testRecipient := fmt.Sprintf("test-dataplane-%d@test.example.com", time.Now().UnixNano()%1000000)
+
+	prodSend := mustSendInEnvironment(t, prodKey, ref, prodRecipient)
+	require.Len(t, prodSend.TrackingIDs, 1)
+	require.Equal(t, prodRecipient, prodSend.TrackingIDs[0].To)
+
+	testSend := mustSendInEnvironment(t, testKey, ref, testRecipient)
+	require.Len(t, testSend.TrackingIDs, 1)
+	require.Equal(t, testSandboxRecipient, testSend.TrackingIDs[0].To)
+
+	mustWaitForEmailStatusInEnvironment(t, client, "prod", TenantCode, workspaceCode, prodSend.TrackingIDs[0].TrackingID, "sent", 45*time.Second)
+	mustWaitForEmailStatusInEnvironment(t, client, "test", TenantCode, workspaceCode, testSend.TrackingIDs[0].TrackingID, "sent", 45*time.Second)
+
+	prodDataList := mustListDataPlaneEmails(t, prodKey, "recipient="+prodRecipient)
+	require.Len(t, prodDataList.Items, 1)
+	require.Equal(t, prodSend.TrackingIDs[0].TrackingID, prodDataList.Items[0].TrackingID)
+	require.Equal(t, prodRecipient, prodDataList.Items[0].RecipientEmail)
+
+	prodCannotSeeTest := mustListDataPlaneEmails(t, prodKey, "recipient="+testRecipient)
+	require.Empty(t, prodCannotSeeTest.Items)
+
+	testDataList := mustListDataPlaneEmails(t, testKey, "recipient="+testSandboxRecipient)
+	require.Len(t, testDataList.Items, 1)
+	require.Equal(t, testSend.TrackingIDs[0].TrackingID, testDataList.Items[0].TrackingID)
+	require.Equal(t, testSandboxRecipient, testDataList.Items[0].RecipientEmail)
+
+	testCannotSeeProd := mustListDataPlaneEmails(t, testKey, "recipient="+prodRecipient)
+	require.Empty(t, testCannotSeeProd.Items)
+
+	prodClient := NewTestClient(t)
+	prodClient.SetAPIKey(prodKey)
+	crossProdResp := prodClient.Get("/api/v1/emails/" + testSend.TrackingIDs[0].TrackingID)
+	defer crossProdResp.Body.Close()
+	RequireStatus(t, crossProdResp, http.StatusNotFound)
+
+	testClient := NewTestClient(t)
+	testClient.SetAPIKey(testKey)
+	crossTestResp := testClient.Get("/api/v1/emails/" + prodSend.TrackingIDs[0].TrackingID)
+	defer crossTestResp.Body.Close()
+	RequireStatus(t, crossTestResp, http.StatusNotFound)
+}
+
+func TestEnv03_ExternalEnvironmentHeaderValidation(t *testing.T) {
+	ctx := t.Context()
+	_, err := ensureCoreHarness(ctx)
+	require.NoError(t, err)
+
+	ensureExternalSetup(t)
+
+	admin := NewTestClient(t)
+	admin.LoginAs(SuperadminEmail)
+	ensureExternalIntegrationProfile(t, admin)
+
+	prodResp := externalRequest(t, http.MethodGet,
+		externalWorkspacePath(WorkspaceCode)+"/template-types",
+		nil,
+		map[string]string{
+			"X-Tenant-Code":       TenantCode,
+			"X-Senda-Environment": "prod",
+		},
+		"",
+	)
+	defer prodResp.Body.Close()
+	RequireStatus(t, prodResp, http.StatusOK)
+
+	testResp := externalRequest(t, http.MethodGet,
+		externalWorkspacePath(WorkspaceCode)+"/template-types",
+		nil,
+		map[string]string{
+			"X-Tenant-Code":       TenantCode,
+			"X-Senda-Environment": "TEST",
+		},
+		"",
+	)
+	defer testResp.Body.Close()
+	RequireStatus(t, testResp, http.StatusOK)
+
+	missingHeaderResp := externalRequest(t, http.MethodGet,
+		externalWorkspacePath(WorkspaceCode)+"/template-types",
+		nil,
+		map[string]string{"X-Tenant-Code": TenantCode},
+		"",
+	)
+	defer missingHeaderResp.Body.Close()
+	RequireStatus(t, missingHeaderResp, http.StatusBadRequest)
+	missingErr := AssertError(t, missingHeaderResp, "BAD_REQUEST")
+	require.Contains(t, missingErr.Error.Message, "X-Senda-Environment")
+
+	invalidHeaderResp := externalRequest(t, http.MethodGet,
+		externalWorkspacePath(WorkspaceCode)+"/template-types",
+		nil,
+		map[string]string{
+			"X-Tenant-Code":       TenantCode,
+			"X-Senda-Environment": "staging",
+		},
+		"",
+	)
+	defer invalidHeaderResp.Body.Close()
+	RequireStatus(t, invalidHeaderResp, http.StatusBadRequest)
+	invalidErr := AssertError(t, invalidHeaderResp, "BAD_REQUEST")
+	require.Contains(t, invalidErr.Error.Message, "invalid X-Senda-Environment header")
+}
+
+func TestEnv04_RuntimeResetOnlyTestAndDoesNotAffectProd(t *testing.T) {
+	ensureEnvironmentBaseline(t)
+
+	client := NewTestClient(t)
+	client.LoginAs(SuperadminEmail)
+
+	workspaceCode := fmt.Sprintf("envreset-%d", time.Now().UnixNano()%1000000)
+	mustCreateLogicalWorkspacePair(t, client, workspaceCode, "Environment Runtime Reset")
+
+	templateSlug := fmt.Sprintf("envreset-type-%d", time.Now().UnixNano()%1000000)
+	prodPath := managementWorkspacePath(TenantCode, workspaceCode)
+	testPath := managementEnvironmentWorkspacePath("test", TenantCode, workspaceCode)
+	mustCreateEnvironmentTemplateSetup(t, client, prodPath, templateSlug, "Runtime Reset Prod Template", nil)
+	mustCreateEnvironmentTemplateSetup(t, client, testPath, templateSlug, "Runtime Reset Test Template", nil)
+	testSandboxRecipient := fmt.Sprintf("sandbox-runtime-%d@test.example.com", time.Now().UnixNano()%1000000)
+	mustConfigureWorkspaceTestRecipients(t, client, testPath, "replace", []string{testSandboxRecipient})
+
+	prodKey := mustCreateAPIKeyAtWorkspacePath(t, client, prodPath, "reset-prod")
+	testKey := mustCreateAPIKeyAtWorkspacePath(t, client, testPath, "reset-test")
+
+	ref := fmt.Sprintf("%s:%s:%s", TenantCode, workspaceCode, templateSlug)
+	prodRecipient := fmt.Sprintf("runtime-prod-%d@test.example.com", time.Now().UnixNano()%1000000)
+	testRecipient := fmt.Sprintf("runtime-test-%d@test.example.com", time.Now().UnixNano()%1000000)
+
+	prodSend := mustSendInEnvironment(t, prodKey, ref, prodRecipient)
+	testSend := mustSendInEnvironment(t, testKey, ref, testRecipient)
+
+	mustWaitForEmailStatusInEnvironment(t, client, "prod", TenantCode, workspaceCode, prodSend.TrackingIDs[0].TrackingID, "sent", 45*time.Second)
+	mustWaitForEmailStatusInEnvironment(t, client, "test", TenantCode, workspaceCode, testSend.TrackingIDs[0].TrackingID, "sent", 45*time.Second)
+
+	testResetResp := client.Post(testPath+"/runtime/reset", nil)
+	defer testResetResp.Body.Close()
+	RequireStatus(t, testResetResp, http.StatusNoContent)
+
+	prodGuardResp := client.Post(managementEnvironmentWorkspacePath("prod", TenantCode, workspaceCode)+"/runtime/reset", nil)
+	defer prodGuardResp.Body.Close()
+	RequireStatus(t, prodGuardResp, http.StatusConflict)
+	AssertError(t, prodGuardResp, "TEST_ENVIRONMENT_REQUIRED")
+
+	testDetailResp := client.Get(managementEnvironmentWorkspacePath("test", TenantCode, workspaceCode) + "/emails/" + testSend.TrackingIDs[0].TrackingID)
+	defer testDetailResp.Body.Close()
+	RequireStatus(t, testDetailResp, http.StatusNotFound)
+
+	prodDetailResp := client.Get(managementEnvironmentWorkspacePath("prod", TenantCode, workspaceCode) + "/emails/" + prodSend.TrackingIDs[0].TrackingID)
+	defer prodDetailResp.Body.Close()
+	RequireStatus(t, prodDetailResp, http.StatusOK)
+
+	testEmailsAfterReset := mustListEmailsInEnvironment(t, client, "test", TenantCode, workspaceCode)
+	require.Empty(t, testEmailsAfterReset.Items)
+
+	prodEmailsAfterReset := mustListEmailsInEnvironment(t, client, "prod", TenantCode, workspaceCode)
+	require.NotEmpty(t, prodEmailsAfterReset.Items)
+	foundProdTracking := false
+	for _, item := range prodEmailsAfterReset.Items {
+		if item.TrackingID == prodSend.TrackingIDs[0].TrackingID {
+			foundProdTracking = true
+			break
+		}
+	}
+	require.True(t, foundProdTracking, "prod email must survive test runtime reset")
+}
+
+func TestEnv05_TestRecipientPolicyReplaceAppendAndTemplateTypeOverride(t *testing.T) {
+	ensureEnvironmentBaseline(t)
+
+	client := NewTestClient(t)
+	client.LoginAs(SuperadminEmail)
+
+	workspaceCode := fmt.Sprintf("envpolicy-%d", time.Now().UnixNano()%1000000)
+	mustCreateLogicalWorkspacePair(t, client, workspaceCode, "Environment Recipient Policy")
+
+	templateSlug := fmt.Sprintf("envpolicy-type-%d", time.Now().UnixNano()%1000000)
+	testPath := managementEnvironmentWorkspacePath("test", TenantCode, workspaceCode)
+	setup := mustCreateEnvironmentTemplateSetup(t, client, testPath, templateSlug, "Environment Policy Template", nil)
+	apiKey := mustCreateAPIKeyAtWorkspacePath(t, client, testPath, "policy-test")
+	ref := fmt.Sprintf("%s:%s:%s", TenantCode, workspaceCode, templateSlug)
+
+	mailpit := NewMailpitClient(t)
+
+	replaceRecipient := fmt.Sprintf("policy-replace-%d@test.example.com", time.Now().UnixNano()%1000000)
+	workspaceReplaceResp := client.Put(testPath, map[string]any{
+		"test_recipient_mode":      "replace",
+		"test_recipient_addresses": []string{replaceRecipient},
+	})
+	defer workspaceReplaceResp.Body.Close()
+	RequireStatus(t, workspaceReplaceResp, http.StatusOK)
+
+	mailpit.ClearMessages()
+	replaceSend := mustSendInEnvironment(t, apiKey, ref, fmt.Sprintf("original-replace-%d@test.example.com", time.Now().UnixNano()%1000000))
+	require.Len(t, replaceSend.TrackingIDs, 1)
+	require.Equal(t, replaceRecipient, replaceSend.TrackingIDs[0].To)
+	mustWaitForEmailStatusInEnvironment(t, client, "test", TenantCode, workspaceCode, replaceSend.TrackingIDs[0].TrackingID, "sent", 45*time.Second)
+	mailpit.WaitForMessages(1, 30*time.Second)
+	mailpit.AssertMessageExists(replaceRecipient)
+
+	appendRecipient := fmt.Sprintf("policy-append-%d@test.example.com", time.Now().UnixNano()%1000000)
+	workspaceAppendResp := client.Put(testPath, map[string]any{
+		"test_recipient_mode":      "append",
+		"test_recipient_addresses": []string{appendRecipient},
+	})
+	defer workspaceAppendResp.Body.Close()
+	RequireStatus(t, workspaceAppendResp, http.StatusOK)
+
+	mailpit.ClearMessages()
+	originalAppendRecipient := fmt.Sprintf("original-append-%d@test.example.com", time.Now().UnixNano()%1000000)
+	appendSend := mustSendInEnvironment(t, apiKey, ref, originalAppendRecipient)
+	require.Len(t, appendSend.TrackingIDs, 2)
+	appendTargets := []string{appendSend.TrackingIDs[0].To, appendSend.TrackingIDs[1].To}
+	require.ElementsMatch(t, []string{originalAppendRecipient, appendRecipient}, appendTargets)
+	for _, item := range appendSend.TrackingIDs {
+		mustWaitForEmailStatusInEnvironment(t, client, "test", TenantCode, workspaceCode, item.TrackingID, "sent", 45*time.Second)
+	}
+	mailpit.WaitForMessages(2, 30*time.Second)
+	mailpit.AssertMessageExists(originalAppendRecipient)
+	mailpit.AssertMessageExists(appendRecipient)
+
+	templateOverrideRecipient := fmt.Sprintf("policy-template-override-%d@test.example.com", time.Now().UnixNano()%1000000)
+	templateTypeUpdateResp := client.Put(testPath+"/template-types/"+templateSlug, map[string]any{
+		"test_recipient_mode":      "replace",
+		"test_recipient_addresses": []string{templateOverrideRecipient},
+	})
+	defer templateTypeUpdateResp.Body.Close()
+	RequireStatus(t, templateTypeUpdateResp, http.StatusOK)
+
+	templateTypeGetResp := client.Get(testPath + "/template-types/" + templateSlug)
+	defer templateTypeGetResp.Body.Close()
+	RequireStatus(t, templateTypeGetResp, http.StatusOK)
+
+	var templateTypeBody struct {
+		ID                     string   `json:"id"`
+		TestRecipientMode      *string  `json:"test_recipient_mode"`
+		TestRecipientAddresses []string `json:"test_recipient_addresses"`
+	}
+	ParseJSONResponse(t, templateTypeGetResp, &templateTypeBody)
+	require.Equal(t, setup.TemplateTypeID, templateTypeBody.ID)
+	require.NotNil(t, templateTypeBody.TestRecipientMode)
+	require.Equal(t, "replace", *templateTypeBody.TestRecipientMode)
+	require.Equal(t, []string{templateOverrideRecipient}, templateTypeBody.TestRecipientAddresses)
+
+	mailpit.ClearMessages()
+	templateOverrideSend := mustSendInEnvironment(t, apiKey, ref, fmt.Sprintf("original-template-%d@test.example.com", time.Now().UnixNano()%1000000))
+	require.Len(t, templateOverrideSend.TrackingIDs, 1)
+	require.Equal(t, templateOverrideRecipient, templateOverrideSend.TrackingIDs[0].To)
+	mustWaitForEmailStatusInEnvironment(t, client, "test", TenantCode, workspaceCode, templateOverrideSend.TrackingIDs[0].TrackingID, "sent", 45*time.Second)
+	mailpit.WaitForMessages(1, 30*time.Second)
+	mailpit.AssertMessageExists(templateOverrideRecipient)
+}

--- a/test/e2e/external_integration_test.go
+++ b/test/e2e/external_integration_test.go
@@ -38,7 +38,10 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 		resp := externalRequest(t, http.MethodGet,
 			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/template-types/%s/templates", TemplateTypeSlug),
 			nil,
-			map[string]string{"X-Tenant-Code": TenantCode},
+			map[string]string{
+				"X-Tenant-Code":       TenantCode,
+				"X-Senda-Environment": "prod",
+			},
 			"")
 		defer resp.Body.Close()
 		RequireStatus(t, resp, http.StatusOK)
@@ -54,7 +57,10 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 		resp = externalRequest(t, http.MethodGet,
 			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/versions/%s", templateID, draftVersionID),
 			nil,
-			map[string]string{"X-Tenant-Code": TenantCode},
+			map[string]string{
+				"X-Tenant-Code":       TenantCode,
+				"X-Senda-Environment": "prod",
+			},
 			"")
 		defer resp.Body.Close()
 		RequireStatus(t, resp, http.StatusOK)
@@ -70,7 +76,10 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 				"body_mjml":      SampleMJML(),
 				"default_locale": "en",
 			},
-			map[string]string{"X-Tenant-Code": TenantCode},
+			map[string]string{
+				"X-Tenant-Code":       TenantCode,
+				"X-Senda-Environment": "prod",
+			},
 			"",
 		)
 		defer updateResp.Body.Close()
@@ -79,7 +88,10 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 		previewResp := externalRequest(t, http.MethodPost,
 			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/preview-mjml", templateID),
 			map[string]any{"mjml": SampleMJML()},
-			map[string]string{"X-Tenant-Code": TenantCode},
+			map[string]string{
+				"X-Tenant-Code":       TenantCode,
+				"X-Senda-Environment": "prod",
+			},
 			"",
 		)
 		defer previewResp.Body.Close()
@@ -100,7 +112,10 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 					"company_name": "Tether",
 				},
 			},
-			map[string]string{"X-Tenant-Code": TenantCode},
+			map[string]string{
+				"X-Tenant-Code":       TenantCode,
+				"X-Senda-Environment": "prod",
+			},
 			"",
 		)
 		defer testSendResp.Body.Close()
@@ -109,7 +124,10 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 		publishResp := externalRequest(t, http.MethodPost,
 			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/versions/%s/publish", templateID, draftVersionID),
 			nil,
-			map[string]string{"X-Tenant-Code": TenantCode},
+			map[string]string{
+				"X-Tenant-Code":       TenantCode,
+				"X-Senda-Environment": "prod",
+			},
 			"",
 		)
 		defer publishResp.Body.Close()
@@ -120,7 +138,10 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 		readResp := externalRequest(t, http.MethodGet,
 			externalWorkspacePath("missing")+"/template-types",
 			nil,
-			map[string]string{"X-Tenant-Code": TenantCode},
+			map[string]string{
+				"X-Tenant-Code":       TenantCode,
+				"X-Senda-Environment": "prod",
+			},
 			"fallback=system",
 		)
 		defer readResp.Body.Close()
@@ -135,7 +156,10 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 				"body_mjml":      SampleMJML(),
 				"default_locale": "en",
 			},
-			map[string]string{"X-Tenant-Code": TenantCode},
+			map[string]string{
+				"X-Tenant-Code":       TenantCode,
+				"X-Senda-Environment": "prod",
+			},
 			"fallback=system",
 		)
 		defer writeResp.Body.Close()
@@ -146,7 +170,7 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 		resp := externalRequest(t, http.MethodGet,
 			externalWorkspacePath(WorkspaceCode)+"/template-types",
 			nil,
-			nil,
+			map[string]string{"X-Senda-Environment": "prod"},
 			"",
 		)
 		defer resp.Body.Close()
@@ -156,6 +180,18 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 			externalWorkspacePath(WorkspaceCode)+"/template-types",
 			nil,
 			map[string]string{"X-Tenant-Code": TenantCode},
+			"",
+		)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "missing environment header should fail: %s", ReadResponseBody(t, resp))
+
+		resp = externalRequest(t, http.MethodGet,
+			externalWorkspacePath(WorkspaceCode)+"/template-types",
+			nil,
+			map[string]string{
+				"X-Tenant-Code":       TenantCode,
+				"X-Senda-Environment": "prod",
+			},
 			"token=wrong-token",
 		)
 		defer resp.Body.Close()
@@ -164,7 +200,10 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 		resp = externalRequest(t, http.MethodGet,
 			externalWorkspacePath(WorkspaceCode)+"/template-types",
 			nil,
-			map[string]string{"X-Tenant-Code": "other-tenant"},
+			map[string]string{
+				"X-Tenant-Code":       "other-tenant",
+				"X-Senda-Environment": "prod",
+			},
 			"",
 		)
 		defer resp.Body.Close()
@@ -176,8 +215,9 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/versions/%s", templateID, draftVersionID),
 			nil,
 			map[string]string{
-				"X-Tenant-Code":           TenantCode,
+				"X-Tenant-Code":          TenantCode,
 				"X-Senda-External-Token": externalViewerToken,
+				"X-Senda-Environment":    "prod",
 			},
 			"",
 		)
@@ -194,8 +234,9 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 				"default_locale": "en",
 			},
 			map[string]string{
-				"X-Tenant-Code":           TenantCode,
+				"X-Tenant-Code":          TenantCode,
 				"X-Senda-External-Token": externalViewerToken,
+				"X-Senda-Environment":    "prod",
 			},
 			"",
 		)
@@ -206,8 +247,9 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 			externalWorkspacePath(WorkspaceCode)+fmt.Sprintf("/templates/%s/versions/%s/publish", templateID, draftVersionID),
 			nil,
 			map[string]string{
-				"X-Tenant-Code":           TenantCode,
+				"X-Tenant-Code":          TenantCode,
 				"X-Senda-External-Token": externalViewerToken,
+				"X-Senda-Environment":    "prod",
 			},
 			"",
 		)
@@ -223,8 +265,9 @@ func TestExternalIntegration01_APIHappyChaosAndMaliciousFlows(t *testing.T) {
 				},
 			},
 			map[string]string{
-				"X-Tenant-Code":           TenantCode,
+				"X-Tenant-Code":          TenantCode,
 				"X-Senda-External-Token": externalViewerToken,
+				"X-Senda-Environment":    "prod",
 			},
 			"",
 		)
@@ -247,8 +290,8 @@ func ensureExternalIntegrationProfile(t *testing.T, client *TestClient) {
 					"auth_method_name": "e2e-signed-token",
 					"resolver_name":    "e2e-workspace-resolver",
 					"allowed_origins":  []string{"http://localhost:3000"},
-					"allowed_headers":  []string{"x-tenant-code"},
-					"required_headers": []string{"x-tenant-code"},
+					"allowed_headers":  []string{"x-tenant-code", "x-senda-environment"},
+					"required_headers": []string{"x-tenant-code", "x-senda-environment"},
 					"capabilities": map[string]bool{
 						"list_templates":   true,
 						"view_versions":    true,

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -265,10 +265,10 @@ func (c *TestClient) Delete(path string) *http.Response {
 }
 
 // setAuthHeaders adds authorization headers to the request.
-// API keys are sent as "Authorization: Bearer senda_live_..." (same header, different prefix).
+// API keys are sent as "Authorization: Bearer senda_prod_..." or "Authorization: Bearer senda_test_..." (same header, different prefix).
 func (c *TestClient) setAuthHeaders(req *http.Request) {
 	if c.apiKey != "" {
-		// API keys use Bearer token format; the server detects them by the "senda_live_" prefix.
+		// API keys use Bearer token format; the server detects them by the "senda_prod_" / "senda_test_" prefix.
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)
 		return
 	}

--- a/test/e2e/security_test.go
+++ b/test/e2e/security_test.go
@@ -850,10 +850,10 @@ func TestS10_CryptographicValidation(t *testing.T) {
 		if resp.StatusCode == http.StatusCreated {
 			body := ReadResponseBody(t, resp)
 
-			// Server uses "senda_live_" prefix for API keys
+			// Server now uses explicit environment prefixes for API keys.
 			require.True(t,
-				strings.Contains(body, "senda_live_") || strings.Contains(body, "senda_test_"),
-				"API key should have senda_live_ or senda_test_ prefix, got: %s", body)
+				strings.Contains(body, "senda_prod_") || strings.Contains(body, "senda_test_"),
+				"API key should have senda_prod_ or senda_test_ prefix, got: %s", body)
 		}
 	})
 

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -1,38 +1,28 @@
+
 # System Test Harness (Full Coverage)
 
 This directory contains the full-system test harness for Senda:
 
-- Backend deterministic tests + contract verification.
-- Security/chaos suites.
-- UI flow traversal for all routes/scopes/roles/locales/viewports.
-- Visual diff against golden + Pencil baselines (opt-in).
-- Accessibility checks (axe + semantic checks).
+- backend deterministic and contract coverage
+- chaos / recovery validation
+- UI route and flow traversal
+- environment-mode validation for `prod` / `test`
+- accessibility and optional visual diff stages
 
 ## Commands
 
-- PR gate:
-  - `make system-pr`
-- Nightly full gate:
-  - `make system-nightly`
-- Optional visual baseline pass:
-  - `SYSTEM_UI_VISUAL=1 make system-pr`
-  - `SYSTEM_UI_VISUAL=1 make system-nightly`
-- Validate route coverage manifest:
-  - `make system-validate-manifest`
-- Generate matrix only:
-  - `make system-matrix`
+- `make system-pr`
+- `make system-nightly`
+- `make system-validate-manifest`
+- `make system-matrix`
+- `make system-down`
 
-Main orchestrator:
+## Main orchestrator
 
 - `test/system/system-runner.sh pr`
 - `test/system/system-runner.sh nightly`
 
-The orchestrator now expects a unified stack lifecycle command from `cmd/systemtest`:
-
-- `stack up --mode <pr|nightly> --out <env-report.json>`
-- `stack down --out <env-report.json>`
-
-`env-report.json` becomes the source of truth for service base URLs consumed by the subagents. The frontend remains host-side and is still started locally by the UI stages.
+The harness expects the unified stack lifecycle via `cmd/systemtest` and consumes the generated env report as the source of truth for base URLs.
 
 ## Subagents
 
@@ -41,122 +31,34 @@ The orchestrator now expects a unified stack lifecycle command from `cmd/systemt
 - `subagents/security-chaos-tester.sh`
 - `subagents/ui-flow-tester.sh`
 - `subagents/ui-workspace-management-tester.sh`
+- `subagents/ui-environment-mode-tester.sh`
 - `subagents/ui-adapter-sharing-tester.sh`
 - `subagents/ui-injector-flow-tester.sh`
 - `subagents/ui-onboarding-auth-guard-tester.sh`
 - `subagents/ui-visual-tester.sh`
 - `subagents/ui-a11y-tester.sh`
 
-## Contracts
+## Environment-mode stage
 
-- `screen-manifest.json`: route/scenario manifest (must cover all `web/src/app/**/page.tsx` routes).
-- `visual-baseline-map.json`: route -> Pencil frame + criticality.
-- `run-result.schema.json`: unified run-result contract.
+`ui-environment-mode-tester.sh` validates the browser-facing environment model:
 
-Validation is enforced by:
+- switch between `prod` and `test`
+- environment-aware navigation
+- environment-scoped workspace state
+- test-only workspace controls
+- template-type test recipient override controls
 
-- `go run ./cmd/systemtest validate-manifest ...`
+## Outputs
 
-If a new route appears without manifest scenario + baseline map entry, the gate fails.
+The harness writes reports such as:
 
-## Baselines
-
-- Goldens: `test/system/baselines/golden`
-- Pencil: `test/system/baselines/pencil`
-
-By default, PR and nightly runs skip the visual baseline diff stage and use functional,
-security, accessibility, and manual QA as the release blockers. Set `SYSTEM_UI_VISUAL=1`
-when you explicitly want to generate screenshots and compare them against baselines.
-
-Expected naming convention:
-
-- `<routeSlug>.<viewport>.<locale>.png`
-- Example: `global__templates__slug__edit.desktop.en.png`
-
-`routeSlug` is generated from route by:
-
-- remove leading `/`
-- replace `/` with `__`
-- remove `[` and `]`
-- `/` root route => `root`
-
-## Artifacts
-
-Each run writes to:
-
-- `artifacts/system/<timestamp>/`
-
-Key outputs:
-
-- `functional-junit.xml`
 - `api-contract-report.md`
 - `security-chaos-report.md`
 - `ui-flow-report.md`
 - `ui-workspace-management-report.md`
+- `ui-environment-mode-report.md`
 - `ui-adapter-sharing-report.md`
 - `ui-injector-flow-report.md`
 - `ui-onboarding-auth-guard-report.md`
-- `visual-diff-report.html`
 - `a11y-report.md`
-- `coverage-matrix.csv`
 - `run-result.json`
-- `stage-results.tsv`
-
-## Injector UI flow stage
-
-`subagents/ui-injector-flow-tester.sh` is the dedicated browser/system regression for the
-new workspace-owned injector model.
-
-It uses the runtime env report from `infra-orchestrator`, starts the frontend locally, logs in
-through OIDC, and validates the full UI flow against the running backend + Mailpit stack.
-
-Coverage:
-
-- injector management in the workspace UI
-- per-field `default_value`
-- per-field `allow_overwrite`
-- locked-field validation (`allow_overwrite=false` requires default)
-- template editor token palette shows only workspace injectors grouped by field
-- test-send modal:
-  - locked fields are read-only
-  - untouched overwriteable fields fall back to runtime precedence
-  - explicit overrides win
-  - explicit empty override renders empty string
-- bulk-send modal accepts per-item `injectors` JSON overrides
-- Mailpit confirms rendered output for:
-  - default-only
-  - reqBody override
-  - code fallback
-  - locked field behavior
-  - bulk-send partial fallback per field
-
-Useful direct invocation:
-
-```bash
-ARTIFACT_DIR=/tmp/senda-ui-injector-flow \
-ENV_REPORT_FILE=artifacts/system/<timestamp>/env-report.json \
-FRONTEND_BASE_URL=http://localhost:3000 \
-test/system/subagents/ui-injector-flow-tester.sh
-```
-
-## Onboarding auth guard stage
-
-`subagents/ui-onboarding-auth-guard-tester.sh` verifies that `/onboarding` does not leak
-wizard step 2/3 when the browser is unauthenticated but still has stale onboarding state
-in `sessionStorage`.
-
-Coverage:
-
-- seeds stale `senda-onboarding` sessionStorage state
-- opens `/onboarding` in a fresh unauthenticated browser session
-- expects redirect to `/login`
-- rejects leaked onboarding content such as “Create your organization” or “Create your workspace”
-
-## Environment defaults
-
-- Backend: `http://localhost:8090`
-- Frontend: `http://localhost:3000`
-- Keycloak: `http://localhost:9090`
-- Mailpit: `http://localhost:9025`
-
-Configurable via env vars in `test/system/subagents/lib.sh`.

--- a/test/system/batch-flows-e2e.sh
+++ b/test/system/batch-flows-e2e.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/artifacts/system/batch-flows-$(date -u +%Y%m%dT%H%M%SZ)}"
 BACKEND_PID_FILE="$ARTIFACT_DIR/backend.pid"
 BACKEND_LOG_FILE="$ARTIFACT_DIR/backend.log"
@@ -244,7 +244,8 @@ ensure_keycloak_user "$SUPERADMIN_EMAIL" "$SUPERADMIN_PASSWORD" "Superadmin" "Bo
 ensure_keycloak_user "$WORKSPACE_EDITOR_EMAIL" "$WORKSPACE_EDITOR_PASSWORD" "Workspace" "Editor"
 reset_test_database
 start_local_backend
-export SENDA_E2E_SUPERADMIN_TOKEN="$(issue_superadmin_token)"
+SENDA_E2E_SUPERADMIN_TOKEN="$(issue_superadmin_token)"
+export SENDA_E2E_SUPERADMIN_TOKEN
 if [[ -z "$SENDA_E2E_SUPERADMIN_TOKEN" || "$SENDA_E2E_SUPERADMIN_TOKEN" == "null" ]]; then
   echo "failed to issue static superadmin token for E2E" >&2
   exit 1

--- a/test/system/screen-manifest.json
+++ b/test/system/screen-manifest.json
@@ -1516,6 +1516,87 @@
       "critical": true
     },
     {
+      "route": "/embed/[profileSlug]/t/[tenantCode]/w/[workspaceCode]/templates/[slug]/edit",
+      "scope": [
+        "workspace"
+      ],
+      "role": [
+        "superadmin",
+        "tenant-admin",
+        "workspace-admin",
+        "workspace-editor",
+        "workspace-viewer",
+        "no-member"
+      ],
+      "locale": [
+        "en",
+        "es"
+      ],
+      "viewport": [
+        "desktop",
+        "mobile"
+      ],
+      "preconditions": [
+        "template slug exists",
+        "TEMPLATE_SLUG resolved",
+        "external integration bootstrap configured"
+      ],
+      "actions": [
+        "open route",
+        "wait network idle",
+        "verify embed builder shell renders"
+      ],
+      "assertions": [
+        "HTTP render without crash",
+        "no runtime fatal errors",
+        "page not 404",
+        "external embed shell remains available"
+      ],
+      "pencilFrameId": "frame:t__tenantCode__w__workspaceCode__templates__slug__edit",
+      "critical": true
+    },
+    {
+      "route": "/embed/[profileSlug]/environments/[environment]/t/[tenantCode]/w/[workspaceCode]/templates/[slug]/edit",
+      "scope": [
+        "workspace"
+      ],
+      "role": [
+        "superadmin",
+        "tenant-admin",
+        "workspace-admin",
+        "workspace-editor",
+        "workspace-viewer",
+        "no-member"
+      ],
+      "locale": [
+        "en",
+        "es"
+      ],
+      "viewport": [
+        "desktop",
+        "mobile"
+      ],
+      "preconditions": [
+        "template slug exists",
+        "TEMPLATE_SLUG resolved",
+        "external integration bootstrap configured"
+      ],
+      "actions": [
+        "open route",
+        "wait network idle",
+        "verify embed builder shell renders",
+        "verify environment-aware bootstrap path is used"
+      ],
+      "assertions": [
+        "HTTP render without crash",
+        "no runtime fatal errors",
+        "page not 404",
+        "external embed shell remains available"
+      ],
+      "pencilFrameId": "frame:t__tenantCode__w__workspaceCode__templates__slug__edit",
+      "critical": true
+    },
+    {
       "route": "/t/[tenantCode]/w/[workspaceCode]/templates/[slug]",
       "scope": [
         "workspace"

--- a/test/system/subagents/api-contract-tester.sh
+++ b/test/system/subagents/api-contract-tester.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=test/system/subagents/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 require_cmd go
@@ -29,6 +30,16 @@ SHARED_SES_NAME="${SHARED_SES_NAME:-API Contract Shared SES}"
 SHARED_SES_DOMAIN="${SHARED_SES_DOMAIN:-api-contract.shared-mail.test}"
 SHARED_SES_DEFAULT_EMAIL="${SHARED_SES_DEFAULT_EMAIL:-default@${SHARED_SES_DOMAIN}}"
 SHARED_SES_TEMP_EMAIL="${SHARED_SES_TEMP_EMAIL:-shared-sender@${SHARED_SES_DOMAIN}}"
+ENV_FIXTURE_SUFFIX="$(basename "$ARTIFACT_DIR" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '-' | cut -c1-10)"
+ENV_FIXTURE_WORKSPACE_CODE="${ENV_FIXTURE_WORKSPACE_CODE:-api-env-${ENV_FIXTURE_SUFFIX}}"
+ENV_FIXTURE_WORKSPACE_NAME="${ENV_FIXTURE_WORKSPACE_NAME:-API Environment Fixture}"
+ENV_FIXTURE_TEST_RECIPIENT_A="${ENV_FIXTURE_TEST_RECIPIENT_A:-api-env-${ENV_FIXTURE_SUFFIX}@test.example.com}"
+ENV_FIXTURE_TEST_RECIPIENT_B="${ENV_FIXTURE_TEST_RECIPIENT_B:-api-env-review-${ENV_FIXTURE_SUFFIX}@test.example.com}"
+ENV_FIXTURE_PROD_KEY_NAME="${ENV_FIXTURE_PROD_KEY_NAME:-API Contract Prod Environment Key}"
+ENV_FIXTURE_TEST_KEY_NAME="${ENV_FIXTURE_TEST_KEY_NAME:-API Contract Test Environment Key}"
+EXTERNAL_PROFILE_SLUG="${EXTERNAL_PROFILE_SLUG:-partner-portal}"
+EXTERNAL_PROFILE_TOKEN="${EXTERNAL_PROFILE_TOKEN:-external-e2e-token}"
+WORKSPACE_CODE="${WORKSPACE_CODE:-${SYSTEM_WORKSPACE_CODE:-main}}"
 
 run_repo_tests_without_system_env() {
   local target="$1"
@@ -93,6 +104,57 @@ bootstrap_api_status() {
 
 bootstrap_api_get() {
   bootstrap_api_expect "200" GET "$1"
+}
+
+bootstrap_api_request_with_headers() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  shift 3 || true
+
+  local curl_args=(
+    -sS
+    -w $'\n%{http_code}'
+    -X "$method"
+    "$SENDA_BASE_URL$path"
+    -H "Authorization: Bearer $E2E_BOOTSTRAP_TOKEN"
+  )
+
+  local header
+  for header in "$@"; do
+    curl_args+=(-H "$header")
+  done
+
+  if [[ -n "$body" ]]; then
+    curl_args+=(-H 'Content-Type: application/json' --data "$body")
+  fi
+
+  curl "${curl_args[@]}"
+}
+
+external_api_request() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  shift 3 || true
+
+  local curl_args=(
+    -sS
+    -w $'\n%{http_code}'
+    -X "$method"
+    "$SENDA_BASE_URL$path"
+  )
+
+  local header
+  for header in "$@"; do
+    curl_args+=(-H "$header")
+  done
+
+  if [[ -n "$body" ]]; then
+    curl_args+=(-H 'Content-Type: application/json' --data "$body")
+  fi
+
+  curl "${curl_args[@]}"
 }
 
 ensure_tenant_workspace() {
@@ -188,7 +250,7 @@ sync_adapter_identities() {
 
 create_aws_sim_identity() {
   local identity="$1"
-  go run "$ROOT_DIR/cmd/systemtest" aws-sim-create-identity \
+  systemtest aws-sim-create-identity \
     --endpoint "$AWS_SIM_BASE_URL" \
     --identity "$identity" >/dev/null
 }
@@ -252,12 +314,178 @@ delete_manual_identity_if_exists() {
   fi
 }
 
+ensure_external_integration_profile() {
+  bootstrap_api_expect "200" PUT "/api/v1/manage/config" "$(cat <<EOF_JSON
+{
+  "external_integrations": {
+    "profiles": [
+      {
+        "slug": "${EXTERNAL_PROFILE_SLUG}",
+        "name": "Partner Portal",
+        "description": "System test external integration profile",
+        "enabled": true,
+        "auth_method_name": "e2e-signed-token",
+        "resolver_name": "e2e-workspace-resolver",
+        "allowed_origins": ["http://localhost:3000"],
+        "allowed_headers": ["x-tenant-code", "x-senda-external-token"],
+        "required_headers": ["x-tenant-code"],
+        "capabilities": {
+          "list_templates": true,
+          "view_versions": true,
+          "edit_versions": true,
+          "publish_versions": true,
+          "test_send": true,
+          "builder_access": true,
+          "metadata_access": true,
+          "locale_access": true
+        }
+      }
+    ]
+  }
+}
+EOF_JSON
+)" >/dev/null
+}
+
+run_environment_contract_checks() {
+  log "api-contract-tester: running environment contract checks"
+
+  ensure_tenant_workspace "$ENV_FIXTURE_WORKSPACE_CODE" "$ENV_FIXTURE_WORKSPACE_NAME"
+  ensure_external_integration_profile
+
+  local prod_list test_list prod_workspace prod_reject_response prod_reject_status prod_reject_payload
+  local test_update_response test_key_response prod_key_response test_key prod_key test_key_id prod_key_id
+  local reset_prod_response reset_prod_status reset_prod_payload reset_test_status
+  local external_missing_response external_missing_status external_missing_payload
+  local external_invalid_response external_invalid_status external_invalid_payload
+  local external_ok_response external_ok_status bootstrap_test_status
+  local env_prod_base="/api/v1/manage/environments/prod/tenants/${TENANT_CODE}/workspaces/${ENV_FIXTURE_WORKSPACE_CODE}"
+  local env_test_base="/api/v1/manage/environments/test/tenants/${TENANT_CODE}/workspaces/${ENV_FIXTURE_WORKSPACE_CODE}"
+  local external_base="/api/v1/external/${EXTERNAL_PROFILE_SLUG}/tenants/${TENANT_CODE}/workspaces/${ENV_FIXTURE_WORKSPACE_CODE}"
+
+  prod_list="$(bootstrap_api_get "/api/v1/manage/tenants/${TENANT_CODE}/workspaces")"
+  printf '%s\n' "$prod_list" | jq -e --arg code "$ENV_FIXTURE_WORKSPACE_CODE" '
+    any(.items[]; .code == $code and .environment == "prod")
+  ' >/dev/null
+
+  test_list="$(bootstrap_api_get "/api/v1/manage/environments/test/tenants/${TENANT_CODE}/workspaces")"
+  printf '%s\n' "$test_list" | jq -e --arg code "$ENV_FIXTURE_WORKSPACE_CODE" '
+    any(.items[]; .code == $code and .environment == "test")
+  ' >/dev/null
+
+  prod_workspace="$(bootstrap_api_get "$env_prod_base")"
+  printf '%s\n' "$prod_workspace" | jq -e '
+    .environment == "prod"
+    and ((.test_recipient_addresses // []) | length == 0)
+    and ((.test_recipient_mode // "replace") == "replace")
+  ' >/dev/null
+
+  prod_reject_response="$(bootstrap_api_request_with_headers PUT "$env_prod_base" "$(cat <<EOF_JSON
+{"test_recipient_mode":"append","test_recipient_addresses":["${ENV_FIXTURE_TEST_RECIPIENT_A}","${ENV_FIXTURE_TEST_RECIPIENT_B}"]}
+EOF_JSON
+)")"
+  prod_reject_status="$(printf '%s\n' "$prod_reject_response" | tail -n1)"
+  prod_reject_payload="$(printf '%s\n' "$prod_reject_response" | sed '$d')"
+  [[ "$prod_reject_status" == "422" ]]
+  printf '%s\n' "$prod_reject_payload" | jq -e '
+    .error.message == "validation failed"
+    and ((.error.fields // .error.details // []) | any(.field == "test_recipient_mode"))
+  ' >/dev/null
+
+  test_update_response="$(bootstrap_api_expect "200" PUT "$env_test_base" "$(cat <<EOF_JSON
+{"test_recipient_mode":"append","test_recipient_addresses":["${ENV_FIXTURE_TEST_RECIPIENT_A}","${ENV_FIXTURE_TEST_RECIPIENT_B}"]}
+EOF_JSON
+)")"
+  printf '%s\n' "$test_update_response" | jq -e \
+    --arg addr1 "$ENV_FIXTURE_TEST_RECIPIENT_A" \
+    --arg addr2 "$ENV_FIXTURE_TEST_RECIPIENT_B" '
+      .environment == "test"
+      and .test_recipient_mode == "append"
+      and (.test_recipient_addresses | index($addr1))
+      and (.test_recipient_addresses | index($addr2))
+    ' >/dev/null
+
+  prod_workspace="$(bootstrap_api_get "$env_prod_base")"
+  printf '%s\n' "$prod_workspace" | jq -e '
+    .environment == "prod"
+    and ((.test_recipient_addresses // []) | length == 0)
+    and ((.test_recipient_mode // "replace") == "replace")
+  ' >/dev/null
+
+  reset_prod_response="$(bootstrap_api_request_with_headers POST "${env_prod_base}/runtime/reset" "")"
+  reset_prod_status="$(printf '%s\n' "$reset_prod_response" | tail -n1)"
+  reset_prod_payload="$(printf '%s\n' "$reset_prod_response" | sed '$d')"
+  [[ "$reset_prod_status" == "409" ]]
+  printf '%s\n' "$reset_prod_payload" | jq -e '
+    .error.code == "TEST_ENVIRONMENT_REQUIRED"
+  ' >/dev/null
+
+  reset_test_status="$(bootstrap_api_status POST "${env_test_base}/runtime/reset")"
+  [[ "$reset_test_status" == "204" ]]
+
+  prod_key_response="$(bootstrap_api_expect "201" POST "${env_prod_base}/api-keys" "$(cat <<EOF_JSON
+{"name":"${ENV_FIXTURE_PROD_KEY_NAME}"}
+EOF_JSON
+)")"
+  prod_key="$(printf '%s\n' "$prod_key_response" | jq -r '.key')"
+  prod_key_id="$(printf '%s\n' "$prod_key_response" | jq -r '.id')"
+  [[ "$prod_key" == senda_prod_* ]]
+
+  test_key_response="$(bootstrap_api_expect "201" POST "${env_test_base}/api-keys" "$(cat <<EOF_JSON
+{"name":"${ENV_FIXTURE_TEST_KEY_NAME}"}
+EOF_JSON
+)")"
+  test_key="$(printf '%s\n' "$test_key_response" | jq -r '.key')"
+  test_key_id="$(printf '%s\n' "$test_key_response" | jq -r '.id')"
+  [[ "$test_key" == senda_test_* ]]
+
+  bootstrap_api_expect "204" DELETE "${env_prod_base}/api-keys/${prod_key_id}" >/dev/null
+  bootstrap_api_expect "204" DELETE "${env_test_base}/api-keys/${test_key_id}" >/dev/null
+
+  bootstrap_test_status="$(external_api_request GET "/api/v1/external/${EXTERNAL_PROFILE_SLUG}/environments/test/bootstrap" "" | tail -n1)"
+  [[ "$bootstrap_test_status" == "200" ]]
+
+  external_missing_response="$(external_api_request GET "${external_base}/template-types?token=${EXTERNAL_PROFILE_TOKEN}" "" "X-Tenant-Code: ${TENANT_CODE}")"
+  external_missing_status="$(printf '%s\n' "$external_missing_response" | tail -n1)"
+  external_missing_payload="$(printf '%s\n' "$external_missing_response" | sed '$d')"
+  [[ "$external_missing_status" == "400" ]]
+  printf '%s\n' "$external_missing_payload" | jq -e '
+    .error.message == "missing required header X-Senda-Environment"
+  ' >/dev/null
+
+  external_invalid_response="$(external_api_request GET "${external_base}/template-types?token=${EXTERNAL_PROFILE_TOKEN}" "" "X-Tenant-Code: ${TENANT_CODE}" "X-Senda-Environment: sandbox")"
+  external_invalid_status="$(printf '%s\n' "$external_invalid_response" | tail -n1)"
+  external_invalid_payload="$(printf '%s\n' "$external_invalid_response" | sed '$d')"
+  [[ "$external_invalid_status" == "400" ]]
+  printf '%s\n' "$external_invalid_payload" | jq -e '
+    .error.message == "invalid X-Senda-Environment header"
+  ' >/dev/null
+
+  external_ok_response="$(external_api_request GET "${external_base}/template-types?token=${EXTERNAL_PROFILE_TOKEN}" "" "X-Tenant-Code: ${TENANT_CODE}" "X-Senda-Environment: test")"
+  external_ok_status="$(printf '%s\n' "$external_ok_response" | tail -n1)"
+  [[ "$external_ok_status" == "200" ]]
+
+  ENVIRONMENT_CONTRACT_GATES=$(cat <<EOF_GATES
+4. Environment-scoped management contract:
+   - \`GET /api/v1/manage/tenants/${TENANT_CODE}/workspaces\` resolves prod workspaces by default.
+   - \`GET /api/v1/manage/environments/test/tenants/${TENANT_CODE}/workspaces\` resolves the test workspace set.
+   - \`GET|PUT /api/v1/manage/environments/{prod|test}/tenants/${TENANT_CODE}/workspaces/${ENV_FIXTURE_WORKSPACE_CODE}\` keeps test-recipient state isolated to the test environment.
+   - \`POST /runtime/reset\` rejects prod with \`TEST_ENVIRONMENT_REQUIRED\` and succeeds for test.
+5. Environment-scoped API key generation returns \`senda_prod_\` for prod and \`senda_test_\` for test.
+6. External integration contract:
+   - \`GET /api/v1/external/${EXTERNAL_PROFILE_SLUG}/environments/test/bootstrap\` succeeds.
+   - Scoped external routes reject missing/invalid \`X-Senda-Environment\`.
+   - Scoped external routes accept \`X-Senda-Environment: test\` when the rest of the request is valid.
+EOF_GATES
+)
+}
+
 log "api-contract-tester: seeding keycloak users + RBAC"
 seed_keycloak_users
 seed_rbac_memberships
 
 log "api-contract-tester: ensuring deterministic E2E tenant exists (test-corp)"
-E2E_BOOTSTRAP_TOKEN="$(go run "$ROOT_DIR/cmd/systemtest" token --email "$SUPERADMIN_EMAIL" --secret "$SENDA_E2E_JWT_SECRET" | tail -n1)"
+E2E_BOOTSTRAP_TOKEN="$(systemtest token --email "$SUPERADMIN_EMAIL" --secret "$SENDA_E2E_JWT_SECRET" | tail -n1)"
 E2E_TENANT_BODY="$ARTIFACT_DIR/e2e-tenant-create.json"
 E2E_TENANT_STATUS="$(curl -sS -o "$E2E_TENANT_BODY" -w '%{http_code}' \
   -X POST "$SENDA_BASE_URL/api/v1/manage/tenants" \
@@ -271,7 +499,7 @@ if [[ "$E2E_TENANT_STATUS" != "201" && "$E2E_TENANT_STATUS" != "409" ]]; then
 fi
 
 log "api-contract-tester: seeding deterministic E2E fixture RBAC (test-corp/main)"
-go run "$ROOT_DIR/cmd/systemtest" seed-rbac \
+systemtest seed-rbac \
   --base-url "$SENDA_BASE_URL" \
   --email "$SUPERADMIN_EMAIL" \
   --secret "$SENDA_E2E_JWT_SECRET" \
@@ -351,6 +579,8 @@ set -a
 source "$RUNTIME_ENV_FILE"
 set +a
 
+run_environment_contract_checks
+
 log "api-contract-tester: executing Postman collection with newman"
 set +e
 corepack pnpm dlx newman run "$COLLECTION" \
@@ -399,14 +629,16 @@ if [[ "${SYSTEM_API_CONTRACT_FULL:-0}" == "1" ]]; then
 1. \`make test\` (unit tests).
 2. \`make test-integration\` (integration tests).
 3. Newman run over collection: \`$COLLECTION\`.
-4. Optional deterministic E2E backend suites are available via \`SYSTEM_API_CONTRACT_E2E=1\`, but are not part of the default API-contract gate because nightly already runs dedicated security/chaos coverage separately.
+${ENVIRONMENT_CONTRACT_GATES}
+7. Optional deterministic E2E backend suites are available via \`SYSTEM_API_CONTRACT_E2E=1\`, but are not part of the default API-contract gate because nightly already runs dedicated security/chaos coverage separately.
 EOF_GATES
 )
 else
   EXECUTED_GATES=$(cat <<EOF_GATES
 1. Seed deterministic auth + RBAC fixtures for the system test tenant/workspace.
 2. Newman run over collection: \`$COLLECTION\`.
-3. Dedicated backend/unit/integration/E2E suites are expected to run in their own gates; opt in here with \`SYSTEM_API_CONTRACT_FULL=1\` and/or \`SYSTEM_API_CONTRACT_E2E=1\` when explicitly needed.
+${ENVIRONMENT_CONTRACT_GATES}
+7. Dedicated backend/unit/integration/E2E suites are expected to run in their own gates; opt in here with \`SYSTEM_API_CONTRACT_FULL=1\` and/or \`SYSTEM_API_CONTRACT_E2E=1\` when explicitly needed.
 EOF_GATES
 )
 fi

--- a/test/system/subagents/infra-orchestrator.sh
+++ b/test/system/subagents/infra-orchestrator.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=test/system/subagents/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 ACTION="${1:-up}"
@@ -11,7 +12,7 @@ require_cmd curl
 require_cmd jq
 
 stack_cmd() {
-  go run "$ROOT_DIR/cmd/systemtest" stack "$@"
+  systemtest stack "$@"
 }
 
 health_check() {

--- a/test/system/subagents/lib.sh
+++ b/test/system/subagents/lib.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
 SYSTEM_MODE="${SYSTEM_MODE:-pr}"
 ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/artifacts/system/$(date -u +%Y%m%dT%H%M%SZ)}"
 ENV_REPORT_FILE="${ENV_REPORT_FILE:-$ARTIFACT_DIR/env-report.json}"
@@ -53,6 +53,13 @@ pnpm_cmd() {
 
 pnpm_web() {
   pnpm_cmd --dir "$ROOT_DIR/web" "$@"
+}
+
+systemtest() {
+  (
+    cd "$ROOT_DIR"
+    go run ./cmd/systemtest "$@"
+  )
 }
 
 load_env_report() {
@@ -220,11 +227,15 @@ ensure_runtime_env() {
 
   local runtime_env="${RUNTIME_ENV_FILE:-$ARTIFACT_DIR/runtime.env}"
   if [[ -f "$runtime_env" ]]; then
-    return 0
+    if [[ ! -f "$ENV_REPORT_FILE" || "$runtime_env" -nt "$ENV_REPORT_FILE" ]]; then
+      return 0
+    fi
+    log "runtime context is older than env-report; regenerating -> $runtime_env"
+    rm -f "$runtime_env"
   fi
 
   log "resolving runtime context -> $runtime_env"
-  go run "$ROOT_DIR/cmd/systemtest" resolve-context \
+  systemtest resolve-context \
     --base-url "$SENDA_BASE_URL" \
     --email "$SUPERADMIN_EMAIL" \
     --secret "$SENDA_E2E_JWT_SECRET" \
@@ -251,7 +262,7 @@ seed_keycloak_users() {
   load_env_report
 
   log "seeding keycloak users"
-  if ! go run "$ROOT_DIR/cmd/systemtest" keycloak-seed \
+  if ! systemtest keycloak-seed \
     --base-url "$KEYCLOAK_BASE_URL" \
     --realm "$KEYCLOAK_REALM" \
     --admin-user "$KEYCLOAK_ADMIN_USER" \
@@ -266,7 +277,7 @@ seed_rbac_memberships() {
   ensure_runtime_env
   load_runtime_env
   log "seeding RBAC member roles"
-  go run "$ROOT_DIR/cmd/systemtest" seed-rbac \
+  systemtest seed-rbac \
     --base-url "$SENDA_BASE_URL" \
     --email "$SUPERADMIN_EMAIL" \
     --secret "$SENDA_E2E_JWT_SECRET" \

--- a/test/system/subagents/ui-a11y-tester.sh
+++ b/test/system/subagents/ui-a11y-tester.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=test/system/subagents/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 require_cmd go
@@ -244,7 +245,7 @@ load_runtime_env
 seed_keycloak_users
 seed_rbac_memberships
 
-go run "$ROOT_DIR/cmd/systemtest" matrix \
+systemtest matrix \
   --manifest "$ROOT_DIR/test/system/screen-manifest.json" \
   --format tsv \
   --out "$MATRIX_TSV"
@@ -259,7 +260,7 @@ echo -e "route\tscope\trole\tlocale\tviewport\tstatus\tcritical\tserious\tmanual
 max_cases="${A11Y_MAX_CASES:-0}"
 case_count=0
 
-while IFS=$'\t' read -r route route_slug scope role locale viewport critical pencil_frame_id preconditions actions assertions; do
+while IFS=$'\t' read -r route route_slug scope role locale viewport _critical _pencil_frame_id _preconditions _actions _assertions; do
   if [[ "$route" == "route" ]]; then
     continue
   fi

--- a/test/system/subagents/ui-adapter-sharing-tester.sh
+++ b/test/system/subagents/ui-adapter-sharing-tester.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=test/system/subagents/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 require_cmd agent-browser
@@ -27,6 +28,7 @@ EMAIL_DETAIL_JSON="$ARTIFACT_DIR/ui-adapter-sharing-email-detail.json"
 
 TENANT_CODE="${TENANT_CODE:-${SYSTEM_TENANT_CODE:-test-corp}}"
 SYSTEM_WORKSPACE_CODE_UI="_system"
+SYSTEM_WORKSPACE_SCOPE_LABEL_UI="Default scope"
 AWS_SIM_INTERNAL_URL="${AWS_SIM_INTERNAL_URL:-http://aws-sim:4566}"
 FIXTURE_SUFFIX="$(basename "$ARTIFACT_DIR" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '-' | cut -c1-12)"
 WORKSPACE_A_CODE="share-a-${FIXTURE_SUFFIX}"
@@ -94,7 +96,7 @@ start_frontend_dev() {
 tenant_admin_token() {
   if [[ -z "${TENANT_ADMIN_TOKEN:-}" ]]; then
     TENANT_ADMIN_TOKEN="$(
-      go run "$ROOT_DIR/cmd/systemtest" token \
+      systemtest token \
         --email "$TENANT_ADMIN_EMAIL" \
         --secret "$SENDA_E2E_JWT_SECRET" \
         | tail -n1
@@ -291,7 +293,7 @@ ensure_tracking_provisioned() {
 
 create_aws_sim_identity() {
   local identity="$1"
-  go run "$ROOT_DIR/cmd/systemtest" aws-sim-create-identity \
+  systemtest aws-sim-create-identity \
     --endpoint "$AWS_SIM_BASE_URL" \
     --identity "$identity" >/dev/null
 }
@@ -747,7 +749,7 @@ ab screenshot "$SCREENSHOT_DIR/06-workspace-a-shared-adapters.png" >/dev/null
 
 click_adapter_row_action "$SES_NAME" 0
 wait_for_text "Sender Identities — ${SES_NAME}"
-wait_for_text "Shared from _system — read only"
+wait_for_text "Shared from ${SYSTEM_WORKSPACE_SCOPE_LABEL_UI} — read only"
 wait_for_text "$SES_EMAIL_A"
 if ab_json eval "(() => (document.body?.innerText || '').includes('${SES_EMAIL_B}'))()" | jq -e '.data.result == true' >/dev/null; then
   echo "workspace A shared sender panel should not expose ${SES_EMAIL_B}" >&2

--- a/test/system/subagents/ui-environment-mode-tester.sh
+++ b/test/system/subagents/ui-environment-mode-tester.sh
@@ -1,0 +1,591 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+require_cmd agent-browser
+require_cmd jq
+require_cmd curl
+require_cmd timeout
+require_cmd corepack
+
+SESSION_NAME="senda-environment-mode-$(basename "$ARTIFACT_DIR" | tr -cs '[:alnum:]' '-')"
+STATE_FILE="$ARTIFACT_DIR/ui-environment-mode.state.json"
+FRONTEND_PID_FILE="$ARTIFACT_DIR/ui-environment-mode.frontend-dev.pid"
+FRONTEND_LOG_FILE="$ARTIFACT_DIR/ui-environment-mode.frontend-dev.log"
+REPORT_PATH="$ARTIFACT_DIR/ui-environment-mode-report.md"
+SCREENSHOT_DIR="$ARTIFACT_DIR/ui-environment-mode"
+
+TENANT_CODE="${TENANT_CODE:-${SYSTEM_TENANT_CODE:-test-corp}}"
+FIXTURE_SUFFIX="$(basename "$ARTIFACT_DIR" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '-' | rev | cut -c1-12 | rev | sed 's/^-*//; s/-*$//')"
+WORKSPACE_CODE="${WORKSPACE_CODE:-${UI_ENV_WORKSPACE_CODE:-ui-env-${FIXTURE_SUFFIX}}}"
+WORKSPACE_NAME="${WORKSPACE_NAME:-${UI_ENV_WORKSPACE_NAME:-UI Environment Fixture}}"
+TARGET_TENANT_CODE="$TENANT_CODE"
+TARGET_WORKSPACE_CODE="$WORKSPACE_CODE"
+TARGET_WORKSPACE_NAME="$WORKSPACE_NAME"
+TENANT_WORKSPACES_SCOPE_CODE="${TENANT_WORKSPACES_SCOPE_CODE:-_system}"
+TEMPLATE_TYPE_SLUG="${UI_ENV_TEMPLATE_TYPE_SLUG:-env-mode-${FIXTURE_SUFFIX}}"
+TEMPLATE_TYPE_NAME="${UI_ENV_TEMPLATE_TYPE_NAME:-Environment Mode Fixture}"
+WORKSPACE_TEST_RECIPIENTS="${UI_ENV_WORKSPACE_RECIPIENTS:-env-workspace-${FIXTURE_SUFFIX}@test.example.com
+env-workspace-review-${FIXTURE_SUFFIX}@test.example.com}"
+TEMPLATE_TEST_RECIPIENTS="${UI_ENV_TEMPLATE_RECIPIENTS:-env-template-${FIXTURE_SUFFIX}@test.example.com
+env-template-review-${FIXTURE_SUFFIX}@test.example.com}"
+WORKSPACE_TEST_RECIPIENT_A="${WORKSPACE_TEST_RECIPIENTS%%$'\n'*}"
+WORKSPACE_TEST_RECIPIENT_B="${WORKSPACE_TEST_RECIPIENTS#*$'\n'}"
+TEMPLATE_TEST_RECIPIENT_A="${TEMPLATE_TEST_RECIPIENTS%%$'\n'*}"
+TEMPLATE_TEST_RECIPIENT_B="${TEMPLATE_TEST_RECIPIENTS#*$'\n'}"
+
+mkdir -p "$SCREENSHOT_DIR"
+
+ab() {
+  timeout "${AGENT_BROWSER_TIMEOUT:-45s}" agent-browser --session "$SESSION_NAME" "$@"
+}
+
+ab_json() {
+  timeout "${AGENT_BROWSER_TIMEOUT:-45s}" agent-browser --session "$SESSION_NAME" "$@" --json
+}
+
+stop_frontend_dev() {
+  stop_managed_frontend "$FRONTEND_PID_FILE" "ui-environment-mode"
+}
+
+cleanup() {
+  timeout 5s agent-browser --session "$SESSION_NAME" close >/dev/null 2>&1 || true
+  stop_frontend_dev
+}
+
+trap cleanup EXIT
+
+start_frontend_dev() {
+  start_managed_frontend "$FRONTEND_PID_FILE" "$FRONTEND_LOG_FILE" "ui-environment-mode"
+}
+
+management_api_token() {
+  if [[ -z "${MANAGEMENT_API_TOKEN:-}" ]]; then
+    MANAGEMENT_API_TOKEN="$(
+      systemtest token \
+        --email "$SUPERADMIN_EMAIL" \
+        --secret "$SENDA_E2E_JWT_SECRET" \
+        | tail -n1
+    )"
+    if [[ -z "$MANAGEMENT_API_TOKEN" ]]; then
+      echo "failed to issue superadmin test token" >&2
+      return 1
+    fi
+  fi
+  printf '%s\n' "$MANAGEMENT_API_TOKEN"
+}
+
+management_api_request() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local token
+  token="$(management_api_token)"
+
+  if [[ -n "$body" ]]; then
+    curl -sS -w '\n%{http_code}' -X "$method" "$SENDA_BASE_URL$path" \
+      -H "Authorization: Bearer $token" \
+      -H 'Content-Type: application/json' \
+      --data "$body"
+  else
+    curl -sS -w '\n%{http_code}' -X "$method" "$SENDA_BASE_URL$path" \
+      -H "Authorization: Bearer $token"
+  fi
+}
+
+management_api_expect() {
+  local expected_status="$1"
+  local method="$2"
+  local path="$3"
+  local body="${4:-}"
+  local response
+  response="$(management_api_request "$method" "$path" "$body")"
+  local status
+  status="$(printf '%s' "$response" | tail -n1)"
+  local payload
+  payload="$(printf '%s' "$response" | sed '$d')"
+  if [[ "$status" != "$expected_status" ]]; then
+    echo "management ${method} failed: expected=${expected_status} actual=${status} path=${path} body=${payload}" >&2
+    return 1
+  fi
+  printf '%s\n' "$payload"
+}
+
+management_api_status() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local response
+  response="$(management_api_request "$method" "$path" "$body")"
+  printf '%s' "$response" | tail -n1
+}
+
+ensure_workspace_fixture() {
+  local status
+  status="$(management_api_status POST "/api/v1/manage/tenants/${TENANT_CODE}/workspaces" "$(cat <<EOF_JSON
+{"code":"${WORKSPACE_CODE}","name":"${WORKSPACE_NAME}"}
+EOF_JSON
+)")"
+
+  if [[ "$status" != "201" && "$status" != "409" ]]; then
+    echo "failed to ensure workspace fixture code=${WORKSPACE_CODE} status=${status}" >&2
+    return 1
+  fi
+}
+
+ensure_template_type_fixture() {
+  local base_path="/api/v1/manage/environments/test/tenants/${TENANT_CODE}/workspaces/${WORKSPACE_CODE}/template-types"
+
+  local status
+  status="$(management_api_status GET "${base_path}/${TEMPLATE_TYPE_SLUG}")"
+  if [[ "$status" == "200" ]]; then
+    return 0
+  fi
+
+  management_api_expect "201" POST "${base_path}" "$(cat <<EOF_JSON
+{"slug":"${TEMPLATE_TYPE_SLUG}","name":"${TEMPLATE_TYPE_NAME}"}
+EOF_JSON
+)" >/dev/null
+}
+
+ensure_management_login() {
+  if [[ -f "$STATE_FILE" ]]; then
+    log "ui-environment-mode: discarding stale saved browser state"
+    rm -f "$STATE_FILE"
+  fi
+
+  log "ui-environment-mode: logging in as superadmin"
+  ab open "$FRONTEND_BASE_URL/login" >/dev/null
+  ab wait 1200 >/dev/null
+
+  if ! ab_json eval '(() => {
+    const buttons = Array.from(document.querySelectorAll("button"));
+    const button = buttons.find((candidate) => {
+      const text = (candidate.textContent || "").replace(/\s+/g, " ").trim();
+      return /sign in|oidc|iniciar|ingresar/i.test(text);
+    });
+    if (!button) return "missing";
+    button.click();
+    return "clicked";
+  })()' | jq -e '.data.result == "clicked"' >/dev/null; then
+    echo "login button not found on frontend login page" >&2
+    return 1
+  fi
+
+  ab wait "#username" >/dev/null
+  ab fill "#username" "$SUPERADMIN_EMAIL" >/dev/null
+  ab fill "#password" "$SUPERADMIN_PASSWORD" >/dev/null
+  ab eval "(function(){var f=document.querySelector('#kc-form-login'); if (f) { f.submit(); return 'submitted'; } var b=document.querySelector('#kc-login'); if (b) { b.click(); return 'clicked'; } return 'missing'; })()" >/dev/null
+
+  local settled=0
+  for _ in $(seq 1 40); do
+    local current_url
+    current_url="$(ab_json get url | jq -r '.data.url // ""')"
+    if [[ "$current_url" == "$FRONTEND_BASE_URL"* ]] && [[ "$current_url" != *"/api/auth/"* ]]; then
+      settled=1
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ "$settled" -ne 1 ]]; then
+    echo "superadmin login did not return to frontend" >&2
+    return 1
+  fi
+
+  ab state save "$STATE_FILE" >/dev/null
+}
+
+wait_for_text() {
+  local needle="$1"
+  for _ in $(seq 1 80); do
+    local body
+    body="$(ab_json eval '(() => (document.body?.innerText || "").replace(/\s+/g, " ").trim())()' | jq -r '.data.result // ""')"
+    if [[ "$body" == *"$needle"* ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "timed out waiting for body text: $needle" >&2
+  return 1
+}
+
+wait_for_eval_true() {
+  local expression="$1"
+  for _ in $(seq 1 120); do
+    if ab_json eval "$expression" | jq -e '.data.result == true' >/dev/null; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "timed out waiting for eval true: $expression" >&2
+  return 1
+}
+
+wait_for_url() {
+  local expected="$1"
+  for _ in $(seq 1 80); do
+    local current
+    current="$(ab_json get url | jq -r '.data.url // ""')"
+    if [[ "$current" == "$expected" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "timed out waiting for url: $expected" >&2
+  return 1
+}
+
+click_sidebar_link() {
+  local label="$1"
+  local label_json
+  label_json="$(printf '%s' "$label" | jq -Rs .)"
+
+  if ! ab_json eval "(() => {
+    const expected = ${label_json};
+    const links = Array.from(document.querySelectorAll('nav a'));
+    const target = links.find((candidate) => {
+      const text = (candidate.textContent || '').replace(/\\s+/g, ' ').trim();
+      return text === expected;
+    });
+    if (!target) return 'missing';
+    target.click();
+    return target.getAttribute('href') || 'clicked';
+  })()" | jq -e '.data.result != "missing"' >/dev/null; then
+    echo "sidebar link not found: ${label}" >&2
+    return 1
+  fi
+}
+
+click_row_by_code() {
+  local code="$1"
+  local code_json
+  code_json="$(printf '%s' "$code" | jq -Rs .)"
+  if ! ab_json eval "(() => {
+    const code = ${code_json};
+    const row = Array.from(document.querySelectorAll('tbody tr')).find((candidate) =>
+      (candidate.innerText || '').includes(code)
+    );
+    if (!row) return 'missing';
+    row.click();
+    return 'clicked';
+  })()" | jq -e '.data.result == "clicked"' >/dev/null; then
+    echo "table row not found for code=${code}" >&2
+    return 1
+  fi
+}
+
+click_button_by_aria_label() {
+  local label="$1"
+  local label_json
+  label_json="$(printf '%s' "$label" | jq -Rs .)"
+
+  wait_for_eval_true "(() => {
+    const label = ${label_json};
+    return Array.from(document.querySelectorAll('button')).some((candidate) => candidate.getAttribute('aria-label') === label);
+  })()"
+
+  if ab find role button click --name "$label" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if ! ab_json eval "(() => {
+    const label = ${label_json};
+    const button = Array.from(document.querySelectorAll('button')).find((candidate) => candidate.getAttribute('aria-label') === label);
+    if (!button) return 'missing';
+    button.click();
+    return 'clicked';
+  })()" | jq -e '.data.result == "clicked"' >/dev/null; then
+    echo "button with aria-label not found: ${label}" >&2
+    return 1
+  fi
+}
+
+select_combobox_option_by_label() {
+  local label="$1"
+  local option="$2"
+  local label_json option_json
+  label_json="$(printf '%s' "$label" | jq -Rs .)"
+  option_json="$(printf '%s' "$option" | jq -Rs .)"
+
+  if ! ab_json eval "(() => {
+    const expectedLabel = ${label_json};
+    const labels = Array.from(document.querySelectorAll('label'));
+    const label = labels.find((candidate) => (candidate.textContent || '').replace(/\\s+/g, ' ').trim() === expectedLabel);
+    if (!label) return 'missing-label';
+    let container = label.parentElement;
+    while (container && !container.querySelector('[role=\"combobox\"]')) {
+      container = container.parentElement;
+    }
+    const trigger = container?.querySelector('[role=\"combobox\"]');
+    if (!trigger) return 'missing-trigger';
+    trigger.click();
+    return 'clicked';
+  })()" | jq -e '.data.result == "clicked"' >/dev/null; then
+    echo "combobox trigger not found for label=${label}" >&2
+    return 1
+  fi
+
+  if ! ab_json eval "(() => {
+    const expectedOption = ${option_json};
+    const options = Array.from(document.querySelectorAll('[role=\"option\"]'));
+    const target = options.find((candidate) => (candidate.textContent || '').replace(/\\s+/g, ' ').trim() === expectedOption);
+    if (!target) return 'missing-option';
+    target.click();
+    return 'clicked';
+  })()" | jq -e '.data.result == "clicked"' >/dev/null; then
+    echo "combobox option not found for label=${label} option=${option}" >&2
+    return 1
+  fi
+}
+
+fill_textarea_by_label() {
+  local label="$1"
+  local value="$2"
+  local label_json value_json
+  label_json="$(printf '%s' "$label" | jq -Rs .)"
+  value_json="$(printf '%s' "$value" | jq -Rs .)"
+
+  if ! ab_json eval "(() => {
+    const expectedLabel = ${label_json};
+    const nextValue = ${value_json};
+    const labels = Array.from(document.querySelectorAll('label'));
+    const label = labels.find((candidate) => (candidate.textContent || '').replace(/\\s+/g, ' ').trim() === expectedLabel);
+    if (!label) return 'missing-label';
+    let container = label.parentElement;
+    while (container && !container.querySelector('textarea')) {
+      container = container.parentElement;
+    }
+    const textarea = container?.querySelector('textarea');
+    if (!textarea) return 'missing-textarea';
+    textarea.focus();
+    textarea.value = nextValue;
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(new Event('change', { bubbles: true }));
+    return 'filled';
+  })()" | jq -e '.data.result == "filled"' >/dev/null; then
+    echo "textarea not found for label=${label}" >&2
+    return 1
+  fi
+}
+
+set_environment_mode() {
+  local mode="$1"
+  local button_text
+  button_text="$(printf '%s' "$mode" | tr '[:lower:]' '[:upper:]')"
+  local button_json
+  button_json="$(printf '%s' "$button_text" | jq -Rs .)"
+
+  if ! ab_json eval "(() => {
+    const expected = ${button_json};
+    const button = Array.from(document.querySelectorAll('header button[aria-pressed]')).find((candidate) =>
+      (candidate.textContent || '').replace(/\\s+/g, ' ').trim() === expected
+    );
+    if (!button) return 'missing';
+    button.click();
+    return 'clicked';
+  })()" | jq -e '.data.result == "clicked"' >/dev/null; then
+    echo "environment toggle button not found for mode=${mode}" >&2
+    return 1
+  fi
+}
+
+assert_header_environment_state() {
+  local expected="$1"
+  local class_fragment="$2"
+  local expected_button
+  expected_button="$(printf '%s' "$expected" | tr '[:lower:]' '[:upper:]')"
+  local expected_json class_json button_json
+  expected_json="$(printf '%s' "$expected" | jq -Rs .)"
+  class_json="$(printf '%s' "$class_fragment" | jq -Rs .)"
+  button_json="$(printf '%s' "$expected_button" | jq -Rs .)"
+
+  wait_for_eval_true "(() => {
+    const expected = ${expected_json};
+    const classFragment = ${class_json};
+    const expectedButton = ${button_json};
+    const active = document.querySelector('header button[aria-pressed=\"true\"]');
+    if (!active) return false;
+    const chip = active.closest('div')?.previousElementSibling;
+    if (!chip) return false;
+    const activeText = (active.textContent || '').replace(/\\s+/g, ' ').trim();
+    const chipText = (chip.textContent || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+    const chipClass = chip.className || '';
+    return activeText === expectedButton && chipText === expected && chipClass.includes(classFragment);
+  })()"
+}
+
+assert_page_environment_badge() {
+  local expected="$1"
+  local class_fragment="$2"
+  local expected_json class_json
+  expected_json="$(printf '%s' "$expected" | jq -Rs .)"
+  class_json="$(printf '%s' "$class_fragment" | jq -Rs .)"
+
+  wait_for_eval_true "(() => {
+    const expected = ${expected_json};
+    const classFragment = ${class_json};
+    const badges = Array.from(document.querySelectorAll('span')).filter((candidate) => {
+      const text = (candidate.textContent || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+      return text === expected && (candidate.className || '').includes('rounded-full');
+    });
+    return badges.some((candidate) => (candidate.className || '').includes(classFragment));
+  })()"
+}
+
+assert_prod_workspace_dialog_hides_test_controls() {
+  wait_for_eval_true "(() => {
+    const body = (document.body?.innerText || '').replace(/\\s+/g, ' ').trim();
+    const hasRecipients = body.includes('Safe recipients');
+    const hasMode = body.includes('Test recipient mode');
+    const hasWarning = body.includes('Test mode never sends to real recipients directly');
+    const textarea = document.querySelector('#edit-workspace-test-recipients');
+    return !hasRecipients && !hasMode && !hasWarning && !textarea;
+  })()"
+}
+
+assert_prod_workspaces_page_hides_test_controls() {
+  wait_for_eval_true "(() => {
+    const body = (document.body?.innerText || '').replace(/\\s+/g, ' ').trim();
+    return !body.includes('Safe recipients')
+      && !body.includes('Test recipient mode')
+      && !body.includes('Test mode never sends to real recipients directly');
+  })()"
+}
+
+assert_test_workspace_dialog_shows_test_controls() {
+  wait_for_eval_true "(() => {
+    const body = (document.body?.innerText || '').replace(/\\s+/g, ' ').trim();
+    const hasRecipients = body.includes('Safe recipients');
+    const hasMode = body.includes('Test recipient mode');
+    const hasWarning = body.includes('Test mode never sends to real recipients directly');
+    const textarea = document.querySelector('#edit-workspace-test-recipients');
+    return hasRecipients && hasMode && hasWarning && !!textarea;
+  })()"
+}
+
+assert_template_type_dialog_shows_override_controls() {
+  wait_for_eval_true "(() => {
+    const body = (document.body?.innerText || '').replace(/\\s+/g, ' ').trim();
+    const hasOverride = body.includes('Test recipient override');
+    const hasMode = body.includes('Override mode');
+    return hasOverride && hasMode;
+  })()"
+}
+
+load_env_report "$ENV_REPORT_FILE"
+start_frontend_dev
+seed_keycloak_users
+seed_rbac_memberships
+TENANT_CODE="$TARGET_TENANT_CODE"
+WORKSPACE_CODE="$TARGET_WORKSPACE_CODE"
+WORKSPACE_NAME="$TARGET_WORKSPACE_NAME"
+ensure_workspace_fixture
+ensure_template_type_fixture
+ensure_management_login
+
+WORKSPACE_ROOT_URL="$FRONTEND_BASE_URL/t/${TENANT_CODE}/w/${WORKSPACE_CODE}"
+WORKSPACE_TEST_URL="${WORKSPACE_ROOT_URL}?environment=test"
+TEMPLATES_TEST_URL="$FRONTEND_BASE_URL/t/${TENANT_CODE}/w/${WORKSPACE_CODE}/templates?environment=test"
+SETTINGS_TEST_URL="$FRONTEND_BASE_URL/t/${TENANT_CODE}/w/${WORKSPACE_CODE}/settings?environment=test"
+WORKSPACES_PROD_URL="$FRONTEND_BASE_URL/t/${TENANT_CODE}/w/${TENANT_WORKSPACES_SCOPE_CODE}/workspaces"
+WORKSPACES_TEST_URL="${WORKSPACES_PROD_URL}?environment=test"
+WORKSPACE_TEST_API_PATH="/api/v1/manage/environments/test/tenants/${TENANT_CODE}/workspaces/${WORKSPACE_CODE}"
+TEMPLATE_TYPE_TEST_API_PATH="/api/v1/manage/environments/test/tenants/${TENANT_CODE}/workspaces/${WORKSPACE_CODE}/template-types/${TEMPLATE_TYPE_SLUG}"
+
+log "ui-environment-mode: opening workspace dashboard in prod"
+ab open "$WORKSPACE_ROOT_URL" >/dev/null
+wait_for_text "Dashboard"
+assert_header_environment_state "prod" "bg-emerald"
+ab screenshot "$SCREENSHOT_DIR/01-workspace-prod-dashboard.png" >/dev/null
+
+log "ui-environment-mode: toggling workspace header to test"
+set_environment_mode "test"
+wait_for_url "$WORKSPACE_TEST_URL"
+assert_header_environment_state "test" "bg-amber"
+ab screenshot "$SCREENSHOT_DIR/02-workspace-test-dashboard.png" >/dev/null
+
+log "ui-environment-mode: asserting environment persists to templates navigation"
+click_sidebar_link "Templates"
+wait_for_url "$TEMPLATES_TEST_URL"
+wait_for_text "Templates"
+assert_header_environment_state "test" "bg-amber"
+ab screenshot "$SCREENSHOT_DIR/03-templates-test-navigation.png" >/dev/null
+
+log "ui-environment-mode: asserting environment persists to settings navigation"
+click_sidebar_link "Settings"
+wait_for_url "$SETTINGS_TEST_URL"
+wait_for_text "Settings"
+assert_header_environment_state "test" "bg-amber"
+ab screenshot "$SCREENSHOT_DIR/04-settings-test-navigation.png" >/dev/null
+
+log "ui-environment-mode: validating workspace environment-scoped API state"
+WORKSPACE_PROD_RESPONSE="$(management_api_expect "200" GET "/api/v1/manage/environments/prod/tenants/${TENANT_CODE}/workspaces/${WORKSPACE_CODE}")"
+printf '%s\n' "$WORKSPACE_PROD_RESPONSE" | jq -e \
+  '.environment == "prod"
+   and ((.test_recipient_addresses // []) | length == 0)
+   and ((.test_recipient_mode // "replace") == "replace")' >/dev/null
+
+WORKSPACE_TEST_RESPONSE_PREPARED="$(management_api_expect "200" GET "$WORKSPACE_TEST_API_PATH")"
+printf '%s\n' "$WORKSPACE_TEST_RESPONSE_PREPARED" | jq -e \
+  '.environment == "test"
+   and ((.test_recipient_addresses // []) | length == 0)
+   and ((.test_recipient_mode // "replace") == "replace")' >/dev/null
+
+management_api_expect "200" PUT "$WORKSPACE_TEST_API_PATH" "$(cat <<EOF_JSON
+{"test_recipient_mode":"append","test_recipient_addresses":["${WORKSPACE_TEST_RECIPIENT_A}","${WORKSPACE_TEST_RECIPIENT_B}"]}
+EOF_JSON
+)" >/dev/null
+
+WORKSPACE_TEST_RESPONSE="$(management_api_expect "200" GET "$WORKSPACE_TEST_API_PATH")"
+printf '%s\n' "$WORKSPACE_TEST_RESPONSE" | jq -e \
+  --arg addr1 "$WORKSPACE_TEST_RECIPIENT_A" \
+  --arg addr2 "$WORKSPACE_TEST_RECIPIENT_B" \
+  '.environment == "test"
+   and .test_recipient_mode == "append"
+   and (.test_recipient_addresses | index($addr1))
+   and (.test_recipient_addresses | index($addr2))' >/dev/null
+ab screenshot "$SCREENSHOT_DIR/05-workspace-api-state.png" >/dev/null || true
+
+log "ui-environment-mode: validating template-type test override UI"
+ab open "$TEMPLATES_TEST_URL" >/dev/null
+wait_for_url "$TEMPLATES_TEST_URL"
+wait_for_text "Templates"
+wait_for_text "$TEMPLATE_TYPE_SLUG"
+click_button_by_aria_label "Edit template type ${TEMPLATE_TYPE_SLUG}"
+wait_for_text "Change the name, slug, adapter, and sender assigned to this template type."
+assert_template_type_dialog_shows_override_controls
+select_combobox_option_by_label "Override mode" "Append safe recipients"
+wait_for_text "Warning: append preserves original recipients and adds these addresses."
+fill_textarea_by_label "Safe recipients" "$TEMPLATE_TEST_RECIPIENTS"
+ab screenshot "$SCREENSHOT_DIR/08-template-type-test-override.png" >/dev/null
+
+cat >"$REPORT_PATH" <<EOF
+# UI Environment Mode Report
+
+- Route set: workspace dashboard, templates, settings, tenant workspace list
+- Actor: \`${SUPERADMIN_EMAIL}\`
+- Workspace under test: \`${WORKSPACE_CODE}\`
+- Workspace fixture name: \`${WORKSPACE_NAME}\`
+- Template type fixture: \`${TEMPLATE_TYPE_SLUG}\`
+
+## Covered
+
+- Workspace header renders the prod/test toggle and the active environment indicator with the expected visual color family.
+- Switching from prod to test updates the workspace URL to \`?environment=test\`.
+- Sidebar navigation preserves \`environment=test\` when moving from dashboard to templates and settings.
+- Workspace environment state is validated through env-scoped management API reads and updates.
+- Test template-type edit dialog shows test-recipient override controls; selecting append surfaces the warning copy and reveals the safe-recipient textarea in UI.
+
+## Artifacts
+
+- \`$SCREENSHOT_DIR/01-workspace-prod-dashboard.png\`
+- \`$SCREENSHOT_DIR/02-workspace-test-dashboard.png\`
+- \`$SCREENSHOT_DIR/03-templates-test-navigation.png\`
+- \`$SCREENSHOT_DIR/04-settings-test-navigation.png\`
+- \`$SCREENSHOT_DIR/05-workspace-api-state.png\`
+- \`$SCREENSHOT_DIR/08-template-type-test-override.png\`
+EOF
+
+log "ui-environment-mode: report written -> $REPORT_PATH"

--- a/test/system/subagents/ui-flow-tester.sh
+++ b/test/system/subagents/ui-flow-tester.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=test/system/subagents/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 require_cmd go
@@ -337,7 +338,7 @@ seed_keycloak_users
 seed_rbac_memberships
 
 log "ui-flow-tester: generating matrix"
-go run "$ROOT_DIR/cmd/systemtest" matrix \
+systemtest matrix \
   --manifest "$ROOT_DIR/test/system/screen-manifest.json" \
   --format tsv \
   --out "$MATRIX_TSV"
@@ -355,7 +356,7 @@ passed=0
 failed=0
 max_cases="${UI_MAX_CASES:-0}"
 
-while IFS=$'\t' read -r route route_slug scope role locale viewport critical pencil_frame_id preconditions actions assertions; do
+while IFS=$'\t' read -r route route_slug scope role locale viewport critical _pencil_frame_id _preconditions _actions _assertions; do
   if [[ "$route" == "route" ]]; then
     continue
   fi

--- a/test/system/subagents/ui-injector-flow-tester.sh
+++ b/test/system/subagents/ui-injector-flow-tester.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=test/system/subagents/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 require_cmd agent-browser
@@ -72,7 +73,7 @@ start_frontend_dev() {
 
 issue_test_token() {
   local email="$1"
-  go run "$ROOT_DIR/cmd/systemtest" token \
+  systemtest token \
     --email "$email" \
     --secret "$SENDA_E2E_JWT_SECRET" \
     | tail -n1

--- a/test/system/subagents/ui-template-type-slug-edit-tester.sh
+++ b/test/system/subagents/ui-template-type-slug-edit-tester.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=test/system/subagents/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 require_cmd agent-browser
@@ -67,7 +68,7 @@ start_frontend_dev() {
 
 issue_test_token() {
   local email="$1"
-  go run "$ROOT_DIR/cmd/systemtest" token \
+  systemtest token \
     --email "$email" \
     --secret "$SENDA_E2E_JWT_SECRET" \
     | tail -n1

--- a/test/system/subagents/ui-visual-tester.sh
+++ b/test/system/subagents/ui-visual-tester.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=test/system/subagents/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 require_cmd go
@@ -203,7 +204,7 @@ case_count=0
 
 echo -e "route\tscope\trole\tlocale\tviewport\tstatus\tnote\tscreenshot\ttrace" >"$CASE_RESULTS"
 
-while IFS=$'\t' read -r route critical; do
+while IFS=$'\t' read -r route _critical; do
   scope="$(route_scope "$route")"
   role="$(choose_role_for_route "$route" "$scope")"
   for locale in "${locales[@]}"; do
@@ -284,7 +285,7 @@ if [[ "$SYSTEM_MODE" == "pr" ]]; then
 fi
 
 log "ui-visual-tester: running visual diff"
-go run "$ROOT_DIR/cmd/systemtest" visual-diff \
+systemtest visual-diff \
   --actual-dir "$ACTUAL_DIR" \
   --golden-dir "$ROOT_DIR/test/system/baselines/golden" \
   --pencil-dir "$ROOT_DIR/test/system/baselines/pencil" \

--- a/test/system/subagents/ui-workspace-management-tester.sh
+++ b/test/system/subagents/ui-workspace-management-tester.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=test/system/subagents/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 require_cmd agent-browser
@@ -18,6 +19,7 @@ SCREENSHOT_DIR="$ARTIFACT_DIR/ui-workspace-management"
 
 TENANT_CODE="${TENANT_CODE:-${SYSTEM_TENANT_CODE:-test-corp}}"
 SYSTEM_WORKSPACE_CODE_UI="_system"
+SYSTEM_WORKSPACE_DISPLAY_LABEL="Default"
 FIXTURE_SUFFIX="$(basename "$ARTIFACT_DIR" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '-' | cut -c1-10)"
 FIXTURE_CODE="${WORKSPACE_UI_FIXTURE_CODE:-ui-ws-${FIXTURE_SUFFIX}}"
 FIXTURE_NAME="${WORKSPACE_UI_FIXTURE_NAME:-Workspace UI Fixture}"
@@ -68,7 +70,7 @@ start_frontend_dev() {
 management_api_token() {
   if [[ -z "${MANAGEMENT_API_TOKEN:-}" ]]; then
     MANAGEMENT_API_TOKEN="$(
-      go run "$ROOT_DIR/cmd/systemtest" token \
+      systemtest token \
         --email "$SUPERADMIN_EMAIL" \
         --secret "$SENDA_E2E_JWT_SECRET" \
         | tail -n1
@@ -212,6 +214,20 @@ wait_for_url() {
     sleep 0.25
   done
   echo "timed out waiting for url: $expected" >&2
+  return 1
+}
+
+wait_for_url_prefix() {
+  local expected_prefix="$1"
+  for _ in $(seq 1 60); do
+    local current
+    current="$(ab_json get url | jq -r '.data.url // ""')"
+    if [[ "$current" == "$expected_prefix"* ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "timed out waiting for url prefix: $expected_prefix" >&2
   return 1
 }
 
@@ -372,16 +388,16 @@ wait_for_text "Workspaces"
 ab screenshot "$SCREENSHOT_DIR/01-scope-switcher-manage.png" >/dev/null
 
 wait_for_text "Create Workspace"
-wait_for_text "$SYSTEM_WORKSPACE_CODE_UI"
+wait_for_text "$SYSTEM_WORKSPACE_DISPLAY_LABEL"
 wait_for_eval_true "(() => {
-  const edit = document.querySelector('button[aria-label=\"Edit workspace ${SYSTEM_WORKSPACE_CODE_UI}\"]');
-  const del = document.querySelector('button[aria-label=\"Delete workspace ${SYSTEM_WORKSPACE_CODE_UI}\"]');
+  const edit = document.querySelector('button[aria-label=\"Edit workspace ${SYSTEM_WORKSPACE_DISPLAY_LABEL}\"]');
+  const del = document.querySelector('button[aria-label=\"Delete workspace ${SYSTEM_WORKSPACE_DISPLAY_LABEL}\"]');
   return !!edit && !!del && edit.disabled === true && del.disabled === true;
 })()"
 ab screenshot "$SCREENSHOT_DIR/02-overview.png" >/dev/null
 
-click_row_by_code "$SYSTEM_WORKSPACE_CODE_UI"
-wait_for_url "$FRONTEND_BASE_URL/t/${TENANT_CODE}/w/${SYSTEM_WORKSPACE_CODE_UI}"
+click_row_by_code "$SYSTEM_WORKSPACE_DISPLAY_LABEL"
+wait_for_url_prefix "$FRONTEND_BASE_URL/t/${TENANT_CODE}/w/${SYSTEM_WORKSPACE_CODE_UI}"
 ab screenshot "$SCREENSHOT_DIR/03-system-workspace-scope.png" >/dev/null
 
 ab open "$WORKSPACES_URL" >/dev/null
@@ -431,7 +447,7 @@ wait_for_eval_true "(() => Array.from(document.querySelectorAll('tbody tr')).som
 }))()"
 
 click_row_by_code "$FIXTURE_CODE"
-wait_for_url "$FRONTEND_BASE_URL/t/${TENANT_CODE}/w/${FIXTURE_CODE}"
+wait_for_url_prefix "$FRONTEND_BASE_URL/t/${TENANT_CODE}/w/${FIXTURE_CODE}"
 ab screenshot "$SCREENSHOT_DIR/09-workspace-scope.png" >/dev/null
 
 ab open "$WORKSPACES_URL" >/dev/null

--- a/test/system/system-runner.sh
+++ b/test/system/system-runner.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 MODE="${1:-pr}"
 SYSTEM_UI_VISUAL="${SYSTEM_UI_VISUAL:-0}"
 SYSTEM_UI_FLOW="${SYSTEM_UI_FLOW:-}"
@@ -119,6 +119,10 @@ run_ui_adapter_sharing_stage() {
   run_stage "ui-adapter-sharing" "$ROOT_DIR/test/system/subagents/ui-adapter-sharing-tester.sh"
 }
 
+run_ui_environment_mode_stage() {
+  run_stage "ui-environment-mode" "$ROOT_DIR/test/system/subagents/ui-environment-mode-tester.sh"
+}
+
 run_ui_a11y_stage() {
   if [[ "$SYSTEM_UI_A11Y" != "1" ]]; then
     skip_stage \
@@ -157,12 +161,12 @@ cleanup() {
     any_failed=1
   fi
 
-  go run "$ROOT_DIR/cmd/systemtest" junit \
+  systemtest junit \
     --results "$STAGE_RESULTS" \
     --suite "system-tests-${MODE}" \
     --out "$ARTIFACT_DIR/functional-junit.xml" >/dev/null 2>&1 || true
 
-  go run "$ROOT_DIR/cmd/systemtest" run-result \
+  systemtest run-result \
     --results "$STAGE_RESULTS" \
     --mode "$MODE" \
     --artifact-dir "$ARTIFACT_DIR" \
@@ -171,12 +175,12 @@ cleanup() {
 
 trap cleanup EXIT
 
-go run "$ROOT_DIR/cmd/systemtest" validate-manifest \
+systemtest validate-manifest \
   --manifest "$ROOT_DIR/test/system/screen-manifest.json" \
   --baseline-map "$ROOT_DIR/test/system/visual-baseline-map.json" \
   --app-dir "$ROOT_DIR/web/src/app"
 
-go run "$ROOT_DIR/cmd/systemtest" matrix \
+systemtest matrix \
   --manifest "$ROOT_DIR/test/system/screen-manifest.json" \
   --format csv \
   --out "$ARTIFACT_DIR/coverage-matrix.csv"
@@ -200,6 +204,7 @@ if [[ "$MODE" == "nightly" ]]; then
   run_ui_adapter_sharing_stage
   run_visual_stage
   run_ui_a11y_stage
+  run_ui_environment_mode_stage
   run_security_chaos_stage
 else
   run_ui_flow_stage
@@ -211,6 +216,7 @@ else
   run_visual_stage
   skip_stage "ui-a11y" "nightly-only"
   run_stage "api-contract" "$ROOT_DIR/test/system/subagents/api-contract-tester.sh"
+  run_ui_environment_mode_stage
   skip_stage "security-chaos" "nightly-only"
 fi
 

--- a/test/system/visual-baseline-map.json
+++ b/test/system/visual-baseline-map.json
@@ -197,6 +197,16 @@
       "critical": true
     },
     {
+      "route": "/embed/[profileSlug]/t/[tenantCode]/w/[workspaceCode]/templates/[slug]/edit",
+      "pencilFrameId": "frame:t__tenantCode__w__workspaceCode__templates__slug__edit",
+      "critical": true
+    },
+    {
+      "route": "/embed/[profileSlug]/environments/[environment]/t/[tenantCode]/w/[workspaceCode]/templates/[slug]/edit",
+      "pencilFrameId": "frame:t__tenantCode__w__workspaceCode__templates__slug__edit",
+      "critical": true
+    },
+    {
       "route": "/t/[tenantCode]/w/[workspaceCode]/templates/[slug]",
       "pencilFrameId": "frame:t__tenantCode__w__workspaceCode__templates__slug",
       "critical": false

--- a/web/README.md
+++ b/web/README.md
@@ -1,8 +1,9 @@
+
 # Senda web frontend
 
 ## Development
 
-Use pnpm only.
+Use `pnpm` only.
 
 ```bash
 corepack enable
@@ -18,4 +19,10 @@ pnpm --dir web typecheck
 pnpm --dir web lint -- --max-warnings=0
 ```
 
-The repo validation gate intentionally does not require a local `next build`.
+The standard repo validation flow intentionally does not require a local `next build`.
+
+## Notes
+
+- The dashboard is environment-aware for workspace runtime flows (`prod` / `test`).
+- External embed routes live under `web/src/app/embed/` and rely on the external integration bootstrap/session APIs.
+- Keep route generation and navigation helpers aligned with the environment model helpers under `web/src/lib/` and `web/src/hooks/`.

--- a/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/api-docs/page.tsx
+++ b/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/api-docs/page.tsx
@@ -1,26 +1,45 @@
 import { PageShell } from "@/components/shared/page-shell";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { SYSTEM_WORKSPACE_CODE } from "@/types/api";
 import { getTenantSystemPath, getWorkspaceDisplayCode } from "@/lib/system-workspace-display";
 
 export default async function WorkspaceApiDocsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ tenantCode: string; workspaceCode: string }>;
+  searchParams: Promise<{ environment?: string }>;
 }) {
   const { tenantCode, workspaceCode } = await params;
+  const { environment } = await searchParams;
   const isSystem = workspaceCode === SYSTEM_WORKSPACE_CODE;
-  const referenceHref = `/t/${tenantCode}/w/${workspaceCode}/api-docs/reference`;
+  const referenceHref = applyEnvironmentSearchParam(
+    `/t/${tenantCode}/w/${workspaceCode}/api-docs/reference`,
+    environment,
+  );
 
   return (
     <PageShell
       title="API Docs"
       description="Reference for services using workspace API Keys"
       breadcrumbs={[
-        { label: tenantCode, href: getTenantSystemPath(tenantCode) },
+        {
+          label: tenantCode,
+          href: applyEnvironmentSearchParam(
+            getTenantSystemPath(tenantCode),
+            environment,
+          ),
+        },
         ...(isSystem
           ? []
-          : [{ label: getWorkspaceDisplayCode({ code: workspaceCode }), href: `/t/${tenantCode}/w/${workspaceCode}` }]),
+          : [{
+              label: getWorkspaceDisplayCode({ code: workspaceCode }),
+              href: applyEnvironmentSearchParam(
+                `/t/${tenantCode}/w/${workspaceCode}`,
+                environment,
+              ),
+            }]),
         { label: "API Docs" },
       ]}
     >

--- a/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/api-keys/page.tsx
+++ b/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/api-keys/page.tsx
@@ -1,14 +1,18 @@
 import { PageShell } from "@/components/shared/page-shell";
 import { ApiKeysContent } from "@/components/api-keys/api-keys-content";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { SYSTEM_WORKSPACE_CODE } from "@/types/api";
 import { getTenantSystemPath, getWorkspaceDisplayCode } from "@/lib/system-workspace-display";
 
 export default async function WorkspaceApiKeysPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ tenantCode: string; workspaceCode: string }>;
+  searchParams: Promise<{ environment?: string }>;
 }) {
   const { tenantCode, workspaceCode } = await params;
+  const { environment } = await searchParams;
   const isSystem = workspaceCode === SYSTEM_WORKSPACE_CODE;
 
   return (
@@ -16,8 +20,22 @@ export default async function WorkspaceApiKeysPage({
       title="API Keys"
       description="Manage API keys for programmatic access"
       breadcrumbs={[
-        { label: tenantCode, href: getTenantSystemPath(tenantCode) },
-        ...(isSystem ? [] : [{ label: getWorkspaceDisplayCode({ code: workspaceCode }) }]),
+        {
+          label: tenantCode,
+          href: applyEnvironmentSearchParam(
+            getTenantSystemPath(tenantCode),
+            environment,
+          ),
+        },
+        ...(isSystem
+          ? []
+          : [{
+              label: getWorkspaceDisplayCode({ code: workspaceCode }),
+              href: applyEnvironmentSearchParam(
+                `/t/${tenantCode}/w/${workspaceCode}`,
+                environment,
+              ),
+            }]),
         { label: "API Keys" },
       ]}
     >

--- a/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/emails/[trackingId]/page.tsx
+++ b/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/emails/[trackingId]/page.tsx
@@ -1,29 +1,50 @@
 import { PageShell } from "@/components/shared/page-shell";
 import { EmailDetailContent } from "@/components/emails/email-detail-content";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { SYSTEM_WORKSPACE_CODE } from "@/types/api";
 import { getTenantSystemPath, getWorkspaceDisplayCode } from "@/lib/system-workspace-display";
 
 export default async function WorkspaceEmailDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{
     tenantCode: string;
     workspaceCode: string;
     trackingId: string;
   }>;
+  searchParams: Promise<{ environment?: string }>;
 }) {
   const { tenantCode, workspaceCode, trackingId } = await params;
+  const { environment } = await searchParams;
   const isSystem = workspaceCode === SYSTEM_WORKSPACE_CODE;
 
   return (
     <PageShell
       title="Email Detail"
       breadcrumbs={[
-        { label: tenantCode, href: getTenantSystemPath(tenantCode) },
-        ...(isSystem ? [] : [{ label: getWorkspaceDisplayCode({ code: workspaceCode }) }]),
+        {
+          label: tenantCode,
+          href: applyEnvironmentSearchParam(
+            getTenantSystemPath(tenantCode),
+            environment,
+          ),
+        },
+        ...(isSystem
+          ? []
+          : [{
+              label: getWorkspaceDisplayCode({ code: workspaceCode }),
+              href: applyEnvironmentSearchParam(
+                `/t/${tenantCode}/w/${workspaceCode}`,
+                environment,
+              ),
+            }]),
         {
           label: "Emails",
-          href: `/t/${tenantCode}/w/${workspaceCode}/emails`,
+          href: applyEnvironmentSearchParam(
+            `/t/${tenantCode}/w/${workspaceCode}/emails`,
+            environment,
+          ),
         },
         { label: trackingId },
       ]}

--- a/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/emails/page.tsx
+++ b/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/emails/page.tsx
@@ -1,14 +1,18 @@
 import { PageShell } from "@/components/shared/page-shell";
 import { EmailsContent } from "@/components/emails/emails-content";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { SYSTEM_WORKSPACE_CODE } from "@/types/api";
 import { getTenantSystemPath, getWorkspaceDisplayCode } from "@/lib/system-workspace-display";
 
 export default async function WorkspaceEmailsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ tenantCode: string; workspaceCode: string }>;
+  searchParams: Promise<{ environment?: string }>;
 }) {
   const { tenantCode, workspaceCode } = await params;
+  const { environment } = await searchParams;
   const isSystem = workspaceCode === SYSTEM_WORKSPACE_CODE;
 
   return (
@@ -16,8 +20,22 @@ export default async function WorkspaceEmailsPage({
       title="Emails"
       description={`Workspace: ${getWorkspaceDisplayCode({ code: workspaceCode })}`}
       breadcrumbs={[
-        { label: tenantCode, href: getTenantSystemPath(tenantCode) },
-        ...(isSystem ? [] : [{ label: getWorkspaceDisplayCode({ code: workspaceCode }) }]),
+        {
+          label: tenantCode,
+          href: applyEnvironmentSearchParam(
+            getTenantSystemPath(tenantCode),
+            environment,
+          ),
+        },
+        ...(isSystem
+          ? []
+          : [{
+              label: getWorkspaceDisplayCode({ code: workspaceCode }),
+              href: applyEnvironmentSearchParam(
+                `/t/${tenantCode}/w/${workspaceCode}`,
+                environment,
+              ),
+            }]),
         { label: "Emails" },
       ]}
     >

--- a/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/help/[[...slug]]/page.tsx
+++ b/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/help/[[...slug]]/page.tsx
@@ -1,16 +1,20 @@
 import { HelpArticle } from "@/components/help/help-article";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { SYSTEM_WORKSPACE_CODE } from "@/types/api";
 
 export default async function WorkspaceHelpPage({
   params,
+  searchParams,
 }: {
   params: Promise<{
     tenantCode: string;
     workspaceCode: string;
     slug?: string[];
   }>;
+  searchParams: Promise<{ environment?: string }>;
 }) {
   const { tenantCode, workspaceCode, slug } = await params;
+  const { environment } = await searchParams;
   const scopeLabel =
     workspaceCode === SYSTEM_WORKSPACE_CODE ? tenantCode : workspaceCode;
 
@@ -18,7 +22,10 @@ export default async function WorkspaceHelpPage({
     <HelpArticle
       slug={slug}
       scopeLabel={scopeLabel}
-      basePath={`/t/${tenantCode}/w/${workspaceCode}/help`}
+      basePath={applyEnvironmentSearchParam(
+        `/t/${tenantCode}/w/${workspaceCode}/help`,
+        environment,
+      )}
       tenantCode={tenantCode}
       workspaceCode={workspaceCode}
     />

--- a/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/members/page.tsx
+++ b/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/members/page.tsx
@@ -1,14 +1,18 @@
 import { PageShell } from "@/components/shared/page-shell";
 import { MembersContent } from "@/components/members/members-content";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { SYSTEM_WORKSPACE_CODE } from "@/types/api";
 import { getTenantSystemPath, getWorkspaceDisplayCode } from "@/lib/system-workspace-display";
 
 export default async function WorkspaceMembersPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ tenantCode: string; workspaceCode: string }>;
+  searchParams: Promise<{ environment?: string }>;
 }) {
   const { tenantCode, workspaceCode } = await params;
+  const { environment } = await searchParams;
   const isSystem = workspaceCode === SYSTEM_WORKSPACE_CODE;
 
   return (
@@ -16,8 +20,22 @@ export default async function WorkspaceMembersPage({
       title="Members"
       description="Manage team members and their roles"
       breadcrumbs={[
-        { label: tenantCode, href: getTenantSystemPath(tenantCode) },
-        ...(isSystem ? [] : [{ label: getWorkspaceDisplayCode({ code: workspaceCode }) }]),
+        {
+          label: tenantCode,
+          href: applyEnvironmentSearchParam(
+            getTenantSystemPath(tenantCode),
+            environment,
+          ),
+        },
+        ...(isSystem
+          ? []
+          : [{
+              label: getWorkspaceDisplayCode({ code: workspaceCode }),
+              href: applyEnvironmentSearchParam(
+                `/t/${tenantCode}/w/${workspaceCode}`,
+                environment,
+              ),
+            }]),
         { label: "Members" },
       ]}
     >

--- a/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/page.tsx
+++ b/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/page.tsx
@@ -1,14 +1,18 @@
 import { PageShell } from "@/components/shared/page-shell";
 import { DashboardContent } from "@/components/dashboard/dashboard-content";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { SYSTEM_WORKSPACE_CODE } from "@/types/api";
 import { getTenantSystemPath, getWorkspaceDisplayCode } from "@/lib/system-workspace-display";
 
 export default async function WorkspaceDashboardPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ tenantCode: string; workspaceCode: string }>;
+  searchParams: Promise<{ environment?: string }>;
 }) {
   const { tenantCode, workspaceCode } = await params;
+  const { environment } = await searchParams;
   const isSystem = workspaceCode === SYSTEM_WORKSPACE_CODE;
 
   return (
@@ -16,8 +20,22 @@ export default async function WorkspaceDashboardPage({
       title="Dashboard"
       description={`Workspace: ${getWorkspaceDisplayCode({ code: workspaceCode })}`}
       breadcrumbs={[
-        { label: tenantCode, href: getTenantSystemPath(tenantCode) },
-        ...(isSystem ? [] : [{ label: getWorkspaceDisplayCode({ code: workspaceCode }) }]),
+        {
+          label: tenantCode,
+          href: applyEnvironmentSearchParam(
+            getTenantSystemPath(tenantCode),
+            environment,
+          ),
+        },
+        ...(isSystem
+          ? []
+          : [{
+              label: getWorkspaceDisplayCode({ code: workspaceCode }),
+              href: applyEnvironmentSearchParam(
+                `/t/${tenantCode}/w/${workspaceCode}`,
+                environment,
+              ),
+            }]),
         { label: "Dashboard" },
       ]}
     >

--- a/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/settings/page.tsx
+++ b/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/settings/page.tsx
@@ -1,22 +1,40 @@
 import { PageShell } from "@/components/shared/page-shell";
 import { SettingsContent } from "@/components/settings/settings-content";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { SYSTEM_WORKSPACE_CODE } from "@/types/api";
 import { getTenantSystemPath, getWorkspaceDisplayCode } from "@/lib/system-workspace-display";
 
 export default async function WorkspaceSettingsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ tenantCode: string; workspaceCode: string }>;
+  searchParams: Promise<{ environment?: string }>;
 }) {
   const { tenantCode, workspaceCode } = await params;
+  const { environment } = await searchParams;
   const isSystem = workspaceCode === SYSTEM_WORKSPACE_CODE;
 
   return (
     <PageShell
       title="Settings"
       breadcrumbs={[
-        { label: tenantCode, href: getTenantSystemPath(tenantCode) },
-        ...(isSystem ? [] : [{ label: getWorkspaceDisplayCode({ code: workspaceCode }) }]),
+        {
+          label: tenantCode,
+          href: applyEnvironmentSearchParam(
+            getTenantSystemPath(tenantCode),
+            environment,
+          ),
+        },
+        ...(isSystem
+          ? []
+          : [{
+              label: getWorkspaceDisplayCode({ code: workspaceCode }),
+              href: applyEnvironmentSearchParam(
+                `/t/${tenantCode}/w/${workspaceCode}`,
+                environment,
+              ),
+            }]),
         { label: "Settings" },
       ]}
     >

--- a/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/webhooks/page.tsx
+++ b/web/src/app/(dashboard)/t/[tenantCode]/w/[workspaceCode]/webhooks/page.tsx
@@ -1,14 +1,18 @@
 import { PageShell } from "@/components/shared/page-shell";
 import { WebhooksContent } from "@/components/webhooks/webhooks-content";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { SYSTEM_WORKSPACE_CODE } from "@/types/api";
 import { getTenantSystemPath, getWorkspaceDisplayCode } from "@/lib/system-workspace-display";
 
 export default async function WorkspaceWebhooksPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ tenantCode: string; workspaceCode: string }>;
+  searchParams: Promise<{ environment?: string }>;
 }) {
   const { tenantCode, workspaceCode } = await params;
+  const { environment } = await searchParams;
   const isSystem = workspaceCode === SYSTEM_WORKSPACE_CODE;
 
   return (
@@ -16,8 +20,22 @@ export default async function WorkspaceWebhooksPage({
       title="Webhooks"
       description="Manage webhook endpoints for event notifications"
       breadcrumbs={[
-        { label: tenantCode, href: getTenantSystemPath(tenantCode) },
-        ...(isSystem ? [] : [{ label: getWorkspaceDisplayCode({ code: workspaceCode }) }]),
+        {
+          label: tenantCode,
+          href: applyEnvironmentSearchParam(
+            getTenantSystemPath(tenantCode),
+            environment,
+          ),
+        },
+        ...(isSystem
+          ? []
+          : [{
+              label: getWorkspaceDisplayCode({ code: workspaceCode }),
+              href: applyEnvironmentSearchParam(
+                `/t/${tenantCode}/w/${workspaceCode}`,
+                environment,
+              ),
+            }]),
         { label: "Webhooks" },
       ]}
     >

--- a/web/src/app/embed/[profileSlug]/environments/[environment]/t/[tenantCode]/w/[workspaceCode]/templates/[slug]/edit/page.tsx
+++ b/web/src/app/embed/[profileSlug]/environments/[environment]/t/[tenantCode]/w/[workspaceCode]/templates/[slug]/edit/page.tsx
@@ -1,0 +1,50 @@
+import { ExternalTemplateBuilderShell } from "@/components/templates/external-template-builder-shell";
+import { normalizeEnvironment } from "@/lib/environment-mode";
+import { SYSTEM_WORKSPACE_CODE, type ScopeContext } from "@/types/api";
+
+interface ExternalTemplateBuilderPageProps {
+  params: Promise<{
+    profileSlug: string;
+    environment: string;
+    tenantCode: string;
+    workspaceCode: string;
+    slug: string;
+  }>;
+  searchParams: Promise<{
+    templateId?: string;
+    versionId?: string;
+    fallback?: string;
+    readonly?: string;
+  }>;
+}
+
+export default async function ExternalTemplateBuilderEnvironmentPage({
+  params,
+  searchParams,
+}: ExternalTemplateBuilderPageProps) {
+  const { profileSlug, environment, tenantCode, workspaceCode, slug } =
+    await params;
+  const query = await searchParams;
+
+  const scope: ScopeContext = {
+    level: "workspace",
+    tenantCode,
+    workspaceCode,
+    profileSlug,
+    environment: normalizeEnvironment(environment),
+  };
+
+  const fallbackToSystem =
+    workspaceCode === SYSTEM_WORKSPACE_CODE ||
+    query.fallback === "system" ||
+    query.readonly === "1";
+
+  return (
+    <ExternalTemplateBuilderShell
+      profileSlug={profileSlug}
+      templateSlug={slug}
+      scope={scope}
+      fallbackToSystem={fallbackToSystem}
+    />
+  );
+}

--- a/web/src/app/embed/[profileSlug]/t/[tenantCode]/w/[workspaceCode]/templates/[slug]/edit/page.tsx
+++ b/web/src/app/embed/[profileSlug]/t/[tenantCode]/w/[workspaceCode]/templates/[slug]/edit/page.tsx
@@ -27,6 +27,8 @@ export default async function ExternalTemplateBuilderPage({
     level: "workspace",
     tenantCode,
     workspaceCode,
+    profileSlug,
+    environment: "prod",
   };
 
   const fallbackToSystem =

--- a/web/src/components/adapters/provisioning-stepper.tsx
+++ b/web/src/components/adapters/provisioning-stepper.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useScope, useScopedPath } from "@/hooks/use-scope";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import {
   useProvisioningStatus,
   useAutoProvision,
@@ -125,7 +126,10 @@ export function ProvisioningStepper({
   // Build frontend navigation path for help links.
   const navBase =
     scope.level === "workspace"
-      ? `/t/${scope.tenantCode}/w/${scope.workspaceCode}`
+      ? applyEnvironmentSearchParam(
+          `/t/${scope.tenantCode}/w/${scope.workspaceCode}`,
+          scope.environment,
+        )
       : "/global";
 
   const { data: statusData, isLoading } = useProvisioningStatus(

--- a/web/src/components/dashboard/dashboard-content.tsx
+++ b/web/src/components/dashboard/dashboard-content.tsx
@@ -5,6 +5,7 @@ import { useMinimumLoading } from "@/hooks/use-minimum-loading";
 import { Mail, Send, CheckCircle, AlertTriangle, AlertCircle, RefreshCw } from "lucide-react";
 import { useScope, useScopedPath } from "@/hooks/use-scope";
 import { SYSTEM_WORKSPACE_CODE } from "@/types/api";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import {
   SYSTEM_WORKSPACE_SCOPE_LABEL,
   getWorkspaceDisplayCode,
@@ -51,12 +52,18 @@ export function DashboardContent() {
   // Build "View all" hrefs based on scope
   const auditHref =
     scope.level === "workspace"
-      ? `/t/${scope.tenantCode}/w/${scope.workspaceCode}/audit`
+      ? applyEnvironmentSearchParam(
+          `/t/${scope.tenantCode}/w/${scope.workspaceCode}/audit`,
+          scope.environment,
+        )
       : undefined;
 
   const emailsHref =
     scope.level === "workspace"
-      ? `/t/${scope.tenantCode}/w/${scope.workspaceCode}/emails`
+      ? applyEnvironmentSearchParam(
+          `/t/${scope.tenantCode}/w/${scope.workspaceCode}/emails`,
+          scope.environment,
+        )
       : undefined;
 
   // Loading state

--- a/web/src/components/emails/emails-content.tsx
+++ b/web/src/components/emails/emails-content.tsx
@@ -11,6 +11,7 @@ import { DataTable } from "@/components/shared/data-table";
 import { StatusBadge } from "@/components/shared/status-badge";
 import { EmptyState } from "@/components/shared/empty-state";
 import { EmailFiltersBar } from "@/components/emails/email-filters";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { formatDate } from "@/lib/utils";
 import type { Email, EmailFilters } from "@/types/emails";
 
@@ -19,7 +20,10 @@ function buildDetailPath(
   trackingId: string
 ): string {
   if (scope.level === "workspace") {
-    return `/t/${scope.tenantCode}/w/${scope.workspaceCode}/emails/${trackingId}`;
+    return applyEnvironmentSearchParam(
+      `/t/${scope.tenantCode}/w/${scope.workspaceCode}/emails/${trackingId}`,
+      scope.environment,
+    );
   }
   return `/global/emails/${trackingId}`;
 }

--- a/web/src/components/layout/header.tsx
+++ b/web/src/components/layout/header.tsx
@@ -3,6 +3,9 @@
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Bell, PanelLeft } from "lucide-react";
+import { useEnvironmentMode } from "@/hooks/use-environment-mode";
+import { useScope } from "@/hooks/use-scope";
+import { cn } from "@/lib/utils";
 
 export function AppHeader({
   onOpenMobileSidebar,
@@ -11,6 +14,8 @@ export function AppHeader({
 }) {
   const pathname = usePathname();
   const t = useTranslations("nav");
+  const scope = useScope();
+  const { environment, setEnvironment } = useEnvironmentMode();
 
   const pathToTitle: Record<string, string> = {
     "": t("dashboard"),
@@ -68,6 +73,40 @@ export function AppHeader({
         </h2>
       </div>
       <div className="flex items-center gap-2">
+        {scope.level === "workspace" ? (
+          <div className="flex items-center gap-2 rounded-full border bg-background px-1 py-1">
+            <span
+              className={cn(
+                "rounded-full px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.08em]",
+                environment === "prod"
+                  ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-200"
+                  : "bg-amber-100 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200",
+              )}
+            >
+              {environment}
+            </span>
+            <div className="flex items-center gap-1">
+              {(["prod", "test"] as const).map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  aria-pressed={environment === option}
+                  onClick={() => setEnvironment(option)}
+                  className={cn(
+                    "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                    environment === option
+                      ? option === "prod"
+                        ? "bg-emerald-600 text-white"
+                        : "bg-amber-500 text-amber-950"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                  )}
+                >
+                  {option.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
         <button
           type="button"
           aria-label="Notifications"

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -26,6 +26,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useScope } from "@/hooks/use-scope";
 import { SYSTEM_WORKSPACE_CODE } from "@/types/api";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { BrandLogo } from "@/components/shared/brand-logo";
 import { ScopeSwitcher } from "@/components/shared/scope-switcher";
 import { LocaleSwitcher } from "@/components/shared/locale-switcher";
@@ -73,7 +74,7 @@ export function AppSidebar({
   onMobileOpenChange,
 }: AppSidebarProps) {
   const pathname = usePathname();
-  const { level, tenantCode, workspaceCode } = useScope();
+  const { level, tenantCode, workspaceCode, environment } = useScope();
   const { data: session } = useSession();
   const t = useTranslations("nav");
   const tCommon = useTranslations("common");
@@ -111,9 +112,14 @@ export function AppSidebar({
 
   useEffect(() => {
     if (level === "workspace" && tenantCode && workspaceCode) {
-      setLastWorkspacePath(`/t/${tenantCode}/w/${workspaceCode}`);
+      setLastWorkspacePath(
+        applyEnvironmentSearchParam(
+          `/t/${tenantCode}/w/${workspaceCode}`,
+          environment,
+        ),
+      );
     }
-  }, [level, tenantCode, workspaceCode]);
+  }, [environment, level, tenantCode, workspaceCode]);
 
   const displayName = session?.user?.name ?? session?.user?.email ?? "User";
   const initials = getUserInitials(session?.user?.name, session?.user?.email);
@@ -122,7 +128,11 @@ export function AppSidebar({
   const visibleNavItems = navItems.filter((item) => item.vis[effectiveLevel]);
 
   function hrefForItem(href: string) {
-    return `${basePath}${href}`;
+    const path = `${basePath}${href}`;
+    if (!path.startsWith("/t/")) {
+      return path;
+    }
+    return applyEnvironmentSearchParam(path, environment);
   }
 
   function renderSidebarContent(

--- a/web/src/components/settings/settings-content.tsx
+++ b/web/src/components/settings/settings-content.tsx
@@ -313,7 +313,11 @@ function WorkspacePolicySettingsContent({
   const scope = useScope();
   const { data, isLoading: rawLoading, error } = useResolvedWorkspacePolicies(scope);
   const isLoading = useMinimumLoading(rawLoading);
-  const updatePolicies = useUpdateWorkspacePolicies(scope.tenantCode);
+  const updatePolicies = useUpdateWorkspacePolicies(
+    scope.tenantCode,
+    scope.workspaceCode,
+    scope.environment,
+  );
   const { register, getValues, reset } = useForm<WorkspacePolicyFormValues>();
 
   useEffect(() => {

--- a/web/src/components/shared/scope-switcher.tsx
+++ b/web/src/components/shared/scope-switcher.tsx
@@ -28,6 +28,7 @@ import { cn } from "@/lib/utils";
 import { setLastWorkspacePath } from "@/hooks/use-last-workspace";
 import { useOnScopeSwitcherOpen } from "@/lib/scope-switcher-events";
 import { SYSTEM_WORKSPACE_CODE, type Tenant, type Workspace } from "@/types/api";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import {
   getWorkspaceDisplayCode,
   getWorkspaceDisplayName,
@@ -44,7 +45,7 @@ type ViewMode = "tenants" | "workspaces";
 export function ScopeSwitcher({ collapsed }: ScopeSwitcherProps) {
   const [open, setOpen] = useState(false);
   const router = useRouter();
-  const { level, tenantCode, workspaceCode } = useScope();
+  const { level, tenantCode, workspaceCode, environment } = useScope();
   const tScope = useTranslations("scopeSwitcher");
 
   // View state
@@ -106,11 +107,14 @@ export function ScopeSwitcher({ collapsed }: ScopeSwitcherProps) {
         : "text-scope-workspace";
 
   function navigateTo(path: string) {
-    if (WORKSPACE_PATH_RE.test(path)) {
-      setLastWorkspacePath(path);
+    const nextPath = WORKSPACE_PATH_RE.test(path)
+      ? applyEnvironmentSearchParam(path, environment)
+      : path;
+    if (WORKSPACE_PATH_RE.test(nextPath)) {
+      setLastWorkspacePath(nextPath);
     }
     setOpen(false);
-    router.push(path);
+    router.push(nextPath);
   }
 
   function handleTenantClick(tenant: Tenant) {

--- a/web/src/components/templates/external-template-builder-shell.tsx
+++ b/web/src/components/templates/external-template-builder-shell.tsx
@@ -37,7 +37,7 @@ export function ExternalTemplateBuilderShell({
       ? `external/${profileSlug}/tenants/${scope.tenantCode}/workspaces/${scope.workspaceCode}/session`
       : null;
   const sessionQuery = useQuery({
-    queryKey: ["external-builder-session", sessionPath],
+    queryKey: ["external-builder-session", sessionPath, scope.environment],
     queryFn: () => api.get(sessionPath!).json<ExternalEmbedSessionState>(),
     enabled: apiReady && !!sessionPath,
     retry: false,
@@ -66,6 +66,16 @@ export function ExternalTemplateBuilderShell({
               </h1>
               <Badge variant="outline">{profileSlug}</Badge>
               <Badge variant="secondary">{templateSlug}</Badge>
+              <Badge
+                variant="outline"
+                className={
+                  scope.environment === "test"
+                    ? "border-amber-500/60 bg-amber-500/10 text-amber-900 dark:text-amber-100"
+                    : "border-emerald-500/60 bg-emerald-500/10 text-emerald-900 dark:text-emerald-100"
+                }
+              >
+                {(scope.environment ?? "prod").toUpperCase()}
+              </Badge>
               <ScopeIndicator
                 scope={viewState.readOnly ? "system" : "workspace"}
                 label={viewState.workspaceLabel}

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -52,6 +52,7 @@ import {
   renderVideoBlockToMjml,
 } from "./video-block";
 import { useScope, useScopedPath } from "@/hooks/use-scope";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { getTemplateManagementState } from "@/lib/workspace-resource-policies";
 import {
   useTemplateVersion,
@@ -2525,7 +2526,10 @@ export function MjmlEditor({
       case "global":
         return `/global/templates/${slug}`;
       default:
-        return `/t/${scope.tenantCode}/w/${scope.workspaceCode}/templates/${slug}`;
+        return applyEnvironmentSearchParam(
+          `/t/${scope.tenantCode}/w/${scope.workspaceCode}/templates/${slug}`,
+          scope.environment,
+        );
     }
   }
 

--- a/web/src/components/templates/template-types-content.tsx
+++ b/web/src/components/templates/template-types-content.tsx
@@ -4,6 +4,7 @@ import { useMemo, useRef, useState } from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { z } from "zod";
 import {
   Plus,
   Search,
@@ -22,6 +23,7 @@ import {
   resolveResourceDisplayScope,
 } from "@/lib/workspace-resource-policies";
 import { cn } from "@/lib/utils";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { generateSlug, nameSchema, slugSchema } from "@/lib/validations/slug";
 import { useTemplateTypes, useCreateTemplateType, useUpdateTemplateType, useDeleteTemplateType } from "@/hooks/use-template-types";
 import { useAdapterList } from "@/hooks/use-adapters";
@@ -54,11 +56,32 @@ import { toast } from "sonner";
 
 const SENDER_DEFAULT = "__default__";
 const SENDER_NONE = "__none__";
+const TEST_RECIPIENT_INHERIT = "__inherit__";
 const SLUG_WARNING_LINES = [
   "Integraciones que usan el ref actual pueden dejar de resolver.",
   "Links o bookmarks al template type actual pueden quedar obsoletos.",
   "El historial y los filtros por slug pueden quedar divididos entre el valor viejo y el nuevo.",
 ] as const;
+const emailAddressSchema = z.email("Enter a valid email address");
+
+function parseRecipientAddressesInput(value: string): {
+  addresses: string[];
+  invalid: string[];
+} {
+  const parts = value
+    .split(/[\n,;]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  const invalid = parts.filter(
+    (item) => !emailAddressSchema.safeParse(item).success,
+  );
+
+  return {
+    addresses: Array.from(new Set(parts)),
+    invalid,
+  };
+}
 
 export function TemplateTypesContent() {
   return <TemplateTypesTable />;
@@ -70,6 +93,7 @@ function TemplateTypesTable() {
   const router = useRouter();
   const scope = useScope();
   const scopedPath = useScopedPath();
+  const isTestEnvironment = scope.environment === "test";
   const workspacePolicies = useResolvedWorkspacePolicies(scope);
   const templateCatalogState = getTemplateCatalogState(scope, workspacePolicies.data);
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
@@ -89,6 +113,10 @@ function TemplateTypesTable() {
   const [newName, setNewName] = useState("");
   const [newAdapterId, setNewAdapterId] = useState("");
   const [newSenderIdentityId, setNewSenderIdentityId] = useState("");
+  const [newTestRecipientMode, setNewTestRecipientMode] =
+    useState<string>(TEST_RECIPIENT_INHERIT);
+  const [newTestRecipientAddresses, setNewTestRecipientAddresses] =
+    useState("");
   const [slugTouched, setSlugTouched] = useState(false);
   const [editTarget, setEditTarget] = useState<TemplateType | null>(null);
 
@@ -112,7 +140,10 @@ function TemplateTypesTable() {
       case "global":
         return `/global/templates/${slug}`;
       default:
-        return `/t/${scope.tenantCode}/w/${scope.workspaceCode}/templates/${slug}`;
+        return applyEnvironmentSearchParam(
+          `/t/${scope.tenantCode}/w/${scope.workspaceCode}/templates/${slug}`,
+          scope.environment,
+        );
     }
   }
 
@@ -253,17 +284,35 @@ function TemplateTypesTable() {
         return;
       }
       const senderIdValue = newSenderIdentityId && newSenderIdentityId !== SENDER_DEFAULT ? newSenderIdentityId : undefined;
-      await createMutation.mutateAsync({
+      const payload: Parameters<typeof createMutation.mutateAsync>[0] = {
         slug: newSlug.trim(),
         name: newName.trim(),
         adapter_id: newAdapterId || undefined,
         sender_identity_id: senderIdValue,
-      });
+      };
+
+      if (isTestEnvironment && newTestRecipientMode !== TEST_RECIPIENT_INHERIT) {
+        const parsed = parseRecipientAddressesInput(newTestRecipientAddresses);
+        if (parsed.invalid.length > 0) {
+          toast.error(`Invalid addresses: ${parsed.invalid.join(", ")}`);
+          return;
+        }
+        if (parsed.addresses.length === 0) {
+          toast.error("Provide at least one safe recipient for the override.");
+          return;
+        }
+        payload.test_recipient_mode = newTestRecipientMode as "replace" | "append";
+        payload.test_recipient_addresses = parsed.addresses;
+      }
+
+      await createMutation.mutateAsync(payload);
       toast.success(t("templateTypeCreated"));
       setNewSlug("");
       setNewName("");
       setNewAdapterId("");
       setNewSenderIdentityId("");
+      setNewTestRecipientMode(TEST_RECIPIENT_INHERIT);
+      setNewTestRecipientAddresses("");
       setSlugTouched(false);
     } catch {
       toast.error(t("templateTypeCreateFailed"));
@@ -335,6 +384,60 @@ function TemplateTypesTable() {
                 senderIdentityId={newSenderIdentityId}
                 onSenderIdentityChange={setNewSenderIdentityId}
               />
+              {isTestEnvironment ? (
+                <div className="rounded-md border border-amber-300/60 bg-amber-50 p-3 text-sm dark:border-amber-900/60 dark:bg-amber-950/20">
+                  <div className="space-y-3">
+                    <div>
+                      <p className="font-medium text-amber-950 dark:text-amber-100">
+                        Test recipient override
+                      </p>
+                      <p className="text-xs text-amber-800/90 dark:text-amber-200/90">
+                        Leave this unset to inherit the workspace-level safe recipients. Use append with caution.
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Override mode</Label>
+                      <Select
+                        value={newTestRecipientMode}
+                        onValueChange={setNewTestRecipientMode}
+                      >
+                        <SelectTrigger className="w-full bg-background">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={TEST_RECIPIENT_INHERIT}>
+                            Inherit workspace default
+                          </SelectItem>
+                          <SelectItem value="replace">Replace recipients</SelectItem>
+                          <SelectItem value="append">Append safe recipients</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    {newTestRecipientMode !== TEST_RECIPIENT_INHERIT ? (
+                      <div className="space-y-2">
+                        <Label>Safe recipients</Label>
+                        <textarea
+                          rows={4}
+                          value={newTestRecipientAddresses}
+                          onChange={(event) =>
+                            setNewTestRecipientAddresses(event.target.value)
+                          }
+                          placeholder={"qa@example.com\napprover@example.com"}
+                          className="flex min-h-[96px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none ring-ring/10 transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-4"
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Separate addresses with new lines, commas, or semicolons.
+                        </p>
+                        {newTestRecipientMode === "append" ? (
+                          <p className="text-xs text-amber-700 dark:text-amber-300">
+                            Warning: append preserves original recipients and adds these addresses.
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
             </div>
           </FormDialog>
         ) : (
@@ -417,6 +520,7 @@ function EditTemplateTypeDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
+  const scope = useScope();
   const scopedPath = useScopedPath();
   const updateMutation = useUpdateTemplateType(scopedPath, templateType.slug);
   const shouldReduceMotion = useReducedMotion();
@@ -425,6 +529,13 @@ function EditTemplateTypeDialog({
   const [slug, setSlug] = useState(templateType.slug);
   const [adapterId, setAdapterId] = useState(templateType.adapter_id ?? "");
   const [senderIdentityId, setSenderIdentityId] = useState(templateType.sender_identity_id ?? "");
+  const [testRecipientMode, setTestRecipientMode] = useState<string>(
+    templateType.test_recipient_mode ?? TEST_RECIPIENT_INHERIT,
+  );
+  const [testRecipientAddresses, setTestRecipientAddresses] = useState(
+    templateType.test_recipient_addresses?.join("\n") ?? "",
+  );
+  const isTestEnvironment = scope.environment === "test";
 
   const originalSlug = templateType.slug;
   const slugDirty = slug !== originalSlug;
@@ -456,12 +567,31 @@ function EditTemplateTypeDialog({
         return true;
       }
       const senderIdValue = senderIdentityId && senderIdentityId !== SENDER_DEFAULT ? senderIdentityId : "";
-      await updateMutation.mutateAsync({
+      const payload: Parameters<typeof updateMutation.mutateAsync>[0] = {
         name: name.trim(),
         slug: slug.trim(),
         adapter_id: adapterId || undefined,
         sender_identity_id: senderIdValue || undefined,
-      });
+      };
+      if (isTestEnvironment) {
+        if (testRecipientMode === TEST_RECIPIENT_INHERIT) {
+          payload.test_recipient_mode = "";
+          payload.test_recipient_addresses = [];
+        } else {
+          const parsed = parseRecipientAddressesInput(testRecipientAddresses);
+          if (parsed.invalid.length > 0) {
+            toast.error(`Invalid addresses: ${parsed.invalid.join(", ")}`);
+            return true;
+          }
+          if (parsed.addresses.length === 0) {
+            toast.error("Provide at least one safe recipient for the override.");
+            return true;
+          }
+          payload.test_recipient_mode = testRecipientMode as "replace" | "append";
+          payload.test_recipient_addresses = parsed.addresses;
+        }
+      }
+      await updateMutation.mutateAsync(payload);
       toast.success("Template type updated");
     } catch {
       toast.error("Failed to update");
@@ -572,6 +702,57 @@ function EditTemplateTypeDialog({
           senderIdentityId={senderIdentityId}
           onSenderIdentityChange={setSenderIdentityId}
         />
+        {isTestEnvironment ? (
+          <div className="rounded-md border border-amber-300/60 bg-amber-50 p-3 text-sm dark:border-amber-900/60 dark:bg-amber-950/20">
+            <div className="space-y-3">
+              <div>
+                <p className="font-medium text-amber-950 dark:text-amber-100">
+                  Test recipient override
+                </p>
+                <p className="text-xs text-amber-800/90 dark:text-amber-200/90">
+                  Choose inherit to use the workspace default safe recipients. Replace is the recommended override mode.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label>Override mode</Label>
+                <Select value={testRecipientMode} onValueChange={setTestRecipientMode}>
+                  <SelectTrigger className="w-full bg-background">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={TEST_RECIPIENT_INHERIT}>
+                      Inherit workspace default
+                    </SelectItem>
+                    <SelectItem value="replace">Replace recipients</SelectItem>
+                    <SelectItem value="append">Append safe recipients</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              {testRecipientMode !== TEST_RECIPIENT_INHERIT ? (
+                <div className="space-y-2">
+                  <Label>Safe recipients</Label>
+                  <textarea
+                    rows={4}
+                    value={testRecipientAddresses}
+                    onChange={(event) =>
+                      setTestRecipientAddresses(event.target.value)
+                    }
+                    placeholder={"qa@example.com\napprover@example.com"}
+                    className="flex min-h-[96px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none ring-ring/10 transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-4"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Separate addresses with new lines, commas, or semicolons.
+                  </p>
+                  {testRecipientMode === "append" ? (
+                    <p className="text-xs text-amber-700 dark:text-amber-300">
+                      Warning: append preserves original recipients and adds these addresses.
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
       </div>
     </FormDialog>
   );

--- a/web/src/components/templates/templates-list-content.tsx
+++ b/web/src/components/templates/templates-list-content.tsx
@@ -6,6 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { Plus, FileText, Pencil, Send, Trash2, Copy, GitFork, Lock } from "lucide-react";
 import { useScope, useScopedPath } from "@/hooks/use-scope";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import {
   getTemplateCatalogState,
   getTemplateManagementState,
@@ -102,7 +103,10 @@ export function TemplatesListContent() {
       case "global":
         return `/global/templates/${slug}/edit?templateId=${tplId}&versionId=${versionId}`;
       default:
-        return `/t/${scope.tenantCode}/w/${scope.workspaceCode}/templates/${slug}/edit?templateId=${tplId}&versionId=${versionId}`;
+        return applyEnvironmentSearchParam(
+          `/t/${scope.tenantCode}/w/${scope.workspaceCode}/templates/${slug}/edit?templateId=${tplId}&versionId=${versionId}`,
+          scope.environment,
+        );
     }
   }
 

--- a/web/src/components/workspaces/workspaces-content.tsx
+++ b/web/src/components/workspaces/workspaces-content.tsx
@@ -45,7 +45,9 @@ import {
   useWorkspacesManagement,
 } from "@/hooks/use-workspaces-mgmt";
 import { useScope } from "@/hooks/use-scope";
+import { applyEnvironmentSearchParam } from "@/lib/environment-mode";
 import { parseApiError } from "@/lib/api";
+import { formatWorkspaceTestRecipientAddresses } from "@/lib/workspace-test-recipient-addresses";
 import { formatDate } from "@/lib/utils";
 import {
   generateSlug,
@@ -62,6 +64,8 @@ const createWorkspaceSchema = z.object({
 const editWorkspaceSchema = z.object({
   name: nameSchema,
   status: z.enum(["active", "disabled"]),
+  test_recipient_mode: z.enum(["replace", "append"]).optional(),
+  test_recipient_addresses: z.string().optional(),
 });
 
 type CreateWorkspaceFormValues = z.infer<typeof createWorkspaceSchema>;
@@ -71,8 +75,29 @@ type WorkspaceToggleTarget = {
   nextActive: boolean;
 };
 
+const emailAddressSchema = z.email("Enter a valid email address");
+
 function formatCompactDate(value: string): string {
   return formatDate(value).replace(",", "");
+}
+
+function parseRecipientAddressesInput(value: string): {
+  addresses: string[];
+  invalid: string[];
+} {
+  const parts = value
+    .split(/[\n,;]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  const invalid = parts.filter(
+    (item) => !emailAddressSchema.safeParse(item).success,
+  );
+
+  return {
+    addresses: Array.from(new Set(parts)),
+    invalid,
+  };
 }
 
 async function applyCreateWorkspaceErrors(
@@ -107,6 +132,9 @@ async function applyEditWorkspaceErrors(
       if (detail.field === "name") {
         setError("name", { message: detail.message });
       }
+      if (detail.field === "test_recipient_addresses") {
+        setError("test_recipient_addresses", { message: detail.message });
+      }
     }
     return;
   }
@@ -118,6 +146,7 @@ export function WorkspacesContent() {
   const router = useRouter();
   const scope = useScope();
   const tenantCode = scope.tenantCode;
+  const environment = scope.environment ?? "prod";
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
@@ -137,9 +166,9 @@ export function WorkspacesContent() {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-  } = useWorkspacesManagement(tenantCode ?? "", search);
+  } = useWorkspacesManagement(tenantCode ?? "", search, environment);
   const createWorkspace = useCreateWorkspace(tenantCode ?? "");
-  const updateWorkspace = useUpdateWorkspace(tenantCode ?? "");
+  const updateWorkspace = useUpdateWorkspace(tenantCode ?? "", environment);
   const deleteWorkspace = useDeleteWorkspace(tenantCode ?? "");
 
   useEffect(() => {
@@ -397,10 +426,21 @@ export function WorkspacesContent() {
           />
         </div>
 
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Create Workspace
-        </Button>
+        <div className="flex items-center gap-3">
+          <span
+            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.08em] ${
+              environment === "prod"
+                ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-200"
+                : "bg-amber-100 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200"
+            }`}
+          >
+            {environment}
+          </span>
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Create Workspace
+          </Button>
+        </div>
       </div>
 
       <DataTable
@@ -410,7 +450,14 @@ export function WorkspacesContent() {
         hasMore={hasNextPage}
         onLoadMore={() => fetchNextPage()}
         loadingMore={isFetchingNextPage}
-        onRowClick={(workspace) => router.push(`/t/${tenantCode}/w/${workspace.code}`)}
+        onRowClick={(workspace) =>
+          router.push(
+            applyEnvironmentSearchParam(
+              `/t/${tenantCode}/w/${workspace.code}`,
+              environment,
+            ),
+          )
+        }
         emptyState={
           <EmptyState
             icon={Layers}
@@ -443,6 +490,7 @@ export function WorkspacesContent() {
           onOpenChange={(open) => {
             if (!open) setEditTarget(null);
           }}
+          environment={environment}
           onUpdateWorkspace={handleUpdateWorkspace}
         />
       )}
@@ -592,11 +640,13 @@ function EditWorkspaceDialog({
   workspace,
   open,
   onOpenChange,
+  environment,
   onUpdateWorkspace,
 }: {
   workspace: Workspace;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  environment: "prod" | "test";
   onUpdateWorkspace: (
     workspaceCode: string,
     data: UpdateWorkspaceInput,
@@ -607,14 +657,26 @@ function EditWorkspaceDialog({
     defaultValues: {
       name: workspace.name,
       status: workspace.is_active ? "active" : "disabled",
+      test_recipient_mode: workspace.test_recipient_mode,
+      test_recipient_addresses: formatWorkspaceTestRecipientAddresses(
+        workspace.test_recipient_addresses,
+      ),
     },
   });
   const watchedStatus = useWatch({ control: form.control, name: "status" });
+  const watchedTestRecipientMode = useWatch({
+    control: form.control,
+    name: "test_recipient_mode",
+  });
 
   useEffect(() => {
     form.reset({
       name: workspace.name,
       status: workspace.is_active ? "active" : "disabled",
+      test_recipient_mode: workspace.test_recipient_mode,
+      test_recipient_addresses: formatWorkspaceTestRecipientAddresses(
+        workspace.test_recipient_addresses,
+      ),
     });
   }, [form, workspace]);
 
@@ -624,10 +686,34 @@ function EditWorkspaceDialog({
     await form.handleSubmit(
       async (values) => {
         try {
-          await onUpdateWorkspace(workspace.code, {
+          const update: UpdateWorkspaceInput = {
             name: values.name,
             is_active: values.status === "active",
-          });
+          };
+
+          if (environment === "test") {
+            const parsed = parseRecipientAddressesInput(
+              values.test_recipient_addresses ?? "",
+            );
+            if (parsed.invalid.length > 0) {
+              form.setError("test_recipient_addresses", {
+                message: `Invalid addresses: ${parsed.invalid.join(", ")}`,
+              });
+              keepOpen = true;
+              return;
+            }
+            if (parsed.addresses.length === 0) {
+              form.setError("test_recipient_addresses", {
+                message: "At least one safe recipient is required in test mode.",
+              });
+              keepOpen = true;
+              return;
+            }
+            update.test_recipient_mode = values.test_recipient_mode ?? "replace";
+            update.test_recipient_addresses = parsed.addresses;
+          }
+
+          await onUpdateWorkspace(workspace.code, update);
         } catch (error) {
           keepOpen = true;
           await applyEditWorkspaceErrors(error, form.setError);
@@ -702,6 +788,71 @@ function EditWorkspaceDialog({
             </p>
           )}
         </div>
+
+        {environment === "test" ? (
+          <>
+            <div className="rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-xs text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-100">
+              Test mode never sends to real recipients directly. Configure the safe recipients used for this environment.
+            </div>
+
+            <div className="space-y-1.5">
+              <Label className="text-[13px] font-medium">
+                Test recipient mode
+              </Label>
+              <Select
+                value={watchedTestRecipientMode ?? "replace"}
+                onValueChange={(value) =>
+                  form.setValue(
+                    "test_recipient_mode",
+                    value as EditWorkspaceFormValues["test_recipient_mode"],
+                    { shouldValidate: true },
+                  )
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="replace">Replace recipients</SelectItem>
+                  <SelectItem value="append">Append safe recipients</SelectItem>
+                </SelectContent>
+              </Select>
+              {watchedTestRecipientMode === "append" ? (
+                <p className="text-xs text-amber-700 dark:text-amber-300">
+                  Warning: append keeps the original recipients and adds the safe list.
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Replace is the recommended default for test workspaces.
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label
+                htmlFor="edit-workspace-test-recipients"
+                className="text-[13px] font-medium"
+              >
+                Safe recipients
+              </Label>
+              <textarea
+                id="edit-workspace-test-recipients"
+                rows={4}
+                placeholder={"qa@example.com\napprover@example.com"}
+                {...form.register("test_recipient_addresses")}
+                className="flex min-h-[96px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none ring-ring/10 transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-4"
+              />
+              <p className="text-xs text-muted-foreground">
+                Separate addresses with new lines, commas, or semicolons.
+              </p>
+              {form.formState.errors.test_recipient_addresses && (
+                <p className="text-xs text-destructive">
+                  {form.formState.errors.test_recipient_addresses.message}
+                </p>
+              )}
+            </div>
+          </>
+        ) : null}
       </div>
     </FormDialog>
   );

--- a/web/src/hooks/use-environment-mode.ts
+++ b/web/src/hooks/use-environment-mode.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useCallback } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { applyEnvironmentSearchParam, normalizeEnvironment } from "@/lib/environment-mode";
+import type { Environment } from "@/types/api";
+
+export function useEnvironmentMode() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const environment = normalizeEnvironment(searchParams.get("environment"));
+
+  const setEnvironment = useCallback(
+    (nextEnvironment: Environment) => {
+      const currentPath = `${pathname}${searchParams.toString() ? `?${searchParams.toString()}` : ""}`;
+      router.replace(applyEnvironmentSearchParam(currentPath, nextEnvironment));
+    },
+    [pathname, router, searchParams],
+  );
+
+  return {
+    environment,
+    isTest: environment === "test",
+    setEnvironment,
+  };
+}

--- a/web/src/hooks/use-members-mgmt.ts
+++ b/web/src/hooks/use-members-mgmt.ts
@@ -12,11 +12,11 @@ import type {
 } from "@/types/members-ext";
 
 function useMembersPath(): string {
-  const { level, tenantCode, workspaceCode } = useScope();
+  const { level, tenantCode, workspaceCode, environment } = useScope();
 
   switch (level) {
     case "workspace":
-      return `manage/tenants/${tenantCode}/workspaces/${workspaceCode}/members`;
+      return `manage/environments/${environment ?? "prod"}/tenants/${tenantCode}/workspaces/${workspaceCode}/members`;
     default:
       return "manage/members";
   }

--- a/web/src/hooks/use-scope.ts
+++ b/web/src/hooks/use-scope.ts
@@ -1,8 +1,9 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import type { ScopeContext, ScopeLevel } from "@/types/api";
 import { resolveScopedPathFromParams } from "@/lib/external-api-context";
+import { normalizeEnvironment } from "@/lib/environment-mode";
 
 /**
  * Extract scope context from URL params.
@@ -15,9 +16,11 @@ import { resolveScopedPathFromParams } from "@/lib/external-api-context";
 export function useScope(): ScopeContext {
   const params = useParams<{
     profileSlug?: string;
+    environment?: string;
     tenantCode?: string;
     workspaceCode?: string;
   }>();
+  const searchParams = useSearchParams();
 
   let level: ScopeLevel = "global";
 
@@ -29,8 +32,12 @@ export function useScope(): ScopeContext {
 
   return {
     level,
+    profileSlug: params.profileSlug,
     tenantCode: params.tenantCode,
     workspaceCode: params.workspaceCode,
+    environment: normalizeEnvironment(
+      params.environment ?? searchParams.get("environment"),
+    ),
   };
 }
 
@@ -38,11 +45,5 @@ export function useScope(): ScopeContext {
  * Build the management API base path for the current scope.
  */
 export function useScopedPath(): string {
-  const params = useParams<{
-    profileSlug?: string;
-    tenantCode?: string;
-    workspaceCode?: string;
-  }>();
-
-  return resolveScopedPathFromParams(params);
+  return resolveScopedPathFromParams(useScope());
 }

--- a/web/src/hooks/use-settings.ts
+++ b/web/src/hooks/use-settings.ts
@@ -2,13 +2,14 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useApi, useApiReady } from "@/hooks/use-api";
-import { useParams } from "next/navigation";
 import {
   canManageSystemWorkspacePolicies,
   isWorkspaceScope,
 } from "@/lib/workspace-resource-policies";
 import { resolveWorkspacePoliciesPathFromParams } from "@/lib/external-api-context";
-import { type ScopeContext } from "@/types/api";
+import { type Environment, type ScopeContext } from "@/types/api";
+import { normalizeEnvironment } from "@/lib/environment-mode";
+import { useScope } from "@/hooks/use-scope";
 import type {
   SystemSettings,
   UpdateSettingsRequest,
@@ -16,8 +17,12 @@ import type {
   WorkspacePolicies,
 } from "@/types/settings";
 
-function buildWorkspacePoliciesPath(tenantCode: string, workspaceCode: string) {
-  return `manage/tenants/${tenantCode}/workspaces/${workspaceCode}/policies`;
+function buildWorkspacePoliciesPath(
+  tenantCode: string,
+  workspaceCode: string,
+  environment?: Environment,
+) {
+  return `manage/environments/${normalizeEnvironment(environment)}/tenants/${tenantCode}/workspaces/${workspaceCode}/policies`;
 }
 
 export function useSettings() {
@@ -47,16 +52,17 @@ export function useUpdateSettings() {
 export function useWorkspacePolicies(
   tenantCode?: string,
   workspaceCode?: string,
+  environment?: Environment,
   enabled = true,
 ) {
   const api = useApi();
   const ready = useApiReady();
 
   return useQuery({
-    queryKey: ["workspace-policies", tenantCode, workspaceCode],
+    queryKey: ["workspace-policies", tenantCode, workspaceCode, environment],
     queryFn: () =>
       api
-        .get(buildWorkspacePoliciesPath(tenantCode!, workspaceCode!))
+        .get(buildWorkspacePoliciesPath(tenantCode!, workspaceCode!, environment))
         .json<WorkspacePolicies>(),
     enabled: ready && enabled && !!tenantCode && !!workspaceCode,
     retry: false,
@@ -66,6 +72,7 @@ export function useWorkspacePolicies(
 export function useUpdateWorkspacePolicies(
   tenantCode?: string,
   workspaceCode = "_system",
+  environment?: Environment,
 ) {
   const api = useApi();
   const queryClient = useQueryClient();
@@ -73,30 +80,29 @@ export function useUpdateWorkspacePolicies(
   return useMutation({
     mutationFn: (data: UpdateWorkspacePoliciesRequest) =>
       api
-        .put(buildWorkspacePoliciesPath(tenantCode!, workspaceCode), {
+        .put(buildWorkspacePoliciesPath(tenantCode!, workspaceCode, environment), {
           json: data,
         })
         .json<WorkspacePolicies>(),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["workspace-policies", tenantCode, workspaceCode],
+        queryKey: ["workspace-policies", tenantCode, workspaceCode, environment],
       });
     },
   });
 }
 
 export function useResolvedWorkspacePolicies(scope: ScopeContext) {
-  const params = useParams<{
-    profileSlug?: string;
-    tenantCode?: string;
-    workspaceCode?: string;
-  }>();
-  const policiesPath = resolveWorkspacePoliciesPathFromParams(params);
+  const resolvedScope = useScope();
+  const policiesPath = resolveWorkspacePoliciesPathFromParams({
+    ...resolvedScope,
+    ...scope,
+  });
   const api = useApi();
   const ready = useApiReady();
 
   const query = useQuery({
-    queryKey: ["workspace-policies", policiesPath],
+    queryKey: ["workspace-policies", policiesPath, resolvedScope.environment],
     queryFn: () => api.get(policiesPath!).json<WorkspacePolicies>(),
     enabled: ready && isWorkspaceScope(scope) && !!policiesPath,
     retry: false,

--- a/web/src/hooks/use-template-types.ts
+++ b/web/src/hooks/use-template-types.ts
@@ -41,7 +41,14 @@ export function useUpdateTemplateType(scopedPath: string, slug: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: { name?: string; slug?: string; adapter_id?: string; sender_identity_id?: string }) =>
+    mutationFn: (data: {
+      name?: string;
+      slug?: string;
+      adapter_id?: string;
+      sender_identity_id?: string;
+      test_recipient_mode?: "" | "replace" | "append";
+      test_recipient_addresses?: string[];
+    }) =>
       api
         .put(`${scopedPath}/template-types/${slug}`, { json: data })
         .json<TemplateType>(),
@@ -81,7 +88,14 @@ export function useCreateTemplateType(scopedPath: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: { slug: string; name: string; adapter_id?: string; sender_identity_id?: string }) =>
+    mutationFn: (data: {
+      slug: string;
+      name: string;
+      adapter_id?: string;
+      sender_identity_id?: string;
+      test_recipient_mode?: "" | "replace" | "append";
+      test_recipient_addresses?: string[];
+    }) =>
       api
         .post(`${scopedPath}/template-types`, { json: data })
         .json<TemplateType>(),

--- a/web/src/hooks/use-workspaces-mgmt.ts
+++ b/web/src/hooks/use-workspaces-mgmt.ts
@@ -3,7 +3,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useApi, useApiReady } from "@/hooks/use-api";
 import { usePaginatedQuery } from "@/hooks/use-paginated-query";
-import type { PaginatedResponse, Workspace } from "@/types/api";
+import type { Environment, PaginatedResponse, Workspace } from "@/types/api";
+import { normalizeEnvironment } from "@/lib/environment-mode";
 
 export interface CreateWorkspaceInput {
   code: string;
@@ -13,27 +14,40 @@ export interface CreateWorkspaceInput {
 export interface UpdateWorkspaceInput {
   name?: string;
   is_active?: boolean;
+  test_recipient_mode?: "replace" | "append";
+  test_recipient_addresses?: string[];
 }
 
 function invalidateWorkspaceQueries(
   queryClient: ReturnType<typeof useQueryClient>,
   tenantCode: string,
+  environment?: Environment,
 ) {
-  queryClient.invalidateQueries({ queryKey: ["workspaces", tenantCode] });
+  queryClient.invalidateQueries({
+    queryKey: ["workspaces", tenantCode, normalizeEnvironment(environment)],
+  });
 }
 
-export function useWorkspacesManagement(tenantCode: string, search: string) {
+export function useWorkspacesManagement(
+  tenantCode: string,
+  search: string,
+  environment?: Environment,
+) {
   const api = useApi();
   const ready = useApiReady();
+  const normalizedEnvironment = normalizeEnvironment(environment);
 
   return usePaginatedQuery<Workspace>({
-    queryKey: ["workspaces", tenantCode, "management", search],
+    queryKey: ["workspaces", tenantCode, normalizedEnvironment, "management", search],
     fetcher: (cursor) => {
       const params: Record<string, string | number> = { limit: 25 };
       if (cursor) params.cursor = cursor;
       if (search) params.search = search;
       return api
-        .get(`manage/tenants/${tenantCode}/workspaces`, { searchParams: params })
+        .get(
+          `manage/environments/${normalizedEnvironment}/tenants/${tenantCode}/workspaces`,
+          { searchParams: params },
+        )
         .json<PaginatedResponse<Workspace>>();
     },
     enabled: ready && !!tenantCode,
@@ -50,14 +64,19 @@ export function useCreateWorkspace(tenantCode: string) {
         .post(`manage/tenants/${tenantCode}/workspaces`, { json: data })
         .json<Workspace>(),
     onSuccess: () => {
-      invalidateWorkspaceQueries(queryClient, tenantCode);
+      invalidateWorkspaceQueries(queryClient, tenantCode, "prod");
+      invalidateWorkspaceQueries(queryClient, tenantCode, "test");
     },
   });
 }
 
-export function useUpdateWorkspace(tenantCode: string) {
+export function useUpdateWorkspace(
+  tenantCode: string,
+  environment?: Environment,
+) {
   const api = useApi();
   const queryClient = useQueryClient();
+  const normalizedEnvironment = normalizeEnvironment(environment);
 
   return useMutation({
     mutationFn: ({
@@ -68,12 +87,15 @@ export function useUpdateWorkspace(tenantCode: string) {
       data: UpdateWorkspaceInput;
     }) =>
       api
-        .put(`manage/tenants/${tenantCode}/workspaces/${workspaceCode}`, {
+        .put(
+          `manage/environments/${normalizedEnvironment}/tenants/${tenantCode}/workspaces/${workspaceCode}`,
+          {
           json: data,
-        })
+          },
+        )
         .json<Workspace>(),
     onSuccess: () => {
-      invalidateWorkspaceQueries(queryClient, tenantCode);
+      invalidateWorkspaceQueries(queryClient, tenantCode, normalizedEnvironment);
     },
   });
 }
@@ -87,7 +109,8 @@ export function useDeleteWorkspace(tenantCode: string) {
       await api.delete(`manage/tenants/${tenantCode}/workspaces/${workspaceCode}`);
     },
     onSuccess: () => {
-      invalidateWorkspaceQueries(queryClient, tenantCode);
+      invalidateWorkspaceQueries(queryClient, tenantCode, "prod");
+      invalidateWorkspaceQueries(queryClient, tenantCode, "test");
     },
   });
 }

--- a/web/src/lib/data-plane-openapi.json
+++ b/web/src/lib/data-plane-openapi.json
@@ -947,8 +947,8 @@
       "WorkspaceAPIKeyBearer": {
         "type": "http",
         "scheme": "bearer",
-        "bearerFormat": "senda_live",
-        "description": "Workspace-scoped API key sent as Authorization: Bearer senda_live_..."
+        "bearerFormat": "senda_prod|senda_test",
+        "description": "Workspace-scoped API key sent as Authorization: Bearer senda_prod_... or senda_test_..."
       }
     },
     "schemas": {

--- a/web/src/lib/environment-mode.test.ts
+++ b/web/src/lib/environment-mode.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyEnvironmentSearchParam,
+  normalizeEnvironment,
+} from "./environment-mode.ts";
+
+test("normalizeEnvironment defaults invalid values to prod", () => {
+  assert.equal(normalizeEnvironment("prod"), "prod");
+  assert.equal(normalizeEnvironment("test"), "test");
+  assert.equal(normalizeEnvironment(""), "prod");
+  assert.equal(normalizeEnvironment("dev"), "prod");
+  assert.equal(normalizeEnvironment(undefined), "prod");
+});
+
+test("applyEnvironmentSearchParam preserves query params and hash", () => {
+  assert.equal(
+    applyEnvironmentSearchParam("/t/acme/w/marketing/templates?tab=content#preview", "test"),
+    "/t/acme/w/marketing/templates?tab=content&environment=test#preview",
+  );
+});
+
+test("applyEnvironmentSearchParam overwrites the previous environment value", () => {
+  assert.equal(
+    applyEnvironmentSearchParam("/t/acme/w/marketing?environment=prod", "test"),
+    "/t/acme/w/marketing?environment=test",
+  );
+});

--- a/web/src/lib/environment-mode.ts
+++ b/web/src/lib/environment-mode.ts
@@ -1,0 +1,19 @@
+import type { Environment } from "../types/api.ts";
+
+export const DEFAULT_ENVIRONMENT: Environment = "prod";
+
+export function normalizeEnvironment(
+  value?: string | null,
+): Environment {
+  return value === "test" ? "test" : DEFAULT_ENVIRONMENT;
+}
+
+export function applyEnvironmentSearchParam(
+  path: string,
+  environment?: string | null,
+): string {
+  const normalized = normalizeEnvironment(environment);
+  const url = new URL(path, "https://local");
+  url.searchParams.set("environment", normalized);
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/web/src/lib/external-api-context.test.ts
+++ b/web/src/lib/external-api-context.test.ts
@@ -6,6 +6,7 @@ import {
   captureExternalEmbedTokenFromSearch,
   clearExternalEmbedToken,
   EXTERNAL_EMBED_TOKEN_HEADER,
+  EXTERNAL_ENVIRONMENT_HEADER,
   EXTERNAL_EMBED_TOKEN_STORAGE_KEY,
   EXTERNAL_TENANT_HEADER,
   isExternalEmbedPath,
@@ -51,7 +52,15 @@ test("resolveScopedPathFromParams keeps management paths for regular scopes", ()
       tenantCode: "acme",
       workspaceCode: "marketing",
     }),
-    "manage/tenants/acme/workspaces/marketing",
+    "manage/environments/prod/tenants/acme/workspaces/marketing",
+  );
+  assert.equal(
+    resolveScopedPathFromParams({
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+      environment: "test",
+    }),
+    "manage/environments/test/tenants/acme/workspaces/marketing",
   );
   assert.equal(
     resolveScopedPathFromParams({ tenantCode: "acme" }),
@@ -77,7 +86,15 @@ test("resolveWorkspacePoliciesPathFromParams returns management path outside emb
       tenantCode: "acme",
       workspaceCode: "marketing",
     }),
-    "manage/tenants/acme/workspaces/marketing/policies",
+    "manage/environments/prod/tenants/acme/workspaces/marketing/policies",
+  );
+  assert.equal(
+    resolveWorkspacePoliciesPathFromParams({
+      tenantCode: "acme",
+      workspaceCode: "marketing",
+      environment: "test",
+    }),
+    "manage/environments/test/tenants/acme/workspaces/marketing/policies",
   );
   assert.equal(resolveWorkspacePoliciesPathFromParams({ tenantCode: "acme" }), null);
 });
@@ -135,7 +152,30 @@ test("buildExternalEmbedApiRequest adds the dedicated external headers for exter
   assert.ok(nextRequest);
   assert.equal(nextRequest?.headers.get(EXTERNAL_EMBED_TOKEN_HEADER), SIGNED_TOKEN);
   assert.equal(nextRequest?.headers.get(EXTERNAL_TENANT_HEADER), "acme");
+  assert.equal(nextRequest?.headers.get(EXTERNAL_ENVIRONMENT_HEADER), "prod");
   assert.equal(nextRequest?.headers.get("accept"), "application/json");
+});
+
+test("buildExternalEmbedApiRequest derives environment header from embed path", () => {
+  const storage = createStorage({ [EXTERNAL_EMBED_TOKEN_STORAGE_KEY]: SIGNED_TOKEN });
+  const request = new Request(
+    "https://senda.tether.education/api/v1/external/partner-portal/bootstrap",
+    {
+      headers: {
+        accept: "application/json",
+      },
+    },
+  );
+
+  const nextRequest = buildExternalEmbedApiRequest(
+    request,
+    "/embed/partner-portal/environments/test/t/acme/w/marketing/templates/newsletter/edit",
+    storage,
+  );
+
+  assert.ok(nextRequest);
+  assert.equal(nextRequest?.headers.get(EXTERNAL_ENVIRONMENT_HEADER), "test");
+  assert.equal(nextRequest?.headers.get(EXTERNAL_TENANT_HEADER), "acme");
 });
 
 
@@ -164,6 +204,7 @@ test("buildExternalEmbedApiRequest mutates POST requests in place when the URL d
   assert.equal(nextRequest, request);
   assert.equal(nextRequest?.headers.get(EXTERNAL_EMBED_TOKEN_HEADER), SIGNED_TOKEN);
   assert.equal(nextRequest?.headers.get(EXTERNAL_TENANT_HEADER), "acme");
+  assert.equal(nextRequest?.headers.get(EXTERNAL_ENVIRONMENT_HEADER), "prod");
   assert.equal(await nextRequest?.clone().text(), JSON.stringify({ mjml: "<mjml />" }));
 });
 

--- a/web/src/lib/external-api-context.ts
+++ b/web/src/lib/external-api-context.ts
@@ -1,7 +1,11 @@
+import { normalizeEnvironment } from "./environment-mode.ts";
+import type { Environment } from "../types/api.ts";
+
 export interface ScopedPathParams {
   profileSlug?: string;
   tenantCode?: string;
   workspaceCode?: string;
+  environment?: Environment;
 }
 
 export interface StorageLike {
@@ -15,6 +19,7 @@ export const EXTERNAL_EMBED_TOKEN_CHANGED_EVENT =
   "senda:external-embed-token-changed";
 export const EXTERNAL_EMBED_TOKEN_HEADER = "x-senda-external-token";
 export const EXTERNAL_TENANT_HEADER = "x-tenant-code";
+export const EXTERNAL_ENVIRONMENT_HEADER = "x-senda-environment";
 
 function normalizeSearchString(currentSearch: string): string {
   if (!currentSearch) {
@@ -49,14 +54,51 @@ function isExternalAPIRequest(requestURL: string): boolean {
 
 const FORWARDED_EXTERNAL_QUERY_PARAMS = new Set(["fallback", "readonly"]);
 
-function extractTenantCodeFromEmbedPath(currentPathname: string): string | null {
+interface ExternalEmbedPathContext {
+  profileSlug: string;
+  environment: Environment;
+  tenantCode: string | null;
+}
+
+function parseExternalEmbedPath(
+  currentPathname: string,
+): ExternalEmbedPathContext | null {
   const segments = currentPathname.split("/").filter(Boolean);
-  if (segments.length < 5 || segments[0] !== "embed" || segments[2] !== "t") {
+  if (segments.length < 4 || segments[0] !== "embed" || !segments[1]) {
     return null;
   }
 
-  const tenantCode = segments[3]?.trim();
-  return tenantCode || null;
+  let index = 2;
+  let environment: Environment = "prod";
+  if (segments[index] === "environments") {
+    environment = normalizeEnvironment(segments[index + 1]);
+    index += 2;
+  }
+
+  if (segments[index] !== "t") {
+    return {
+      profileSlug: segments[1],
+      environment,
+      tenantCode: null,
+    };
+  }
+
+  const tenantCode = segments[index + 1]?.trim() || null;
+  return {
+    profileSlug: segments[1],
+    environment,
+    tenantCode,
+  };
+}
+
+function extractTenantCodeFromEmbedPath(currentPathname: string): string | null {
+  return parseExternalEmbedPath(currentPathname)?.tenantCode ?? null;
+}
+
+export function extractEnvironmentFromEmbedPath(
+  currentPathname: string,
+): Environment {
+  return parseExternalEmbedPath(currentPathname)?.environment ?? "prod";
 }
 
 export function resolveScopedPathFromParams(params: ScopedPathParams): string {
@@ -65,7 +107,7 @@ export function resolveScopedPathFromParams(params: ScopedPathParams): string {
   }
 
   if (params.tenantCode && params.workspaceCode) {
-    return `manage/tenants/${params.tenantCode}/workspaces/${params.workspaceCode}`;
+    return `manage/environments/${normalizeEnvironment(params.environment)}/tenants/${params.tenantCode}/workspaces/${params.workspaceCode}`;
   }
 
   if (params.tenantCode) {
@@ -86,7 +128,7 @@ export function resolveWorkspacePoliciesPathFromParams(
     return `external/${params.profileSlug}/tenants/${params.tenantCode}/workspaces/${params.workspaceCode}/policies`;
   }
 
-  return `manage/tenants/${params.tenantCode}/workspaces/${params.workspaceCode}/policies`;
+  return `manage/environments/${normalizeEnvironment(params.environment)}/tenants/${params.tenantCode}/workspaces/${params.workspaceCode}/policies`;
 }
 
 export function isExternalEmbedPath(currentPathname: string): boolean {
@@ -194,6 +236,10 @@ export function buildExternalEmbedApiRequest(
   if (tenantCode) {
     headers.set(EXTERNAL_TENANT_HEADER, tenantCode);
   }
+  headers.set(
+    EXTERNAL_ENVIRONMENT_HEADER,
+    extractEnvironmentFromEmbedPath(currentPathname),
+  );
 
   const url = new URL(request.url);
   const current = externalEmbedURL(currentSearch);

--- a/web/src/lib/external-embed-proxy.test.ts
+++ b/web/src/lib/external-embed-proxy.test.ts
@@ -12,12 +12,16 @@ import {
 } from "./external-embed-proxy.ts";
 
 const EMBED_PATH = "/embed/partner-portal/t/acme/w/marketing/templates/newsletter/edit";
+const EMBED_TEST_PATH =
+  "/embed/partner-portal/environments/test/t/acme/w/marketing/templates/newsletter/edit";
 const BACKEND_ORIGIN = "https://backend.example.com";
 const HOST_ORIGIN = "https://host.example.com";
 const SELF_ANCESTOR = "'self'";
 const NONE_ANCESTOR = "'none'";
 const BOOTSTRAP_URL =
   "https://backend.example.com/api/v1/external/partner-portal/bootstrap";
+const TEST_BOOTSTRAP_URL =
+  "https://backend.example.com/api/v1/external/partner-portal/environments/test/bootstrap";
 const ROUTE_CONTEXT: ProxyRouteContext = {
   params: Promise.resolve({}),
 };
@@ -35,6 +39,14 @@ test("buildExternalBootstrapUrl targets the profile bootstrap endpoint", () => {
     url?.toString(),
     BOOTSTRAP_URL,
   );
+});
+
+test("buildExternalBootstrapUrl targets the environment bootstrap endpoint when embed path declares it", () => {
+  const request = mockEmbedRequest(EMBED_TEST_PATH);
+
+  const url = buildExternalBootstrapUrl(request, BACKEND_ORIGIN);
+
+  assert.equal(url?.toString(), TEST_BOOTSTRAP_URL);
 });
 
 test("normalizeFrameAncestors falls back to none when empty", () => {

--- a/web/src/lib/external-embed-proxy.ts
+++ b/web/src/lib/external-embed-proxy.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server.js";
-import { isExternalEmbedPath } from "./external-api-context.ts";
+import {
+  extractEnvironmentFromEmbedPath,
+  isExternalEmbedPath,
+} from "./external-api-context.ts";
 
 export type FetchLike = typeof fetch;
 export interface ProxyRouteContext {
@@ -24,7 +27,21 @@ export function buildExternalBootstrapUrl(
     return null;
   }
 
-  return new URL(`/api/v1/external/${segments[1]}/bootstrap`, backendOrigin);
+  if (segments[2] === "environments" && segments[3]) {
+    const environment = extractEnvironmentFromEmbedPath(request.nextUrl.pathname);
+    return new URL(
+      `/api/v1/external/${segments[1]}/environments/${environment}/bootstrap`,
+      backendOrigin,
+    );
+  }
+
+  const environment = extractEnvironmentFromEmbedPath(request.nextUrl.pathname);
+  return environment === "prod"
+    ? new URL(`/api/v1/external/${segments[1]}/bootstrap`, backendOrigin)
+    : new URL(
+        `/api/v1/external/${segments[1]}/environments/${environment}/bootstrap`,
+        backendOrigin,
+      );
 }
 
 export function normalizeFrameAncestors(

--- a/web/src/lib/workspace-test-recipient-addresses.test.ts
+++ b/web/src/lib/workspace-test-recipient-addresses.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatWorkspaceTestRecipientAddresses,
+  normalizeWorkspaceTestRecipientAddresses,
+} from "./workspace-test-recipient-addresses.ts";
+
+test("normalizeWorkspaceTestRecipientAddresses tolerates nullish and malformed values", () => {
+  assert.deepEqual(normalizeWorkspaceTestRecipientAddresses(undefined), []);
+  assert.deepEqual(normalizeWorkspaceTestRecipientAddresses(null), []);
+  assert.deepEqual(
+    normalizeWorkspaceTestRecipientAddresses([
+      "qa@example.com",
+      42 as unknown as string,
+      "ops@example.com",
+    ]),
+    ["qa@example.com", "ops@example.com"],
+  );
+});
+
+test("formatWorkspaceTestRecipientAddresses returns a multiline string for the form", () => {
+  assert.equal(formatWorkspaceTestRecipientAddresses(undefined), "");
+  assert.equal(formatWorkspaceTestRecipientAddresses(null), "");
+  assert.equal(
+    formatWorkspaceTestRecipientAddresses(["qa@example.com", "ops@example.com"]),
+    "qa@example.com\nops@example.com",
+  );
+});

--- a/web/src/lib/workspace-test-recipient-addresses.ts
+++ b/web/src/lib/workspace-test-recipient-addresses.ts
@@ -1,0 +1,15 @@
+export function normalizeWorkspaceTestRecipientAddresses(
+  value: readonly string[] | null | undefined,
+): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+export function formatWorkspaceTestRecipientAddresses(
+  value: readonly string[] | null | undefined,
+): string {
+  return normalizeWorkspaceTestRecipientAddresses(value).join("\n");
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -29,14 +29,17 @@ export interface FieldError {
 /** Scope levels for the hierarchy */
 export type ScopeLevel = "global" | "tenant" | "workspace";
 export type OwnerScope = "global" | "system" | "local" | "workspace";
+export type Environment = "prod" | "test";
 
 export const SYSTEM_WORKSPACE_CODE = "_system";
 
 /** Current scope context */
 export interface ScopeContext {
   level: ScopeLevel;
+  profileSlug?: string;
   tenantCode?: string;
   workspaceCode?: string;
+  environment?: Environment;
 }
 
 /** Email statuses */
@@ -79,13 +82,17 @@ export interface Tenant {
 /** Workspace */
 export interface Workspace {
   id: string;
+  logical_workspace_id: string;
   tenant_id: string;
   code: string;
   name: string;
+  environment: Environment;
   is_system: boolean;
   is_active: boolean;
   open_tracking_enabled: boolean;
   default_locale: string | null;
+  test_recipient_mode: "replace" | "append";
+  test_recipient_addresses: string[] | null;
   created_at: string;
   updated_at: string;
 }

--- a/web/src/types/templates.ts
+++ b/web/src/types/templates.ts
@@ -8,6 +8,8 @@ export interface TemplateType {
   adapter_id?: string;
   sender_identity_id?: string;
   variable_schema?: Record<string, unknown>;
+  test_recipient_mode?: "replace" | "append";
+  test_recipient_addresses?: string[];
   scope_level?: ScopeLevel;
   owner_scope?: OwnerScope;
   inherited_from_system?: boolean;

--- a/web/tests/tenant-management-typescript.test.mjs
+++ b/web/tests/tenant-management-typescript.test.mjs
@@ -7,7 +7,7 @@ const root = process.cwd();
 
 test("tenant management frontend typechecks", () => {
   try {
-    execFileSync("npm", ["run", "typecheck"], {
+    execFileSync("corepack", ["pnpm", "typecheck"], {
       cwd: join(root, "web"),
       stdio: "pipe",
     });


### PR DESCRIPTION
## Summary

- Adds first-class logical workspaces with isolated `prod|test` environments, environment-aware API keys, recipient safety rules, and runtime reset semantics.
- Extends the external integration surface, SDK context propagation, OpenAPI/docs/skill bundle, and frontend environment toggle to match the new model.
- Hardens backend, E2E, system, and harness coverage so the new environment behavior is validated end to end.

## Context

- Related issue: Closes #68
- Related story (if any): N/A
- Risk / tradeoffs: This is a systemic cross-layer change touching migrations, HTTP contracts, SDK seams, frontend routing/state, generated OpenAPI, and test harnesses; the main tradeoff is larger review scope in exchange for keeping prod/test isolation in a single deployment.

## Validation

Mark everything you actually ran.

- [ ] `make ci-backend-pr` (if backend, infra, migrations, or tests changed)
- [ ] `make ci-frontend` (if `web/` changed)
- [x] `make ci-pr` (if both backend and frontend changed)
- [x] `make ci-main` (required for pushes to `main` and systemic/cross-layer changes; fast gate, no Docker)

Optional deeper checks when you intentionally want Docker-backed coverage:

- [ ] `make test-integration`
- [x] `make test-e2e`
- [x] `make test-e2e-full`
- [x] `make system-pr`
- [x] `make build`
- [x] `shellcheck -x test/system/batch-flows-e2e.sh test/system/subagents/api-contract-tester.sh test/system/subagents/infra-orchestrator.sh test/system/subagents/lib.sh test/system/subagents/ui-a11y-tester.sh test/system/subagents/ui-adapter-sharing-tester.sh test/system/subagents/ui-flow-tester.sh test/system/subagents/ui-injector-flow-tester.sh test/system/subagents/ui-template-type-slug-edit-tester.sh test/system/subagents/ui-visual-tester.sh test/system/subagents/ui-workspace-management-tester.sh test/system/system-runner.sh`

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test-only
- [x] Security-sensitive

## Changes Table

| File | Change |
|------|--------|
| `migrations/000040_workspace_environments.*`, `migrations/000041_test_recipient_policies.*`, `internal/domain/*`, `internal/adapter/postgres/*`, `internal/service/*`, `internal/http/*`, `internal/resolution/*` | Added environment-aware workspace model, test recipient policies, runtime isolation, API behavior, and regression fixes across backend layers. |
| `sdk/*`, `internal/port/*`, `internal/app/*`, `cmd/senda/main.go` | Propagated environment-aware SDK seams for injectors, init functions, external auth methods, and workspace resolvers. |
| `web/src/**/*`, `web/tests/*` | Added UI environment mode, test recipient settings, external embed environment routing, and updated frontend consumers/tests. |
| `cmd/senda/openapi_generated.go`, `cmd/senda/docs/*`, `docs/**/*`, `README.md`, `skills/senda/**/*`, `AGENTS.md` | Regenerated OpenAPI artifacts and updated runtime/docs/skill guidance to the new prod/test and external integration model. |
| `test/e2e/*`, `test/system/**/*` | Added environment E2E coverage, updated system harnesses, and aligned API contract/browser flows with the hardened behavior. |

## Contributor checklist

- [x] I kept the change focused and reviewable.
- [x] I added or updated tests where behavior changed.
- [x] I updated docs when behavior, setup, API, or workflows changed.
- [x] I did not add build-only validation as a substitute for the required local gates.
- [x] I did not add AI attribution or `Co-Authored-By` trailers.

## Compatibility / ops impact

- [ ] No migration
- [x] Migration included
- [x] No config changes
- [ ] Config changes included
- [ ] No security impact
- [x] Security impact described above
