### PR TITLE
feat: add static injector catalog and builder preview ux

### DIFF
--- a/cmd/senda-e2e/demo_injectors.go
+++ b/cmd/senda-e2e/demo_injectors.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/sdk"
+)
+
+func demoCodeInjectors() []sdk.InjectorRegistration {
+	return []sdk.InjectorRegistration{
+		demoBrandInjector(),
+		demoWorkspaceProfileInjector(),
+		demoStudentInjector(),
+		demoRequestDebugInjector(),
+	}
+}
+
+func demoBrandInjector() sdk.InjectorRegistration {
+	return sdk.InjectorRegistration{
+		Code:        "brand",
+		Name:        "Brand",
+		Description: "Static brand assets and legal/footer content for the active workspace.",
+		Static:      true,
+		TTL:         2 * time.Minute,
+		Fields: []sdk.InjectorFieldSpec{
+			{Name: "company_name", Type: sdk.FieldTypeText, Description: "Brand/company display name"},
+			{Name: "policy_url", Type: sdk.FieldTypeURL, Description: "Policy/help center URL"},
+			{Name: "logo_url", Type: sdk.FieldTypeImg, Description: "Logo image URL"},
+			{Name: "hero_image_url", Type: sdk.FieldTypeImg, Description: "Hero image URL"},
+			{Name: "footer_html", Type: sdk.FieldTypeHTML, Description: "Renderable HTML footer block"},
+		},
+		Resolve: func(_ context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
+			workspaceCode := workspaceCodeFromRef(injCtx.Ref())
+			profile := brandProfileForWorkspace(workspaceCode)
+			return map[string]any{
+				"company_name":   profile.CompanyName,
+				"policy_url":     profile.PolicyURL,
+				"logo_url":       profile.LogoURL,
+				"hero_image_url": profile.HeroImageURL,
+				"footer_html":    profile.FooterHTML,
+			}, nil
+		},
+		Critical: true,
+	}
+}
+
+func demoWorkspaceProfileInjector() sdk.InjectorRegistration {
+	return sdk.InjectorRegistration{
+		Code:        "workspace_profile",
+		Name:        "Workspace Profile",
+		Description: "Static workspace/environment labels rendered directly by the backend.",
+		Static:      true,
+		TTL:         time.Minute,
+		Fields: []sdk.InjectorFieldSpec{
+			{Name: "workspace_code", Type: sdk.FieldTypeText, Description: "Resolved workspace code"},
+			{Name: "workspace_label", Type: sdk.FieldTypeText, Description: "Human-friendly workspace label"},
+			{Name: "environment_name", Type: sdk.FieldTypeText, Description: "Resolved environment name"},
+			{Name: "environment_badge_html", Type: sdk.FieldTypeHTML, Description: "Renderable environment badge"},
+		},
+		Resolve: func(_ context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
+			workspaceCode := workspaceCodeFromRef(injCtx.Ref())
+			workspaceLabel := humanizeWorkspaceCode(workspaceCode)
+			envName := strings.ToUpper(string(injCtx.Environment()))
+			return map[string]any{
+				"workspace_code":   workspaceCode,
+				"workspace_label":  workspaceLabel,
+				"environment_name": envName,
+				"environment_badge_html": fmt.Sprintf(
+					`<span style="display:inline-block;padding:2px 8px;border-radius:999px;background:%s;color:#fff;font-size:12px;font-weight:600;">%s · %s</span>`,
+					environmentBadgeColor(injCtx.Environment()),
+					envName,
+					workspaceLabel,
+				),
+			}, nil
+		},
+		Critical: true,
+	}
+}
+
+func demoStudentInjector() sdk.InjectorRegistration {
+	return sdk.InjectorRegistration{
+		Code:        "student",
+		Description: "Dynamic runtime injector that can be overridden per request.",
+		Resolve: func(_ context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
+			workspaceCode := workspaceCodeFromRef(injCtx.Ref())
+			name := overrideString(injCtx, "student", "name", defaultStudentName(workspaceCode))
+			status := overrideString(injCtx, "student", "status", defaultStudentStatus(injCtx.Environment()))
+			cohort := overrideString(injCtx, "student", "cohort", fmt.Sprintf("%s-%s", workspaceCode, strings.ToLower(string(injCtx.Environment()))))
+			return map[string]any{
+				"name":   name,
+				"status": status,
+				"cohort": cohort,
+				"age":    22,
+			}, nil
+		},
+		Critical: true,
+	}
+}
+
+func demoRequestDebugInjector() sdk.InjectorRegistration {
+	return sdk.InjectorRegistration{
+		Code:        "request_debug",
+		Description: "Dynamic runtime-only injector that exposes request/workspace/environment context.",
+		Resolve: func(_ context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
+			workspaceCode := workspaceCodeFromRef(injCtx.Ref())
+			userName, _ := injCtx.Variables()["user_name"].(string)
+			return map[string]any{
+				"workspace_code":  workspaceCode,
+				"environment":     strings.ToUpper(string(injCtx.Environment())),
+				"event_user_name": userName,
+				"request_note":    overrideString(injCtx, "request_debug", "request_note", "no-request-note"),
+			}, nil
+		},
+		Critical: false,
+	}
+}
+
+type brandProfile struct {
+	CompanyName  string
+	PolicyURL    string
+	LogoURL      string
+	HeroImageURL string
+	FooterHTML   string
+}
+
+func brandProfileForWorkspace(workspaceCode string) brandProfile {
+	label := humanizeWorkspaceCode(workspaceCode)
+	if label == "" {
+		label = "Workspace Demo"
+	}
+	base := fmt.Sprintf("https://%s.demo.senda.test", workspaceCode)
+	return brandProfile{
+		CompanyName:  label + " Academy",
+		PolicyURL:    base + "/policies/email",
+		LogoURL:      base + "/assets/logo.png",
+		HeroImageURL: base + "/assets/hero.png",
+		FooterHTML: fmt.Sprintf(
+			`<p style="margin:0;"><strong>%s</strong> · <a href=%q>Email policy</a></p>`,
+			label+" Academy",
+			base+"/policies/email",
+		),
+	}
+}
+
+func workspaceCodeFromRef(ref string) string {
+	parts := strings.Split(ref, ":")
+	if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
+		return "unknown-workspace"
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+func humanizeWorkspaceCode(code string) string {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return "Unknown Workspace"
+	}
+	parts := strings.FieldsFunc(code, func(r rune) bool {
+		return r == '-' || r == '_' || r == ':'
+	})
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
+	}
+	return strings.Join(parts, " ")
+}
+
+func environmentBadgeColor(env domain.Environment) string {
+	if env == domain.EnvironmentTest {
+		return "#D97706"
+	}
+	return "#0F766E"
+}
+
+func defaultStudentName(workspaceCode string) string {
+	if workspaceCode == "campus-north" {
+		return "North Campus Student"
+	}
+	return "Code Student"
+}
+
+func defaultStudentStatus(env domain.Environment) string {
+	if env == domain.EnvironmentTest {
+		return "test-mode-status"
+	}
+	return "code-status"
+}
+
+func overrideString(injCtx *sdk.InjectorContext, injectorCode, fieldName, fallback string) string {
+	if injCtx == nil {
+		return fallback
+	}
+	requestValues := injCtx.RequestInjectors()
+	fields, ok := requestValues[injectorCode]
+	if !ok {
+		return fallback
+	}
+	value, ok := fields[fieldName]
+	if !ok || value == nil {
+		return fallback
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprint(typed)
+	}
+}

--- a/cmd/senda-e2e/demo_injectors_test.go
+++ b/cmd/senda-e2e/demo_injectors_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/sdk"
+)
+
+func TestDemoCodeInjectorsIncludeStaticCatalogExamples(t *testing.T) {
+	regs := demoCodeInjectors()
+	byCode := map[string]sdk.InjectorRegistration{}
+	for _, reg := range regs {
+		byCode[reg.Code] = reg
+	}
+
+	brand, ok := byCode["brand"]
+	if !ok {
+		t.Fatalf("brand injector not registered")
+	}
+	if !brand.Static {
+		t.Fatalf("brand injector should be static")
+	}
+	if brand.TTL != 2*time.Minute {
+		t.Fatalf("brand TTL = %s, want %s", brand.TTL, 2*time.Minute)
+	}
+	if len(brand.Fields) < 4 {
+		t.Fatalf("brand fields = %d, want >= 4", len(brand.Fields))
+	}
+
+	workspaceProfile, ok := byCode["workspace_profile"]
+	if !ok {
+		t.Fatalf("workspace_profile injector not registered")
+	}
+	if !workspaceProfile.Static {
+		t.Fatalf("workspace_profile should be static")
+	}
+
+	student, ok := byCode["student"]
+	if !ok {
+		t.Fatalf("student injector not registered")
+	}
+	if student.Static {
+		t.Fatalf("student injector should be dynamic/runtime-only")
+	}
+}
+
+func TestBrandInjectorResolveReturnsRenderableHtmlAndWorkspaceAwareText(t *testing.T) {
+	reg := demoBrandInjector()
+	resolve, _ := reg.Resolve, reg.Dependencies
+	ctx := sdk.NewInjectorContext(nil, "system-test-corp:system-main:welcome-email", nil, uuid.New(), uuid.New(), domain.EnvironmentProd, "welcome-email")
+
+	values, err := resolve(context.Background(), ctx)
+	if err != nil {
+		t.Fatalf("resolve brand injector: %v", err)
+	}
+
+	if got := values["company_name"]; got != "System Main Academy" {
+		t.Fatalf("company_name = %v, want %q", got, "System Main Academy")
+	}
+	footer, _ := values["footer_html"].(string)
+	if !strings.Contains(footer, "<strong>System Main Academy</strong>") {
+		t.Fatalf("footer_html missing branded html: %q", footer)
+	}
+	if !strings.Contains(footer, "https://system-main.demo.senda.test/policies/email") {
+		t.Fatalf("footer_html missing policy link: %q", footer)
+	}
+}
+
+func TestWorkspaceProfileInjectorVariesByWorkspaceAndEnvironment(t *testing.T) {
+	reg := demoWorkspaceProfileInjector()
+	ctx := sdk.NewInjectorContext(nil, "system-test-corp:campus-north:welcome-email", nil, uuid.New(), uuid.New(), domain.EnvironmentTest, "welcome-email")
+
+	values, err := reg.Resolve(context.Background(), ctx)
+	if err != nil {
+		t.Fatalf("resolve workspace_profile injector: %v", err)
+	}
+
+	if got := values["workspace_label"]; got != "Campus North" {
+		t.Fatalf("workspace_label = %v, want %q", got, "Campus North")
+	}
+	badge, _ := values["environment_badge_html"].(string)
+	if !strings.Contains(badge, "TEST") {
+		t.Fatalf("environment badge should mention TEST, got %q", badge)
+	}
+}
+
+func TestStudentInjectorUsesRequestOverridesWhenProvided(t *testing.T) {
+	reg := demoStudentInjector()
+	ctx := sdk.NewInjectorContext(nil, "system-test-corp:system-main:welcome-email", nil, uuid.New(), uuid.New(), domain.EnvironmentProd, "welcome-email")
+	ctx.SetRequestInjectors(map[string]map[string]any{
+		"student": {
+			"name":   "Ada Lovelace",
+			"status": "override-status",
+		},
+	})
+
+	values, err := reg.Resolve(context.Background(), ctx)
+	if err != nil {
+		t.Fatalf("resolve student injector: %v", err)
+	}
+
+	if got := values["name"]; got != "Ada Lovelace" {
+		t.Fatalf("name = %v, want %q", got, "Ada Lovelace")
+	}
+	if got := values["status"]; got != "override-status" {
+		t.Fatalf("status = %v, want %q", got, "override-status")
+	}
+}

--- a/cmd/senda-e2e/main.go
+++ b/cmd/senda-e2e/main.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"strings"
-	"time"
 
 	httpmw "github.com/rendis/senda/internal/http/middleware"
 	"github.com/rendis/senda/sdk"
@@ -21,7 +20,9 @@ func main() {
 	engine := sdk.NewWithConfig(cfgPath)
 	if os.Getenv("SENDA_E2E_ENABLE_CODE_INJECTORS") == "true" {
 		slog.Info("registering e2e code injectors")
-		engine.RegisterInjector(e2eStudentInjector{})
+		for _, reg := range demoCodeInjectors() {
+			engine.RegisterInjector(reg)
+		}
 	} else {
 		slog.Warn("e2e code injectors disabled")
 	}
@@ -40,25 +41,6 @@ func main() {
 		os.Exit(1)
 	}
 }
-
-type e2eStudentInjector struct{}
-
-func (e2eStudentInjector) Code() string { return "student" }
-
-func (e2eStudentInjector) Resolve() (sdk.ResolveFunc, []string) {
-	return func(_ context.Context, _ *sdk.InjectorContext) (map[string]any, error) {
-		return map[string]any{
-			"name":   "Code Student",
-			"age":    22,
-			"locked": "CODE-SHOULD-NOT-WIN",
-			"status": "code-status",
-		}, nil
-	}, nil
-}
-
-func (e2eStudentInjector) IsCritical() bool { return true }
-
-func (e2eStudentInjector) Timeout() time.Duration { return 0 }
 
 type e2eExternalAuthMethod struct {
 	token string

--- a/cmd/senda/docs/docs.go
+++ b/cmd/senda/docs/docs.go
@@ -25778,6 +25778,12 @@ const docTemplate = `{
                 "owner_scope": {
                     "type": "string"
                 },
+                "source": {
+                    "type": "string"
+                },
+                "static": {
+                    "type": "boolean"
+                },
                 "updated_at": {
                     "type": "string"
                 },

--- a/cmd/senda/docs/openapi.yaml
+++ b/cmd/senda/docs/openapi.yaml
@@ -981,6 +981,10 @@ components:
                     type: string
                 owner_scope:
                     type: string
+                source:
+                    type: string
+                static:
+                    type: boolean
                 updated_at:
                     type: string
                 values:

--- a/cmd/senda/docs/swagger.yaml
+++ b/cmd/senda/docs/swagger.yaml
@@ -981,6 +981,10 @@ definitions:
         type: string
       owner_scope:
         type: string
+      source:
+        type: string
+      static:
+        type: boolean
       updated_at:
         type: string
       values:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -115,7 +115,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *slog.Logger, ext
 	if len(codeInjectors) > 0 || codeInitFunc != nil {
 		logger.Info("registered runtime code injector extensions", "injector_count", len(codeInjectors), "has_init_func", codeInitFunc != nil)
 	}
-	injectorMerger := resolution.NewInjectorMerger(injectorRepo, chainResolver, codeInjectors, codeInitFunc)
+	injectorMerger := resolution.NewInjectorMerger(injectorRepo, chainResolver, cache, codeInjectors, codeInitFunc)
 	adapterResolver := resolution.NewAdapterResolver(adapterRepo, cache)
 
 	// 7. Email sender (SMTP for dev/E2E, SES for production).
@@ -208,7 +208,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *slog.Logger, ext
 		ClientSecretSet: cfg.OIDC.ClientSecret != "",
 	})
 	externalIntegrationH := handler.NewExternalIntegrationHandler(configRepo, extExternalAuthMethods(ext), extExternalResolvers(ext))
-	injectorH := handler.NewInjectorHandler(injectorRepo, tenantRepo, wsRepo)
+	injectorH := handler.NewInjectorHandler(injectorRepo, tenantRepo, wsRepo, injectorMerger)
 	// Tracking auto-provisioner (nil if no tracking base URL) — used for deprovision on adapter delete.
 	provisioningStepRepo := postgres.NewProvisioningStepRepo(pool)
 	var trackingProvisioner *sesadapter.TrackingProvisioner
@@ -237,7 +237,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *slog.Logger, ext
 		tenantRepo,
 		wsRepo,
 	)
-	templateH := handler.NewTemplateHandler(templateSvc, templateRepo, tenantRepo, wsRepo, testSendSvc, sendSvc, auditRepo, cfg.Send.BatchMaxItems, cacheInvalidator)
+	templateH := handler.NewTemplateHandler(templateSvc, templateRepo, tenantRepo, wsRepo, testSendSvc, sendSvc, auditRepo, cfg.Send.BatchMaxItems, injectorMerger, cacheInvalidator)
 	sendH := handler.NewSendHandler(sendSvc, cfg.Send.BatchMaxItems)
 	emailH := handler.NewEmailHandler(emailRepo, tenantRepo, wsRepo)
 	dataPlaneEmailH := handler.NewDataPlaneEmailHandler(emailRepo)

--- a/internal/domain/injector.go
+++ b/internal/domain/injector.go
@@ -22,6 +22,8 @@ type InjectorDefinition struct {
 	WorkspaceID         *uuid.UUID // nil = global
 	Name                string
 	Description         *string
+	Source              string
+	Static              bool
 	OwnerScope          string
 	InheritedFromSystem bool
 	CreatedAt           time.Time

--- a/internal/http/handler/injector.go
+++ b/internal/http/handler/injector.go
@@ -14,19 +14,21 @@ import (
 	"github.com/rendis/senda/internal/http/request"
 	"github.com/rendis/senda/internal/http/response"
 	"github.com/rendis/senda/internal/port"
+	"github.com/rendis/senda/internal/resolution"
 	"github.com/rendis/senda/pkg/apperr"
 )
 
 // InjectorHandler handles CRUD operations for injector definitions and values.
 type InjectorHandler struct {
-	store   port.InjectorStore
-	tsStore port.TenantStore
-	wsStore port.WorkspaceStore
+	store          port.InjectorStore
+	tsStore        port.TenantStore
+	wsStore        port.WorkspaceStore
+	injectorMerger *resolution.InjectorMerger
 }
 
 // NewInjectorHandler creates a new InjectorHandler.
-func NewInjectorHandler(is port.InjectorStore, ts port.TenantStore, ws port.WorkspaceStore) *InjectorHandler {
-	return &InjectorHandler{store: is, tsStore: ts, wsStore: ws}
+func NewInjectorHandler(is port.InjectorStore, ts port.TenantStore, ws port.WorkspaceStore, merger *resolution.InjectorMerger) *InjectorHandler {
+	return &InjectorHandler{store: is, tsStore: ts, wsStore: ws, injectorMerger: merger}
 }
 
 // Create handles POST /tenants/:tenant_code/workspaces/:workspace_code/injectors.
@@ -224,6 +226,12 @@ func (h *InjectorHandler) list(c *echo.Context, workspace *domain.Workspace) err
 		annotateInjectorScope(def, workspace, systemWorkspace)
 	}
 
+	staticDefs, staticFields, err := h.staticCatalog(ctx, workspace)
+	if err != nil {
+		return mapStoreError(c, err)
+	}
+	defs, fieldsByDefinition = mergeStaticCatalog(defs, fieldsByDefinition, staticDefs, staticFields)
+
 	return c.JSON(http.StatusOK, response.NewInjectorListResponse(defs, fieldsByDefinition))
 }
 
@@ -334,6 +342,9 @@ func (h *InjectorHandler) get(c *echo.Context, workspace *domain.Workspace) erro
 		}
 	}
 	if err != nil {
+		if staticDetail, staticFields, handled := h.tryStaticDefinition(ctx, workspace, name); handled {
+			return c.JSON(http.StatusOK, response.NewInjectorCreateResponse(staticDetail, staticFields))
+		}
 		return mapStoreError(c, err)
 	}
 	annotateInjectorScope(def, workspace, systemWorkspace)
@@ -575,6 +586,54 @@ func (h *InjectorHandler) loadWorkspaceDefinitionAccess(
 	}
 	annotateInjectorScope(def, workspace, systemWorkspace)
 	return def, systemWorkspace, effectiveWorkspacePolicies(systemWorkspace), nil
+}
+
+func (h *InjectorHandler) staticCatalog(ctx context.Context, workspace *domain.Workspace) ([]*domain.InjectorDefinition, map[uuid.UUID][]*domain.InjectorField, error) {
+	if h.injectorMerger == nil {
+		return nil, map[uuid.UUID][]*domain.InjectorField{}, nil
+	}
+	return h.injectorMerger.StaticCatalog(ctx, workspace, "")
+}
+
+func (h *InjectorHandler) tryStaticDefinition(ctx context.Context, workspace *domain.Workspace, name string) (*domain.InjectorDefinition, []*domain.InjectorField, bool) {
+	defs, fieldsByDefinition, err := h.staticCatalog(ctx, workspace)
+	if err != nil {
+		return nil, nil, false
+	}
+	for _, def := range defs {
+		if def.Name != name {
+			continue
+		}
+		return def, fieldsByDefinition[def.ID], true
+	}
+	return nil, nil, false
+}
+
+func mergeStaticCatalog(
+	defs []*domain.InjectorDefinition,
+	fieldsByDefinition map[uuid.UUID][]*domain.InjectorField,
+	staticDefs []*domain.InjectorDefinition,
+	staticFields map[uuid.UUID][]*domain.InjectorField,
+) ([]*domain.InjectorDefinition, map[uuid.UUID][]*domain.InjectorField) {
+	if len(staticDefs) == 0 {
+		return defs, fieldsByDefinition
+	}
+	if fieldsByDefinition == nil {
+		fieldsByDefinition = make(map[uuid.UUID][]*domain.InjectorField, len(staticDefs))
+	}
+	seen := make(map[string]struct{}, len(defs))
+	merged := append([]*domain.InjectorDefinition(nil), defs...)
+	for _, def := range defs {
+		seen[def.Name] = struct{}{}
+	}
+	for _, def := range staticDefs {
+		if _, exists := seen[def.Name]; exists {
+			continue
+		}
+		merged = append(merged, def)
+		fieldsByDefinition[def.ID] = staticFields[def.ID]
+	}
+	return merged, fieldsByDefinition
 }
 
 func errorsIsNotFound(err error) bool {

--- a/internal/http/handler/injector_test.go
+++ b/internal/http/handler/injector_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rendis/senda/internal/http/middleware"
 	"github.com/rendis/senda/internal/http/response"
 	"github.com/rendis/senda/internal/port"
+	"github.com/rendis/senda/internal/resolution"
 )
 
 // --- Mock InjectorStore ---
@@ -104,12 +105,16 @@ func (m *mockInjectorStore) GetAllValuesByDefinitions(_ context.Context, _ []uui
 // --- Helpers ---
 
 func setupInjectorTest(is port.InjectorStore, ts port.TenantStore, ws port.WorkspaceStore) (*echo.Echo, *handler.InjectorHandler) {
+	return setupInjectorTestWithMerger(is, ts, ws, nil)
+}
+
+func setupInjectorTestWithMerger(is port.InjectorStore, ts port.TenantStore, ws port.WorkspaceStore, merger *resolution.InjectorMerger) (*echo.Echo, *handler.InjectorHandler) {
 	e := echo.New()
 	e.HTTPErrorHandler = response.HTTPErrorHandler
 	e.Use(middleware.RequestID())
 	e.Use(middleware.Scope())
 
-	h := handler.NewInjectorHandler(is, ts, ws)
+	h := handler.NewInjectorHandler(is, ts, ws, merger)
 
 	// Workspace-scoped routes.
 	e.POST("/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code/injectors", h.Create)
@@ -127,6 +132,32 @@ func setupInjectorTest(is port.InjectorStore, ts port.TenantStore, ws port.Works
 	e.PUT("/api/v1/manage/global/injectors/:name/fields/:field_name", h.UpdateFieldGlobal)
 
 	return e, h
+}
+
+type staticCatalogInjector struct {
+	code   string
+	fields []port.InjectorFieldSpec
+	values func(ctx context.Context, injCtx *port.InjectorContext) (map[string]any, error)
+}
+
+func (s staticCatalogInjector) Code() string { return s.code }
+
+func (s staticCatalogInjector) Resolve() (port.CodeResolveFunc, []string) {
+	return s.values, nil
+}
+
+func (s staticCatalogInjector) IsCritical() bool       { return true }
+func (s staticCatalogInjector) Timeout() time.Duration { return 0 }
+
+func (s staticCatalogInjector) Catalog() port.InjectorCatalog {
+	return port.InjectorCatalog{
+		Code:        s.code,
+		Name:        "Static " + s.code,
+		Description: "Code-backed static injector",
+		Static:      true,
+		TTL:         time.Minute,
+		Fields:      s.fields,
+	}
 }
 
 func testTenantAndWorkspace() (*domain.Tenant, *domain.Workspace, *mockTenantStore, *mockWorkspaceStore) {
@@ -241,11 +272,81 @@ func TestInjectorHandler_List_Success(t *testing.T) {
 	}
 }
 
+func TestInjectorHandler_List_IncludesStaticCodeInjectors(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+
+	is := &mockInjectorStore{
+		listDefinitionsInChainFn: func(_ context.Context, _ []uuid.NullUUID) ([]*domain.InjectorDefinition, error) {
+			return []*domain.InjectorDefinition{}, nil
+		},
+	}
+
+	merger := resolution.NewInjectorMerger(
+		is,
+		nil,
+		nil,
+		[]port.CodeInjector{
+			staticCatalogInjector{
+				code: "school",
+				fields: []port.InjectorFieldSpec{
+					{Name: "footer_html", Type: domain.FieldTypeHTML, Description: "Footer"},
+				},
+				values: func(_ context.Context, injCtx *port.InjectorContext) (map[string]any, error) {
+					return map[string]any{
+						"footer_html": "<strong>" + injCtx.WorkspaceID().String() + "</strong>",
+					}, nil
+				},
+			},
+		},
+		nil,
+	)
+
+	e, _ := setupInjectorTestWithMerger(is, ts, wsStore, merger)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/manage/tenants/acme/workspaces/default/injectors", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp response.InjectorListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(resp.Items))
+	}
+	item := resp.Items[0]
+	if item.Name != "school" {
+		t.Fatalf("expected code injector name school, got %q", item.Name)
+	}
+	if item.Source != "code" {
+		t.Fatalf("expected source code, got %q", item.Source)
+	}
+	if !item.Static {
+		t.Fatal("expected static injector response")
+	}
+	if item.OwnerScope != "global" {
+		t.Fatalf("expected owner_scope global, got %q", item.OwnerScope)
+	}
+	if len(item.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(item.Fields))
+	}
+	if item.Fields[0].DefaultValue != "<strong>"+ws.ID.String()+"</strong>" {
+		t.Fatalf("expected resolved default value, got %#v", item.Fields[0].DefaultValue)
+	}
+	if item.Fields[0].AllowOverwrite {
+		t.Fatal("expected static code field to be read-only")
+	}
+}
+
 func TestInjectorHandler_List_IncludeInheritedUsesResolutionChain(t *testing.T) {
 	tenant, ws, ts, wsStore := testTenantAndWorkspace()
 	systemID := uuid.Must(uuid.NewV7())
 
-wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("unexpected tenant id %s", tenantID)
 		}
@@ -295,7 +396,7 @@ func TestInjectorHandler_Get_ResolvesInheritedSystemInjectorInWorkspace(t *testi
 	systemID := uuid.Must(uuid.NewV7())
 	defID := uuid.Must(uuid.NewV7())
 
-wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("unexpected tenant id %s", tenantID)
 		}
@@ -360,11 +461,72 @@ wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ dom
 	}
 }
 
+func TestInjectorHandler_Get_StaticCodeInjectorFallback(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+
+	is := &mockInjectorStore{
+		findDefinitionByNameFn: func(_ context.Context, name string, workspaceID *uuid.UUID) (*domain.InjectorDefinition, error) {
+			if name != "school" {
+				t.Fatalf("unexpected lookup %q", name)
+			}
+			if workspaceID == nil || *workspaceID != ws.ID {
+				t.Fatalf("unexpected workspace lookup %+v", workspaceID)
+			}
+			return nil, domain.ErrNotFound
+		},
+	}
+
+	merger := resolution.NewInjectorMerger(
+		is,
+		nil,
+		nil,
+		[]port.CodeInjector{
+			staticCatalogInjector{
+				code: "school",
+				fields: []port.InjectorFieldSpec{
+					{Name: "name", Type: domain.FieldTypeText, Description: "School name"},
+				},
+				values: func(_ context.Context, _ *port.InjectorContext) (map[string]any, error) {
+					return map[string]any{"name": "Acme Academy"}, nil
+				},
+			},
+		},
+		nil,
+	)
+
+	e, _ := setupInjectorTestWithMerger(is, ts, wsStore, merger)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/manage/tenants/acme/workspaces/default/injectors/school", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp response.InjectorDetailResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Name != "school" {
+		t.Fatalf("expected fallback injector school, got %q", resp.Name)
+	}
+	if resp.Source != "code" {
+		t.Fatalf("expected source code, got %q", resp.Source)
+	}
+	if !resp.Static {
+		t.Fatal("expected fallback injector to be static")
+	}
+	if len(resp.Fields) != 1 || resp.Fields[0].DefaultValue != "Acme Academy" {
+		t.Fatalf("expected resolved static field, got %+v", resp.Fields)
+	}
+}
+
 func TestInjectorHandler_Get_DoesNotFallbackToGlobalInjectorInWorkspace(t *testing.T) {
 	tenant, _, ts, wsStore := testTenantAndWorkspace()
 	systemID := uuid.Must(uuid.NewV7())
 
-wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("unexpected tenant id %s", tenantID)
 		}

--- a/internal/http/handler/template.go
+++ b/internal/http/handler/template.go
@@ -11,11 +11,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/http/middleware"
 	"github.com/rendis/senda/internal/http/pagination"
 	"github.com/rendis/senda/internal/http/request"
-	"github.com/rendis/senda/internal/http/middleware"
 	"github.com/rendis/senda/internal/http/response"
 	"github.com/rendis/senda/internal/port"
+	"github.com/rendis/senda/internal/resolution"
 	"github.com/rendis/senda/internal/service"
 	"github.com/rendis/senda/pkg/apperr"
 )
@@ -35,6 +36,7 @@ type TemplateHandler struct {
 	sendSvc             sendService
 	auditStore          port.AuditLogStore
 	batchMaxItems       int
+	injectorMerger      *resolution.InjectorMerger
 	templateInvalidator resolvedTemplateInvalidator
 }
 
@@ -48,6 +50,7 @@ func NewTemplateHandler(
 	sendSvc sendService,
 	auditStore port.AuditLogStore,
 	batchMaxItems int,
+	injectorMerger *resolution.InjectorMerger,
 	templateInvalidator resolvedTemplateInvalidator,
 ) *TemplateHandler {
 	return &TemplateHandler{
@@ -59,6 +62,7 @@ func NewTemplateHandler(
 		sendSvc:             sendSvc,
 		auditStore:          auditStore,
 		batchMaxItems:       batchMaxItems,
+		injectorMerger:      injectorMerger,
 		templateInvalidator: normalizeResolvedTemplateInvalidator(templateInvalidator),
 	}
 }
@@ -1071,10 +1075,66 @@ func (h *TemplateHandler) PreviewMJML(c *echo.Context) error {
 		c.Scheme()+"://"+c.Request().Host,
 	)
 
-	html, err := h.svc.PreviewMJML(ctx, req.MJML)
+	mjml := req.MJML
+	if h.injectorMerger != nil {
+		templateID, err := uuid.Parse(c.Param("template_id"))
+		if err == nil {
+			template, tplErr := h.store.GetTemplateByID(ctx, templateID)
+			if tplErr == nil && template != nil {
+				var (
+					workspace    *domain.Workspace
+					templateSlug string
+					injCtx       *port.InjectorContext
+					staticValues map[string]map[string]any
+				)
+				if template.WorkspaceID != nil {
+					workspace, _ = h.wsStore.GetByID(ctx, *template.WorkspaceID)
+				}
+				if tt, ttErr := h.store.GetTypeByID(ctx, template.TemplateTypeID); ttErr == nil && tt != nil {
+					templateSlug = tt.Slug
+				}
+				if workspace != nil {
+					injCtx = port.NewInjectorContext(
+						nil,
+						h.previewInjectorRef(ctx, workspace, templateSlug),
+						nil,
+						workspace.TenantID,
+						workspace.ID,
+						workspace.Environment,
+						templateSlug,
+					)
+					staticValues, err = h.injectorMerger.ResolveStaticPreview(ctx, &workspace.ID, injCtx)
+				} else {
+					injCtx = port.NewInjectorContext(nil, "global::"+templateSlug, nil, uuid.Nil, uuid.Nil, domain.EnvironmentProd, templateSlug)
+					staticValues, err = h.injectorMerger.ResolveStaticPreview(ctx, nil, injCtx)
+				}
+				if err == nil {
+					mjml = service.RenderStaticInjectorPreview(mjml, staticValues)
+				}
+			}
+		}
+	}
+
+	html, err := h.svc.PreviewMJML(ctx, mjml)
 	if err != nil {
 		return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", err.Error())
 	}
 
 	return c.JSON(http.StatusOK, response.MJMLPreviewResponse{HTML: html})
+}
+
+func (h *TemplateHandler) previewInjectorRef(ctx context.Context, workspace *domain.Workspace, templateSlug string) string {
+	if workspace == nil {
+		return "global::" + templateSlug
+	}
+	if templateSlug == "" {
+		return ""
+	}
+
+	tenant, err := h.tsStore.GetByID(ctx, workspace.TenantID)
+	if err != nil || tenant == nil || tenant.Code == "" || workspace.Code == "" {
+		return templateSlug
+	}
+
+	return tenant.Code + ":" + workspace.Code + ":" + templateSlug
 }

--- a/internal/http/handler/template_test.go
+++ b/internal/http/handler/template_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rendis/senda/internal/http/middleware"
 	"github.com/rendis/senda/internal/http/response"
 	"github.com/rendis/senda/internal/port"
+	"github.com/rendis/senda/internal/resolution"
 	"github.com/rendis/senda/internal/service"
 )
 
@@ -26,6 +27,15 @@ type mockResolvedTemplateInvalidator struct {
 	invalidateResolvedTemplatesFn func(ctx context.Context, workspaceID uuid.UUID)
 	invalidateAllFn               func(ctx context.Context)
 }
+
+type noopTemplateCache struct{}
+
+func (noopTemplateCache) Get(context.Context, string) ([]byte, error) { return nil, domain.ErrNotFound }
+func (noopTemplateCache) Set(context.Context, string, []byte, time.Duration) error {
+	return nil
+}
+func (noopTemplateCache) Delete(context.Context, string) error        { return nil }
+func (noopTemplateCache) DeletePattern(context.Context, string) error { return nil }
 
 func (m *mockResolvedTemplateInvalidator) InvalidateResolvedTemplates(ctx context.Context, workspaceID uuid.UUID) {
 	if m.invalidateResolvedTemplatesFn != nil {
@@ -41,6 +51,27 @@ func (m *mockResolvedTemplateInvalidator) InvalidateAllResolvedTemplates(ctx con
 
 func setupTemplateTest(store port.TemplateStore, compiler port.TemplateCompiler, ts port.TenantStore, ws port.WorkspaceStore) (*echo.Echo, *handler.TemplateHandler) {
 	return setupTemplateTestWithOptions(store, compiler, ts, ws, nil, nil, nil, 100)
+}
+
+func setupTemplateTestWithMerger(
+	store port.TemplateStore,
+	compiler port.TemplateCompiler,
+	ts port.TenantStore,
+	ws port.WorkspaceStore,
+	merger *resolution.InjectorMerger,
+) (*echo.Echo, *handler.TemplateHandler) {
+	e := echo.New()
+	e.HTTPErrorHandler = response.HTTPErrorHandler
+	e.Use(middleware.RequestID())
+	e.Use(middleware.Scope())
+
+	svc := service.NewTemplateService(store, compiler)
+	h := handler.NewTemplateHandler(svc, store, ts, ws, nil, nil, nil, 100, merger, nil)
+
+	base := "/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code"
+	e.POST(base+"/templates/:template_id/preview-mjml", h.PreviewMJML)
+
+	return e, h
 }
 
 func setupTemplateTestWithInvalidator(
@@ -101,7 +132,7 @@ func setupTemplateTestWithOptions(
 	e.Use(middleware.Scope())
 
 	svc := service.NewTemplateService(store, compiler)
-	h := handler.NewTemplateHandler(svc, store, ts, ws, nil, batchSender, auditStore, batchMaxItems, invalidator)
+	h := handler.NewTemplateHandler(svc, store, ts, ws, nil, batchSender, auditStore, batchMaxItems, nil, invalidator)
 
 	base := "/api/v1/manage/tenants/:tenant_code/workspaces/:workspace_code"
 
@@ -407,7 +438,7 @@ func TestTemplateHandler_ListByTemplateType_ResolvesVisibleSystemTemplateInWorks
 	typeID := uuid.Must(uuid.NewV7())
 	templateID := uuid.Must(uuid.NewV7())
 
-wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
 		}
@@ -477,7 +508,7 @@ func TestTemplateHandler_CreateVersion_BlocksInheritedSystemTemplateInWorkspace(
 	systemWorkspace := uuid.Must(uuid.NewV7())
 	templateID := uuid.Must(uuid.NewV7())
 
-wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
 		}
@@ -530,7 +561,7 @@ func TestTemplateHandler_UpdateVersion_BlocksInheritedSystemTemplateInWorkspace(
 	templateID := uuid.Must(uuid.NewV7())
 	versionID := uuid.Must(uuid.NewV7())
 
-wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
 		}
@@ -594,7 +625,7 @@ func TestTemplateHandler_ForkTemplate_Success(t *testing.T) {
 	systemWorkspace := uuid.Must(uuid.NewV7())
 	invalidatedWorkspace := uuid.Nil
 
-wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			t.Fatalf("expected tenant %s, got %s", tenant.ID, tenantID)
 		}
@@ -1194,6 +1225,130 @@ func TestTemplateHandler_PreviewMJML_Success(t *testing.T) {
 	}
 	if resp.HTML == "" {
 		t.Fatal("expected non-empty HTML")
+	}
+}
+
+type previewStaticCodeInjector struct {
+	code      string
+	resolveFn port.CodeResolveFunc
+}
+
+func (i previewStaticCodeInjector) Code() string { return i.code }
+
+func (i previewStaticCodeInjector) Resolve() (port.CodeResolveFunc, []string) {
+	return i.resolveFn, nil
+}
+
+func (i previewStaticCodeInjector) IsCritical() bool       { return false }
+func (i previewStaticCodeInjector) Timeout() time.Duration { return 0 }
+func (i previewStaticCodeInjector) Catalog() port.InjectorCatalog {
+	return port.InjectorCatalog{
+		Code:   i.code,
+		Static: true,
+		Fields: []port.InjectorFieldSpec{{Name: "label", Type: domain.FieldTypeText}},
+	}
+}
+
+func TestTemplateHandler_PreviewMJML_UsesWorkspaceSendRefForStaticCodeInjectors(t *testing.T) {
+	tenant, ws, ts, wsStore := testTenantAndWorkspace()
+	templateID := uuid.Must(uuid.NewV7())
+	templateTypeID := uuid.Must(uuid.NewV7())
+	systemWS := &domain.Workspace{
+		ID:          uuid.Must(uuid.NewV7()),
+		TenantID:    tenant.ID,
+		Code:        "_system",
+		Name:        "System",
+		IsSystem:    true,
+		Environment: ws.Environment,
+	}
+	ws.Environment = domain.EnvironmentProd
+	wsStore.getByIDFn = func(_ context.Context, id uuid.UUID) (*domain.Workspace, error) {
+		if id == ws.ID {
+			return ws, nil
+		}
+		if id == systemWS.ID {
+			return systemWS, nil
+		}
+		return nil, domain.ErrNotFound
+	}
+	wsStore.getSystemWorkspaceFn = func(_ context.Context, tenantID uuid.UUID, environment domain.Environment) (*domain.Workspace, error) {
+		if tenantID != tenant.ID {
+			return nil, domain.ErrNotFound
+		}
+		return systemWS, nil
+	}
+	ts.getByIDFn = func(_ context.Context, id uuid.UUID) (*domain.Tenant, error) {
+		if id == tenant.ID {
+			return tenant, nil
+		}
+		return nil, domain.ErrNotFound
+	}
+
+	store := &mockTemplateStore{
+		getTemplateByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Template, error) {
+			if id != templateID {
+				t.Fatalf("expected template ID %s, got %s", templateID, id)
+			}
+			return &domain.Template{
+				ID:             templateID,
+				TemplateTypeID: templateTypeID,
+				WorkspaceID:    &ws.ID,
+			}, nil
+		},
+		getTypeByIDFn: func(_ context.Context, id uuid.UUID) (*domain.TemplateType, error) {
+			if id != templateTypeID {
+				t.Fatalf("expected template type ID %s, got %s", templateTypeID, id)
+			}
+			return &domain.TemplateType{ID: templateTypeID, Slug: "welcome"}, nil
+		},
+	}
+
+	compiler := &mockTemplateCompiler{
+		compileFn: func(_ context.Context, mjml string) (string, error) {
+			return mjml, nil
+		},
+	}
+
+	merger := resolution.NewInjectorMerger(
+		&mockInjectorStore{
+			listDefinitionsInChainFn: func(_ context.Context, _ []uuid.NullUUID) ([]*domain.InjectorDefinition, error) {
+				return nil, nil
+			},
+			getValuesFn: func(_ context.Context, _ uuid.UUID, _ []uuid.NullUUID) ([]*domain.InjectorValue, error) {
+				return nil, nil
+			},
+		},
+		resolution.NewChainResolver(wsStore, noopTemplateCache{}),
+		nil,
+		[]port.CodeInjector{
+			previewStaticCodeInjector{
+				code: "workspace_profile",
+				resolveFn: func(_ context.Context, injCtx *port.InjectorContext) (map[string]any, error) {
+					return map[string]any{"label": injCtx.Ref()}, nil
+				},
+			},
+		},
+		nil,
+	)
+
+	e, _ := setupTemplateTestWithMerger(store, compiler, ts, wsStore, merger)
+
+	body := `{"mjml":"<mjml><mj-body><mj-section><mj-column><mj-text>{{ injector.workspace_profile.label }}</mj-text></mj-column></mj-section></mj-body></mjml>"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/templates/"+templateID.String()+"/preview-mjml", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp response.MJMLPreviewResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !strings.Contains(resp.HTML, "acme:default:welcome") {
+		t.Fatalf("expected preview to use workspace send ref, got %q", resp.HTML)
 	}
 }
 

--- a/internal/http/response/injector.go
+++ b/internal/http/response/injector.go
@@ -11,6 +11,8 @@ type InjectorDefinitionResponse struct {
 	ID                  string  `json:"id"`
 	WorkspaceID         *string `json:"workspace_id,omitempty"`
 	Name                string  `json:"name"`
+	Source              string  `json:"source,omitempty"`
+	Static              bool    `json:"static"`
 	Description         *string `json:"description,omitempty"`
 	OwnerScope          string  `json:"owner_scope,omitempty"`
 	InheritedFromSystem bool    `json:"inherited_from_system"`
@@ -52,9 +54,15 @@ type InjectorListResponse struct {
 
 // NewInjectorDefinitionResponse maps a domain InjectorDefinition to a response.
 func NewInjectorDefinitionResponse(d *domain.InjectorDefinition) InjectorDefinitionResponse {
+	source := d.Source
+	if source == "" {
+		source = "database"
+	}
 	resp := InjectorDefinitionResponse{
 		ID:                  d.ID.String(),
 		Name:                d.Name,
+		Source:              source,
+		Static:              d.Static,
 		Description:         d.Description,
 		OwnerScope:          d.OwnerScope,
 		InheritedFromSystem: d.InheritedFromSystem,

--- a/internal/port/code_injector.go
+++ b/internal/port/code_injector.go
@@ -37,6 +37,30 @@ type CodeResolveFunc func(ctx context.Context, injCtx *InjectorContext) (map[str
 // The returned value is stored in InjectorContext.InitData().
 type CodeInitFunc func(ctx context.Context, injCtx *InjectorContext) (any, error)
 
+// InjectorFieldSpec describes one field exposed by a catalogable code injector.
+type InjectorFieldSpec struct {
+	Name        string
+	Type        domain.InjectorFieldType
+	Description string
+}
+
+// InjectorCatalog describes optional UI/catalog metadata for a code injector.
+type InjectorCatalog struct {
+	Code        string
+	Name        string
+	Description string
+	Static      bool
+	TTL         time.Duration
+	Fields      []InjectorFieldSpec
+}
+
+// CatalogCodeInjector augments a runtime injector with catalog metadata
+// so it can be exposed through injector management and builder surfaces.
+type CatalogCodeInjector interface {
+	CodeInjector
+	Catalog() InjectorCatalog
+}
+
 // InjectorContext is the read-only context available to code injectors
 // and the init function during send resolution.
 type InjectorContext struct {

--- a/internal/resolution/injector_merger.go
+++ b/internal/resolution/injector_merger.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -28,6 +29,7 @@ type injectorFieldRule struct {
 type InjectorMerger struct {
 	store         port.InjectorStore
 	chainResolver *ChainResolver
+	cache         port.Cache
 	codeInjectors []port.CodeInjector
 	codeInitFunc  port.CodeInitFunc
 }
@@ -36,12 +38,14 @@ type InjectorMerger struct {
 func NewInjectorMerger(
 	store port.InjectorStore,
 	cr *ChainResolver,
+	cache port.Cache,
 	codeInjectors []port.CodeInjector,
 	codeInitFunc port.CodeInitFunc,
 ) *InjectorMerger {
 	return &InjectorMerger{
 		store:         store,
 		chainResolver: cr,
+		cache:         cache,
 		codeInjectors: codeInjectors,
 		codeInitFunc:  codeInitFunc,
 	}
@@ -50,6 +54,128 @@ func NewInjectorMerger(
 // HasCodeInjectors returns true if user-provided code injectors are registered.
 func (m *InjectorMerger) HasCodeInjectors() bool {
 	return len(m.codeInjectors) > 0 || m.codeInitFunc != nil
+}
+
+// StaticCatalog synthesizes UI/catalog injector definitions for static
+// code injectors, optionally resolving their effective values for a workspace.
+func (m *InjectorMerger) StaticCatalog(ctx context.Context, workspace *domain.Workspace, templateType string) ([]*domain.InjectorDefinition, map[uuid.UUID][]*domain.InjectorField, error) {
+	staticInjectors := m.staticCatalogInjectors()
+	if len(staticInjectors) == 0 {
+		return nil, map[uuid.UUID][]*domain.InjectorField{}, nil
+	}
+
+	var (
+		workspaceID  uuid.UUID
+		tenantID     uuid.UUID
+		environment  domain.Environment
+		hasWorkspace bool
+	)
+	if workspace != nil {
+		hasWorkspace = true
+		workspaceID = workspace.ID
+		tenantID = workspace.TenantID
+		environment = workspace.Environment
+	}
+
+	injCtx := port.NewInjectorContext(nil, staticCatalogInjectorRef(workspace, templateType), nil, tenantID, workspaceID, environment, templateType)
+	resolved, err := m.resolveCodeInjectors(ctx, injCtx, func(inj port.CodeInjector) bool {
+		meta, ok := injectorCatalog(inj)
+		return ok && meta.Static
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	now := time.Now().UTC()
+	defs := make([]*domain.InjectorDefinition, 0, len(staticInjectors))
+	fieldsByDefinition := make(map[uuid.UUID][]*domain.InjectorField, len(staticInjectors))
+	for _, inj := range staticInjectors {
+		meta, _ := injectorCatalog(inj)
+		defID := syntheticCodeInjectorDefinitionID(meta.Code)
+		description := optionalString(meta.Description)
+		def := &domain.InjectorDefinition{
+			ID:          defID,
+			Name:        meta.Code,
+			Description: description,
+			Source:      "code",
+			Static:      true,
+			OwnerScope:  "global",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		defs = append(defs, def)
+
+		fieldDefs := make([]*domain.InjectorField, 0, len(meta.Fields))
+		for position, field := range meta.Fields {
+			var value any
+			if hasWorkspace {
+				value = resolved[meta.Code][field.Name]
+			}
+			fieldDefs = append(fieldDefs, &domain.InjectorField{
+				ID:                   syntheticCodeInjectorFieldID(meta.Code, field.Name),
+				InjectorDefinitionID: defID,
+				FieldName:            field.Name,
+				FieldType:            field.Type,
+				Description:          optionalString(field.Description),
+				Position:             position,
+				DefaultValue:         value,
+				AllowOverwrite:       false,
+			})
+		}
+		fieldsByDefinition[defID] = fieldDefs
+	}
+
+	return defs, fieldsByDefinition, nil
+}
+
+// ResolveStaticPreview resolves only fields that should be materialized in the
+// builder preview: DB locked fields and static code injectors.
+func (m *InjectorMerger) ResolveStaticPreview(ctx context.Context, workspaceID *uuid.UUID, injCtx *port.InjectorContext) (MergedInjectors, error) {
+	result := make(MergedInjectors)
+
+	var (
+		defaults   MergedInjectors
+		fieldRules map[string]map[string]injectorFieldRule
+		err        error
+	)
+	if workspaceID == nil {
+		defaults, fieldRules, err = m.resolveDBForScopes(ctx, []uuid.NullUUID{{}})
+	} else {
+		defaults, fieldRules, err = m.resolveDB(ctx, *workspaceID)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	for injectorName, rules := range fieldRules {
+		for fieldName, rule := range rules {
+			if rule.AllowOverwrite {
+				continue
+			}
+			if result[injectorName] == nil {
+				result[injectorName] = make(map[string]any)
+			}
+			result[injectorName][fieldName] = defaults[injectorName][fieldName]
+		}
+	}
+
+	staticValues, err := m.resolveCodeInjectors(ctx, injCtx, func(inj port.CodeInjector) bool {
+		meta, ok := injectorCatalog(inj)
+		return ok && meta.Static
+	})
+	if err != nil {
+		return nil, err
+	}
+	for name, fields := range staticValues {
+		if result[name] == nil {
+			result[name] = make(map[string]any, len(fields))
+		}
+		for fieldName, value := range fields {
+			result[name][fieldName] = value
+		}
+	}
+
+	return result, nil
 }
 
 // Resolve returns only UI-defined workspace injectors with their default values.
@@ -69,29 +195,27 @@ func (m *InjectorMerger) ResolveGlobalWithContext(ctx context.Context, injCtx *p
 		return nil, err
 	}
 
-	result := cloneMergedInjectors(defaults)
-	requestValues := injCtx.RequestInjectors()
+	injCtx.MergeDBInjectors(defaults)
 
-	for injectorName, rules := range fieldRules {
-		if result[injectorName] == nil {
-			result[injectorName] = make(map[string]any, len(rules))
+	if m.codeInitFunc != nil {
+		initData, initErr := m.codeInitFunc(ctx, injCtx)
+		if initErr != nil {
+			return nil, fmt.Errorf("code init func: %w", initErr)
 		}
-
-		for fieldName, rule := range rules {
-			if !rule.AllowOverwrite {
-				result[injectorName][fieldName] = rule.DefaultValue
-				continue
-			}
-
-			if value, ok := getFieldValue(requestValues, injectorName, fieldName); ok {
-				result[injectorName][fieldName] = value
-				continue
-			}
-
-			result[injectorName][fieldName] = rule.DefaultValue
-		}
+		injCtx.SetInitData(initData)
 	}
 
+	codeValues, err := m.resolveCodeInjectors(ctx, injCtx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result := cloneMergedInjectors(defaults)
+	requestValues := injCtx.RequestInjectors()
+	applyGlobalFieldRules(result, fieldRules, requestValues, codeValues)
+	mergeCodeOnlyFields(result, fieldRules, codeValues)
+
+	injCtx.MergeDBInjectors(result)
 	return result, nil
 }
 
@@ -115,7 +239,7 @@ func (m *InjectorMerger) ResolveWithContext(ctx context.Context, workspaceID uui
 		injCtx.SetInitData(initData)
 	}
 
-	codeValues, err := m.resolveCodeInjectors(ctx, injCtx)
+	codeValues, err := m.resolveCodeInjectors(ctx, injCtx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -234,18 +358,24 @@ func (m *InjectorMerger) resolveDBForScopes(ctx context.Context, scopes []uuid.N
 	return result, fieldRules, nil
 }
 
-// resolveCodeInjectors runs all code injectors respecting dependency order.
-func (m *InjectorMerger) resolveCodeInjectors(ctx context.Context, injCtx *port.InjectorContext) (MergedInjectors, error) {
+// resolveCodeInjectors runs code injectors respecting dependency order.
+func (m *InjectorMerger) resolveCodeInjectors(ctx context.Context, injCtx *port.InjectorContext, filter func(port.CodeInjector) bool) (MergedInjectors, error) {
 	if len(m.codeInjectors) == 0 {
 		return nil, nil
 	}
 
 	byCode := make(map[string]port.CodeInjector, len(m.codeInjectors))
 	for _, inj := range m.codeInjectors {
+		if filter != nil && !filter(inj) {
+			continue
+		}
 		byCode[inj.Code()] = inj
 	}
+	if len(byCode) == 0 {
+		return nil, nil
+	}
 
-	resolved := make(MergedInjectors, len(m.codeInjectors))
+	resolved := make(MergedInjectors, len(byCode))
 	visited := make(map[string]bool)
 
 	var resolveOne func(code string) error
@@ -260,7 +390,7 @@ func (m *InjectorMerger) resolveCodeInjectors(ctx context.Context, injCtx *port.
 			return nil
 		}
 
-		resolveFn, deps := inj.Resolve()
+		_, deps := inj.Resolve()
 		for _, dep := range deps {
 			if err := resolveOne(dep); err != nil {
 				return err
@@ -275,7 +405,7 @@ func (m *InjectorMerger) resolveCodeInjectors(ctx context.Context, injCtx *port.
 		execCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 
-		fields, err := resolveFn(execCtx, injCtx)
+		fields, err := m.resolveInjectorFields(execCtx, injCtx, inj)
 		if err != nil {
 			if inj.IsCritical() {
 				return fmt.Errorf("critical code injector %q failed: %w", code, err)
@@ -289,13 +419,96 @@ func (m *InjectorMerger) resolveCodeInjectors(ctx context.Context, injCtx *port.
 		return nil
 	}
 
-	for _, inj := range m.codeInjectors {
-		if err := resolveOne(inj.Code()); err != nil {
+	for code := range byCode {
+		if err := resolveOne(code); err != nil {
 			return nil, err
 		}
 	}
 
 	return resolved, nil
+}
+
+func (m *InjectorMerger) resolveInjectorFields(ctx context.Context, injCtx *port.InjectorContext, inj port.CodeInjector) (map[string]any, error) {
+	meta, ok := injectorCatalog(inj)
+	if ok && meta.Static && meta.TTL > 0 && m.cache != nil {
+		cacheKey := staticCodeInjectorCacheKey(injCtx.WorkspaceID(), injCtx.TemplateType(), inj.Code())
+		if data, err := m.cache.Get(ctx, cacheKey); err == nil {
+			var cached map[string]any
+			if err := json.Unmarshal(data, &cached); err == nil {
+				return cached, nil
+			}
+		}
+
+		resolveFn, _ := inj.Resolve()
+		fields, err := resolveFn(ctx, injCtx)
+		if err != nil {
+			return nil, err
+		}
+		if data, err := json.Marshal(fields); err == nil {
+			_ = m.cache.Set(ctx, cacheKey, data, meta.TTL)
+		}
+		return fields, nil
+	}
+
+	resolveFn, _ := inj.Resolve()
+	return resolveFn(ctx, injCtx)
+}
+
+func (m *InjectorMerger) staticCatalogInjectors() []port.CodeInjector {
+	result := make([]port.CodeInjector, 0, len(m.codeInjectors))
+	for _, inj := range m.codeInjectors {
+		meta, ok := injectorCatalog(inj)
+		if !ok || !meta.Static {
+			continue
+		}
+		result = append(result, inj)
+	}
+	return result
+}
+
+func injectorCatalog(inj port.CodeInjector) (port.InjectorCatalog, bool) {
+	catalogInj, ok := inj.(port.CatalogCodeInjector)
+	if !ok {
+		return port.InjectorCatalog{}, false
+	}
+	return catalogInj.Catalog(), true
+}
+
+func staticCodeInjectorCacheKey(workspaceID uuid.UUID, templateType string, code string) string {
+	if templateType == "" {
+		templateType = "_"
+	}
+	return fmt.Sprintf("code_injector_static:%s:%s:%s", workspaceID.String(), templateType, code)
+}
+
+func staticCatalogInjectorRef(workspace *domain.Workspace, templateType string) string {
+	if workspace == nil || strings.TrimSpace(workspace.Code) == "" {
+		if templateType == "" {
+			return ""
+		}
+		return "global::" + templateType
+	}
+
+	if templateType == "" {
+		templateType = "catalog"
+	}
+	return "catalog:" + workspace.Code + ":" + templateType
+}
+
+func syntheticCodeInjectorDefinitionID(code string) uuid.UUID {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("code-injector:def:"+code))
+}
+
+func syntheticCodeInjectorFieldID(code, field string) uuid.UUID {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("code-injector:field:"+code+":"+field))
+}
+
+func optionalString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	v := value
+	return &v
 }
 
 func getFieldValue(values map[string]map[string]any, injectorName, fieldName string) (any, bool) {
@@ -321,6 +534,59 @@ func cloneFields(fields map[string]any) map[string]any {
 		cloned[fieldName] = value
 	}
 	return cloned
+}
+
+func applyGlobalFieldRules(
+	result MergedInjectors,
+	fieldRules map[string]map[string]injectorFieldRule,
+	requestValues MergedInjectors,
+	codeValues MergedInjectors,
+) {
+	for injectorName, rules := range fieldRules {
+		if result[injectorName] == nil {
+			result[injectorName] = make(map[string]any, len(rules))
+		}
+		for fieldName, rule := range rules {
+			result[injectorName][fieldName] = resolveGlobalFieldValue(rule, injectorName, fieldName, requestValues, codeValues)
+		}
+	}
+}
+
+func resolveGlobalFieldValue(
+	rule injectorFieldRule,
+	injectorName string,
+	fieldName string,
+	requestValues MergedInjectors,
+	codeValues MergedInjectors,
+) any {
+	if !rule.AllowOverwrite {
+		return rule.DefaultValue
+	}
+	if value, ok := getFieldValue(requestValues, injectorName, fieldName); ok {
+		return value
+	}
+	if value, ok := getFieldValue(codeValues, injectorName, fieldName); ok {
+		return value
+	}
+	return rule.DefaultValue
+}
+
+func mergeCodeOnlyFields(result MergedInjectors, fieldRules map[string]map[string]injectorFieldRule, codeValues MergedInjectors) {
+	for name, fields := range codeValues {
+		if result[name] == nil {
+			result[name] = cloneFields(fields)
+			continue
+		}
+		rules, exists := fieldRules[name]
+		if !exists {
+			continue
+		}
+		for fieldName, value := range fields {
+			if _, defined := rules[fieldName]; !defined {
+				result[name][fieldName] = value
+			}
+		}
+	}
 }
 
 type valueIndex map[uuid.UUID]map[string]map[string]*domain.InjectorValue

--- a/internal/resolution/injector_merger_test.go
+++ b/internal/resolution/injector_merger_test.go
@@ -22,6 +22,32 @@ type mockInjectorStore struct {
 	getValuesFn func(ctx context.Context, defID uuid.UUID, chain []uuid.NullUUID) ([]*domain.InjectorValue, error)
 }
 
+type staticCodeInjector struct {
+	code   string
+	fields []port.InjectorFieldSpec
+	values func(ctx context.Context, injCtx *port.InjectorContext) (map[string]any, error)
+}
+
+func (s staticCodeInjector) Code() string { return s.code }
+
+func (s staticCodeInjector) Resolve() (port.CodeResolveFunc, []string) {
+	return s.values, nil
+}
+
+func (s staticCodeInjector) IsCritical() bool       { return true }
+func (s staticCodeInjector) Timeout() time.Duration { return 0 }
+
+func (s staticCodeInjector) Catalog() port.InjectorCatalog {
+	return port.InjectorCatalog{
+		Code:        s.code,
+		Name:        s.code,
+		Description: "static code injector",
+		Static:      true,
+		TTL:         time.Minute,
+		Fields:      s.fields,
+	}
+}
+
 func (m *mockInjectorStore) CreateDefinition(_ context.Context, _ *domain.InjectorDefinition) error {
 	return nil
 }
@@ -138,7 +164,7 @@ func TestInjectorMerger_IncludesSystemDefinitionsAsFallback(t *testing.T) {
 		Scopes:            []uuid.NullUUID{{UUID: wsID, Valid: true}, {UUID: sysID, Valid: true}},
 	}
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil, nil)
 
 	result, err := merger.Resolve(context.Background(), wsID)
 	if err != nil {
@@ -180,7 +206,7 @@ func TestInjectorMerger_UsesFieldDefaultOnlyWhenNoValueExists(t *testing.T) {
 
 	chain := &resolution.ResolutionChain{WorkspaceID: wsID, Scopes: []uuid.NullUUID{{UUID: wsID, Valid: true}}}
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil, nil)
 
 	result, err := merger.Resolve(context.Background(), wsID)
 	if err != nil {
@@ -217,7 +243,7 @@ func TestInjectorMerger_UsesMultipleFieldDefaults(t *testing.T) {
 
 	chain := &resolution.ResolutionChain{WorkspaceID: wsID, Scopes: []uuid.NullUUID{{UUID: wsID, Valid: true}}}
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil, nil)
 
 	result, err := merger.Resolve(context.Background(), wsID)
 	if err != nil {
@@ -259,7 +285,7 @@ func TestInjectorMerger_FieldWithNilDefault(t *testing.T) {
 
 	chain := &resolution.ResolutionChain{WorkspaceID: wsID, Scopes: []uuid.NullUUID{{UUID: wsID, Valid: true}}}
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil, nil)
 
 	result, err := merger.Resolve(context.Background(), wsID)
 	if err != nil {
@@ -309,7 +335,7 @@ func TestInjectorMerger_MultipleDefinitions(t *testing.T) {
 
 	chain := &resolution.ResolutionChain{WorkspaceID: wsID, Scopes: []uuid.NullUUID{{UUID: wsID, Valid: true}}}
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil, nil)
 
 	result, err := merger.Resolve(context.Background(), wsID)
 	if err != nil {
@@ -361,7 +387,7 @@ func TestInjectorMerger_DuplicateDefNames_WorkspaceWins(t *testing.T) {
 		Scopes: []uuid.NullUUID{{UUID: wsID, Valid: true}, {UUID: sysID, Valid: true}, {Valid: false}},
 	}
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil, nil)
 
 	result, err := merger.Resolve(context.Background(), wsID)
 	if err != nil {
@@ -411,7 +437,7 @@ func TestInjectorMerger_UsesSystemInheritedValueBeforeFieldDefault(t *testing.T)
 		Scopes:            []uuid.NullUUID{{UUID: wsID, Valid: true}, {UUID: sysID, Valid: true}},
 	}
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil, nil)
 
 	result, err := merger.Resolve(context.Background(), wsID)
 	if err != nil {
@@ -439,7 +465,7 @@ func TestInjectorMerger_StoreError(t *testing.T) {
 		WorkspaceID: wsID,
 		Scopes:      []uuid.NullUUID{{UUID: wsID, Valid: true}},
 	}, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil, nil)
 
 	_, err := merger.Resolve(context.Background(), wsID)
 	if err == nil {
@@ -500,7 +526,7 @@ func TestResolveWithContext_CodeInjectorsOnly(t *testing.T) {
 	}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{codeInj}, nil)
+	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, []port.CodeInjector{codeInj}, nil)
 	injCtx := port.NewInjectorContext(nil, "t:w:welcome", nil, uuid.Nil, wsID, domain.EnvironmentProd, "welcome")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
@@ -535,7 +561,7 @@ func TestResolveWithContext_InitFunc(t *testing.T) {
 	}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{inj}, initFunc)
+	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, []port.CodeInjector{inj}, initFunc)
 	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
@@ -558,7 +584,7 @@ func TestResolveWithContext_NonCriticalSkipped(t *testing.T) {
 	okInj := &stubCodeInjector{code: "stable", fields: map[string]any{"ok": true}}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{failInj, okInj}, nil)
+	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, []port.CodeInjector{failInj, okInj}, nil)
 	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
@@ -583,7 +609,7 @@ func TestResolveWithContext_CriticalAborts(t *testing.T) {
 	criticalInj := &stubCodeInjector{code: "must_work", critical: true, err: errors.New("db down")}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{criticalInj}, nil)
+	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, []port.CodeInjector{criticalInj}, nil)
 	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	_, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
@@ -605,7 +631,7 @@ func TestResolveWithContext_DependencyOrder(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	// Register child BEFORE parent to test dependency resolution.
-	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{childInj, parentInj}, nil)
+	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, []port.CodeInjector{childInj, parentInj}, nil)
 	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	_, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
@@ -668,7 +694,7 @@ func TestResolveWithContext_CodeOverridesDB(t *testing.T) {
 	}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, []port.CodeInjector{codeInj}, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, []port.CodeInjector{codeInj}, nil)
 	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
@@ -715,7 +741,7 @@ func TestResolveWithContext_MixedDBAndCode(t *testing.T) {
 	}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, []port.CodeInjector{codeInj}, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, []port.CodeInjector{codeInj}, nil)
 	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
@@ -758,7 +784,7 @@ func TestResolveWithContext_NoCodeInjectors_SameAsResolve(t *testing.T) {
 
 	cr := newTestChainResolver(chain, nil)
 	// No code injectors.
-	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil, nil)
 	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	resultCtx, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
@@ -784,13 +810,13 @@ func TestHasCodeInjectors(t *testing.T) {
 	cr := newTestChainResolver(chain, nil)
 
 	// Without code injectors.
-	m1 := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, nil)
+	m1 := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, nil, nil)
 	if m1.HasCodeInjectors() {
 		t.Error("HasCodeInjectors should be false when no injectors/initFunc")
 	}
 
 	// With code injectors.
-	m2 := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{
+	m2 := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, []port.CodeInjector{
 		&stubCodeInjector{code: "x", fields: map[string]any{}},
 	}, nil)
 	if !m2.HasCodeInjectors() {
@@ -798,7 +824,7 @@ func TestHasCodeInjectors(t *testing.T) {
 	}
 
 	// With only initFunc.
-	m3 := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, func(_ context.Context, _ *port.InjectorContext) (any, error) {
+	m3 := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, nil, func(_ context.Context, _ *port.InjectorContext) (any, error) {
 		return nil, nil
 	})
 	if !m3.HasCodeInjectors() {
@@ -820,7 +846,7 @@ func TestResolveWithContext_InitFuncError(t *testing.T) {
 	inj := &stubCodeInjector{code: "x", fields: map[string]any{"v": 1}}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{inj}, failInit)
+	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, []port.CodeInjector{inj}, failInit)
 	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	_, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
@@ -875,7 +901,7 @@ func TestResolveWithContext_DepOnDBInjector(t *testing.T) {
 	}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, []port.CodeInjector{codeInj}, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, []port.CodeInjector{codeInj}, nil)
 	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
@@ -901,7 +927,7 @@ func TestResolveWithContext_DuplicateCodeInjectorCodes(t *testing.T) {
 	second := &stubCodeInjector{code: "dup", fields: map[string]any{"v": "second"}}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, []port.CodeInjector{first, second}, nil)
+	merger := resolution.NewInjectorMerger(emptyInjStore(), cr, nil, []port.CodeInjector{first, second}, nil)
 	injCtx := port.NewInjectorContext(nil, "t:w:t", nil, uuid.Nil, wsID, domain.EnvironmentProd, "t")
 
 	result, err := merger.ResolveWithContext(context.Background(), wsID, injCtx)
@@ -953,7 +979,7 @@ func TestResolveWithContext_RequestInjectorsOverrideCodeAndDefault(t *testing.T)
 	}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, []port.CodeInjector{codeInj}, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, []port.CodeInjector{codeInj}, nil)
 	injCtx := port.NewInjectorContext(nil, "t:w:welcome", nil, uuid.Nil, wsID, domain.EnvironmentProd, "welcome")
 	injCtx.SetRequestInjectors(map[string]map[string]any{
 		"student": {"name": "Request Student"},
@@ -1010,7 +1036,7 @@ func TestResolveWithContext_LockedFieldAlwaysUsesDefault(t *testing.T) {
 	}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, []port.CodeInjector{codeInj}, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, []port.CodeInjector{codeInj}, nil)
 	injCtx := port.NewInjectorContext(nil, "t:w:welcome", nil, uuid.Nil, wsID, domain.EnvironmentProd, "welcome")
 	injCtx.SetRequestInjectors(map[string]map[string]any{
 		"student": {"name": "Request Student"},
@@ -1077,7 +1103,7 @@ func TestResolve_UsesDefinitionsAcrossWorkspaceAndSystemChain(t *testing.T) {
 	}
 
 	cr := newTestChainResolver(chain, nil)
-	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil)
+	merger := resolution.NewInjectorMerger(injStore, cr, nil, nil, nil)
 
 	result, err := merger.Resolve(context.Background(), wsID)
 	if err != nil {
@@ -1089,5 +1115,254 @@ func TestResolve_UsesDefinitionsAcrossWorkspaceAndSystemChain(t *testing.T) {
 	}
 	if got := result["workspace_only"]["name"]; got != "Workspace" {
 		t.Fatalf("workspace_only.name = %v, want Workspace", got)
+	}
+}
+
+func TestInjectorMerger_ResolveStaticPreview_ResolvesOnlyLockedAndStaticCode(t *testing.T) {
+	defID := uuid.New()
+	wsID := uuid.New()
+
+	injStore := &mockInjectorStore{
+		listDefsFn: func(_ context.Context, _ []uuid.NullUUID) ([]*domain.InjectorDefinition, error) {
+			return []*domain.InjectorDefinition{
+				{ID: defID, WorkspaceID: &wsID, Name: "brand"},
+			}, nil
+		},
+		getFieldsFn: func(_ context.Context, _ uuid.UUID) ([]*domain.InjectorField, error) {
+			return []*domain.InjectorField{
+				{
+					ID:                   uuid.New(),
+					InjectorDefinitionID: defID,
+					FieldName:            "locked_html",
+					FieldType:            domain.FieldTypeHTML,
+					Position:             0,
+					DefaultValue:         "<strong>Locked</strong>",
+					AllowOverwrite:       false,
+				},
+				{
+					ID:                   uuid.New(),
+					InjectorDefinitionID: defID,
+					FieldName:            "editable_name",
+					FieldType:            domain.FieldTypeText,
+					Position:             1,
+					DefaultValue:         "Visible token",
+					AllowOverwrite:       true,
+				},
+			}, nil
+		},
+		getValuesFn: func(_ context.Context, _ uuid.UUID, _ []uuid.NullUUID) ([]*domain.InjectorValue, error) {
+			return nil, nil
+		},
+	}
+
+	chain := &resolution.ResolutionChain{WorkspaceID: wsID, Scopes: []uuid.NullUUID{{UUID: wsID, Valid: true}}}
+	cr := newTestChainResolver(chain, nil)
+	merger := resolution.NewInjectorMerger(
+		injStore,
+		cr,
+		nil,
+		[]port.CodeInjector{
+			staticCodeInjector{
+				code: "school",
+				fields: []port.InjectorFieldSpec{
+					{Name: "name", Type: domain.FieldTypeText, Description: "School name"},
+				},
+				values: func(_ context.Context, _ *port.InjectorContext) (map[string]any, error) {
+					return map[string]any{"name": "Acme Academy"}, nil
+				},
+			},
+		},
+		nil,
+	)
+
+	injCtx := port.NewInjectorContext(nil, "", nil, uuid.New(), wsID, domain.EnvironmentProd, "welcome")
+	result, err := merger.ResolveStaticPreview(context.Background(), &wsID, injCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := result["brand"]["locked_html"]; got != "<strong>Locked</strong>" {
+		t.Fatalf("expected locked field in preview, got %#v", got)
+	}
+	if _, ok := result["brand"]["editable_name"]; ok {
+		t.Fatal("expected editable field to remain unresolved in preview")
+	}
+	if got := result["school"]["name"]; got != "Acme Academy" {
+		t.Fatalf("expected static code injector in preview, got %#v", got)
+	}
+}
+
+func TestInjectorMerger_StaticCatalog_CachesStaticCodeInjectorByWorkspace(t *testing.T) {
+	wsID := uuid.New()
+	tenantID := uuid.New()
+	cache := newMockCache()
+	calls := 0
+
+	merger := resolution.NewInjectorMerger(
+		&mockInjectorStore{
+			listDefsFn:  func(_ context.Context, _ []uuid.NullUUID) ([]*domain.InjectorDefinition, error) { return nil, nil },
+			getFieldsFn: func(_ context.Context, _ uuid.UUID) ([]*domain.InjectorField, error) { return nil, nil },
+			getValuesFn: func(_ context.Context, _ uuid.UUID, _ []uuid.NullUUID) ([]*domain.InjectorValue, error) {
+				return nil, nil
+			},
+		},
+		nil,
+		cache,
+		[]port.CodeInjector{
+			staticCodeInjector{
+				code: "school",
+				fields: []port.InjectorFieldSpec{
+					{Name: "name", Type: domain.FieldTypeText},
+				},
+				values: func(_ context.Context, _ *port.InjectorContext) (map[string]any, error) {
+					calls++
+					return map[string]any{"name": "Acme Academy"}, nil
+				},
+			},
+		},
+		nil,
+	)
+
+	workspace := &domain.Workspace{
+		ID:          wsID,
+		TenantID:    tenantID,
+		Code:        "default",
+		Name:        "Default",
+		Environment: domain.EnvironmentProd,
+	}
+
+	for range 2 {
+		defs, fieldsByDefinition, err := merger.StaticCatalog(context.Background(), workspace, "welcome")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(defs) != 1 {
+			t.Fatalf("expected one static definition, got %d", len(defs))
+		}
+		fields := fieldsByDefinition[defs[0].ID]
+		if len(fields) != 1 || fields[0].DefaultValue != "Acme Academy" {
+			t.Fatalf("expected cached field default, got %+v", fields)
+		}
+	}
+
+	if calls != 1 {
+		t.Fatalf("expected static injector resolver to run once thanks to cache, got %d", calls)
+	}
+	if cache.setCall != 1 {
+		t.Fatalf("expected one cache write, got %d", cache.setCall)
+	}
+}
+
+func TestInjectorMerger_StaticCatalog_PassesWorkspaceRefToStaticCodeInjectors(t *testing.T) {
+	wsID := uuid.New()
+	tenantID := uuid.New()
+
+	merger := resolution.NewInjectorMerger(
+		&mockInjectorStore{
+			listDefsFn:  func(_ context.Context, _ []uuid.NullUUID) ([]*domain.InjectorDefinition, error) { return nil, nil },
+			getFieldsFn: func(_ context.Context, _ uuid.UUID) ([]*domain.InjectorField, error) { return nil, nil },
+			getValuesFn: func(_ context.Context, _ uuid.UUID, _ []uuid.NullUUID) ([]*domain.InjectorValue, error) {
+				return nil, nil
+			},
+		},
+		nil,
+		nil,
+		[]port.CodeInjector{
+			staticCodeInjector{
+				code: "workspace_profile",
+				fields: []port.InjectorFieldSpec{
+					{Name: "workspace_code", Type: domain.FieldTypeText},
+				},
+				values: func(_ context.Context, injCtx *port.InjectorContext) (map[string]any, error) {
+					parts := strings.Split(injCtx.Ref(), ":")
+					workspaceCode := "unknown-workspace"
+					if len(parts) >= 2 && strings.TrimSpace(parts[1]) != "" {
+						workspaceCode = strings.TrimSpace(parts[1])
+					}
+					return map[string]any{"workspace_code": workspaceCode}, nil
+				},
+			},
+		},
+		nil,
+	)
+
+	workspace := &domain.Workspace{
+		ID:          wsID,
+		TenantID:    tenantID,
+		Code:        "default",
+		Name:        "Default",
+		Environment: domain.EnvironmentProd,
+	}
+
+	defs, fieldsByDefinition, err := merger.StaticCatalog(context.Background(), workspace, "welcome")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fields := fieldsByDefinition[defs[0].ID]
+	if len(fields) != 1 {
+		t.Fatalf("expected one static field, got %d", len(fields))
+	}
+	if got := fields[0].DefaultValue; got != "default" {
+		t.Fatalf("expected workspace-aware ref to resolve default workspace code, got %#v", got)
+	}
+}
+
+func TestInjectorMerger_StaticCatalog_CacheVariesByTemplateType(t *testing.T) {
+	wsID := uuid.New()
+	tenantID := uuid.New()
+	cache := newMockCache()
+	calls := 0
+
+	merger := resolution.NewInjectorMerger(
+		&mockInjectorStore{
+			listDefsFn:  func(_ context.Context, _ []uuid.NullUUID) ([]*domain.InjectorDefinition, error) { return nil, nil },
+			getFieldsFn: func(_ context.Context, _ uuid.UUID) ([]*domain.InjectorField, error) { return nil, nil },
+			getValuesFn: func(_ context.Context, _ uuid.UUID, _ []uuid.NullUUID) ([]*domain.InjectorValue, error) {
+				return nil, nil
+			},
+		},
+		nil,
+		cache,
+		[]port.CodeInjector{
+			staticCodeInjector{
+				code: "workspace_profile",
+				fields: []port.InjectorFieldSpec{
+					{Name: "template_type", Type: domain.FieldTypeText},
+				},
+				values: func(_ context.Context, injCtx *port.InjectorContext) (map[string]any, error) {
+					calls++
+					return map[string]any{"template_type": injCtx.TemplateType()}, nil
+				},
+			},
+		},
+		nil,
+	)
+
+	workspace := &domain.Workspace{
+		ID:          wsID,
+		TenantID:    tenantID,
+		Code:        "default",
+		Name:        "Default",
+		Environment: domain.EnvironmentProd,
+	}
+
+	defs, fieldsByDefinition, err := merger.StaticCatalog(context.Background(), workspace, "welcome")
+	if err != nil {
+		t.Fatalf("unexpected error resolving first catalog: %v", err)
+	}
+	if got := fieldsByDefinition[defs[0].ID][0].DefaultValue; got != "welcome" {
+		t.Fatalf("expected first template type to resolve as welcome, got %#v", got)
+	}
+
+	defs, fieldsByDefinition, err = merger.StaticCatalog(context.Background(), workspace, "receipt")
+	if err != nil {
+		t.Fatalf("unexpected error resolving second catalog: %v", err)
+	}
+	if got := fieldsByDefinition[defs[0].ID][0].DefaultValue; got != "receipt" {
+		t.Fatalf("expected second template type to bypass stale cache, got %#v", got)
+	}
+	if calls != 2 {
+		t.Fatalf("expected resolver to run once per template type, got %d calls", calls)
 	}
 }

--- a/internal/service/send_test.go
+++ b/internal/service/send_test.go
@@ -666,7 +666,7 @@ func (f *sendTestFixture) buildService() *service.SendService {
 func (f *sendTestFixture) buildServiceWithCodeInjectors(codeInjectors []port.CodeInjector, initFunc port.CodeInitFunc) *service.SendService {
 	chainResolver := resolution.NewChainResolver(f.wsStore, f.cache)
 	templateResolver := resolution.NewTemplateResolver(f.templateStore, f.cache, chainResolver)
-	injectorMerger := resolution.NewInjectorMerger(f.injectorStore, chainResolver, codeInjectors, initFunc)
+	injectorMerger := resolution.NewInjectorMerger(f.injectorStore, chainResolver, nil, codeInjectors, initFunc)
 	adapterResolver := resolution.NewAdapterResolver(f.adapterStore, f.cache)
 	renderer := service.NewVariableRenderer()
 	identitySvc := service.NewIdentityService(f.identityStore, f.adapterStore, nil, nil)

--- a/internal/service/static_injector_preview.go
+++ b/internal/service/static_injector_preview.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var previewInjectorPattern = regexp.MustCompile(`\{\{\s*(injector\.[^}]+?)\s*\}\}`)
+
+// RenderStaticInjectorPreview replaces only injector placeholders that exist in
+// the provided map, preserving all other tokens verbatim.
+func RenderStaticInjectorPreview(template string, injectors map[string]map[string]any) string {
+	if template == "" || len(injectors) == 0 {
+		return template
+	}
+
+	return previewInjectorPattern.ReplaceAllStringFunc(template, func(match string) string {
+		submatch := previewInjectorPattern.FindStringSubmatch(match)
+		if len(submatch) < 2 {
+			return match
+		}
+
+		path := strings.TrimSpace(strings.TrimPrefix(submatch[1], "injector."))
+		parts := strings.SplitN(path, ".", 2)
+		if len(parts) != 2 {
+			return match
+		}
+
+		fields, ok := injectors[parts[0]]
+		if !ok {
+			return match
+		}
+
+		value, ok := fields[parts[1]]
+		if !ok || value == nil {
+			return match
+		}
+
+		return fmt.Sprintf("%v", value)
+	})
+}

--- a/internal/service/static_injector_preview_test.go
+++ b/internal/service/static_injector_preview_test.go
@@ -1,0 +1,33 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/rendis/senda/internal/service"
+)
+
+func TestRenderStaticInjectorPreview_ReplacesKnownStaticInjectorsOnly(t *testing.T) {
+	input := `<mj-text>{{ injector.brand.name }} {{ injector.student.name }} {{ event.user_name }}</mj-text>`
+
+	got := service.RenderStaticInjectorPreview(input, map[string]map[string]any{
+		"brand": {"name": "Acme"},
+	})
+
+	want := `<mj-text>Acme {{ injector.student.name }} {{ event.user_name }}</mj-text>`
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestRenderStaticInjectorPreview_RendersHTMLVerbatim(t *testing.T) {
+	input := `<mj-text>{{ injector.legal.footer_html }}</mj-text>`
+
+	got := service.RenderStaticInjectorPreview(input, map[string]map[string]any{
+		"legal": {"footer_html": "<strong>Footer</strong>"},
+	})
+
+	want := `<mj-text><strong>Footer</strong></mj-text>`
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/internal/service/test_send_test.go
+++ b/internal/service/test_send_test.go
@@ -206,6 +206,7 @@ func TestTestSendService_ResolvesInjectorsWithRequestCodeAndDefaultPrecedence(t 
 	injectorMerger := resolution.NewInjectorMerger(
 		injectorStore,
 		chainResolver,
+		nil,
 		[]port.CodeInjector{
 			fixedCodeInjectorTestSend{
 				code: "student",
@@ -383,6 +384,7 @@ func TestTestSendService_ResolvesGlobalInjectorsWithRequestAndDefaultPrecedence(
 
 	injectorMerger := resolution.NewInjectorMerger(
 		injectorStore,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/scripts/local-code-injector-demo.sh
+++ b/scripts/local-code-injector-demo.sh
@@ -1,0 +1,437 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+# shellcheck source=test/system/subagents/lib.sh
+source "$ROOT_DIR/test/system/subagents/lib.sh"
+
+require_cmd jq
+require_cmd curl
+require_cmd docker
+require_cmd corepack
+require_cmd go
+
+DEFAULT_DEMO_ARTIFACT_DIR="$ROOT_DIR/artifacts/local-code-injector-demo/$(date -u +%Y%m%dT%H%M%SZ)"
+ARTIFACT_DIR="${LOCAL_CODE_INJECTOR_DEMO_ARTIFACT_DIR:-$DEFAULT_DEMO_ARTIFACT_DIR}"
+ENV_REPORT_FILE="${LOCAL_CODE_INJECTOR_DEMO_ENV_REPORT_FILE:-$ARTIFACT_DIR/env-report.json}"
+RUNTIME_ENV_FILE="${LOCAL_CODE_INJECTOR_DEMO_RUNTIME_ENV_FILE:-$ARTIFACT_DIR/runtime.env}"
+SUMMARY_PATH="$ARTIFACT_DIR/demo-summary.md"
+FRONTEND_PID_FILE="$ARTIFACT_DIR/frontend.pid"
+FRONTEND_LOG_FILE="$ARTIFACT_DIR/frontend.log"
+
+export ARTIFACT_DIR
+export ENV_REPORT_FILE
+export RUNTIME_ENV_FILE
+
+mkdir -p "$ARTIFACT_DIR"
+
+TENANT_CODE="${TENANT_CODE:-system-test-corp}"
+TENANT_NAME="${TENANT_NAME:-System Test Corp}"
+WORKSPACE_CODE="${WORKSPACE_CODE:-system-main}"
+WORKSPACE_NAME="${WORKSPACE_NAME:-System Main}"
+INJECTOR_NAME="${INJECTOR_NAME:-student}"
+TEMPLATE_TYPE_SLUG="${TEMPLATE_TYPE_SLUG:-code-injector-ui-demo}"
+TEMPLATE_TYPE_NAME="${TEMPLATE_TYPE_NAME:-Code Injector UI Demo}"
+RUNTIME_TEMPLATE_TYPE_SLUG="${RUNTIME_TEMPLATE_TYPE_SLUG:-code-runtime-api-demo}"
+RUNTIME_TEMPLATE_TYPE_NAME="${RUNTIME_TEMPLATE_TYPE_NAME:-Code Runtime API Demo}"
+ADAPTER_NAME="${ADAPTER_NAME:-Local Demo SES Adapter}"
+DEFAULT_FROM_EMAIL="${DEFAULT_FROM_EMAIL:-noreply@mail.test.example.com}"
+
+issue_test_token() {
+  local email="$1"
+  systemtest token --email "$email" --secret "$SENDA_E2E_JWT_SECRET" | tail -n1
+}
+
+workspace_admin_token() {
+  if [[ -n "${WORKSPACE_ADMIN_TOKEN:-}" ]]; then
+    printf '%s\n' "$WORKSPACE_ADMIN_TOKEN"
+    return 0
+  fi
+  WORKSPACE_ADMIN_TOKEN="$(issue_test_token "$WORKSPACE_ADMIN_EMAIL")"
+  printf '%s\n' "$WORKSPACE_ADMIN_TOKEN"
+}
+
+management_api_request() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local token
+  token="$(workspace_admin_token)"
+
+  if [[ -n "$body" ]]; then
+    curl -sS -w '\n%{http_code}' -X "$method" "$SENDA_BASE_URL$path" \
+      -H "Authorization: Bearer $token" \
+      -H 'Content-Type: application/json' \
+      --data "$body"
+  else
+    curl -sS -w '\n%{http_code}' -X "$method" "$SENDA_BASE_URL$path" \
+      -H "Authorization: Bearer $token"
+  fi
+}
+
+management_api_expect() {
+  local expected_status="$1"
+  local method="$2"
+  local path="$3"
+  local body="${4:-}"
+  local response status payload
+
+  response="$(management_api_request "$method" "$path" "$body")"
+  status="$(printf '%s' "$response" | tail -n1)"
+  payload="$(printf '%s' "$response" | sed '$d')"
+  if [[ "$status" != "$expected_status" ]]; then
+    echo "management ${method} failed: expected=${expected_status} actual=${status} path=${path} body=${payload}" >&2
+    return 1
+  fi
+  printf '%s\n' "$payload"
+}
+
+management_api_status() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local response
+  response="$(management_api_request "$method" "$path" "$body")"
+  printf '%s' "$response" | tail -n1
+}
+
+management_api_get() {
+  management_api_expect "200" GET "$1"
+}
+
+upsert_default_identity() {
+  local adapter_id="$1"
+  local postgres_container
+  postgres_container="$(jq -r '.runtime.containers.postgres // empty' "$ENV_REPORT_FILE")"
+  if [[ -z "$postgres_container" ]]; then
+    echo "missing postgres container in env report" >&2
+    return 1
+  fi
+
+  docker exec "$postgres_container" psql -U senda -d senda -v ON_ERROR_STOP=1 -c "
+    UPDATE adapter_identities
+       SET is_default = false,
+           updated_at = NOW()
+     WHERE adapter_id = '${adapter_id}'::uuid
+       AND identity <> '${DEFAULT_FROM_EMAIL}';
+
+    INSERT INTO adapter_identities (
+      id, adapter_id, identity, identity_type, status,
+      sending_enabled, is_default, source, last_synced_at, created_at, updated_at
+    )
+    VALUES (
+      gen_random_uuid(), '${adapter_id}'::uuid, '${DEFAULT_FROM_EMAIL}', 'email', 'verified',
+      true, true, 'provider', NOW(), NOW(), NOW()
+    )
+    ON CONFLICT (adapter_id, identity) DO UPDATE
+      SET status = 'verified',
+          sending_enabled = true,
+          is_default = true,
+          source = 'provider',
+          last_synced_at = NOW(),
+          updated_at = NOW();
+  " >/dev/null
+}
+
+ensure_workspace_adapter() {
+  local base_path="/api/v1/manage/tenants/${TENANT_CODE}/workspaces/${WORKSPACE_CODE}"
+  local payload adapter_id
+
+  payload="$(management_api_get "${base_path}/adapters")"
+  adapter_id="$(printf '%s' "$payload" | jq -r --arg name "$ADAPTER_NAME" '.items[] | select(.name == $name) | .id' | head -n1)"
+
+  if [[ -z "$adapter_id" ]]; then
+    adapter_id="$(
+      management_api_expect "201" POST "${base_path}/adapters" "$(cat <<JSON
+{"adapter_type":"ses","name":"${ADAPTER_NAME}","rate_limit_per_second":100,"config":{"region":"us-east-1","access_key":"test","secret_key":"test"}}
+JSON
+)" | jq -r '.id // empty'
+    )"
+  fi
+
+  if [[ -z "$adapter_id" ]]; then
+    echo "failed to resolve demo adapter" >&2
+    return 1
+  fi
+
+  upsert_default_identity "$adapter_id"
+  printf '%s\n' "$adapter_id"
+}
+
+reset_student_injector_fixture() {
+  local base_path="/api/v1/manage/tenants/${TENANT_CODE}/workspaces/${WORKSPACE_CODE}/injectors/${INJECTOR_NAME}"
+  local status
+  status="$(management_api_status DELETE "$base_path")"
+  if [[ "$status" != "204" && "$status" != "404" ]]; then
+    echo "failed to reset student injector fixture status=${status}" >&2
+    return 1
+  fi
+}
+
+ensure_student_injector_fixture() {
+  local base_path="/api/v1/manage/tenants/${TENANT_CODE}/workspaces/${WORKSPACE_CODE}"
+  reset_student_injector_fixture
+  management_api_expect "201" POST "${base_path}/injectors" "$(cat <<JSON
+{"name":"${INJECTOR_NAME}","description":"Demo DB injector that merges with the runtime code injector.","fields":[{"field_name":"name","field_type":"text","default_value":"Default Student","allow_overwrite":true,"position":0},{"field_name":"locked","field_type":"text","default_value":"LOCKED-DEFAULT","allow_overwrite":false,"position":1},{"field_name":"status","field_type":"text","default_value":"DEFAULT-STATUS","allow_overwrite":true,"position":2},{"field_name":"cohort","field_type":"text","default_value":"DB-COHORT","allow_overwrite":true,"position":3}]}
+JSON
+)" >/dev/null
+}
+
+ensure_template_fixture() {
+  local slug="$1"
+  local name="$2"
+  local subject="$3"
+  local from_name="$4"
+  local preview_text="$5"
+  local body_mjml="$6"
+  local base_path="/api/v1/manage/tenants/${TENANT_CODE}/workspaces/${WORKSPACE_CODE}"
+  local adapter_id type_status template_type_id template_id template_version_id
+
+  adapter_id="$(ensure_workspace_adapter)"
+
+  type_status="$(management_api_status GET "${base_path}/template-types/${slug}")"
+  if [[ "$type_status" != "200" ]]; then
+    management_api_expect "201" POST "${base_path}/template-types" "$(jq -nc \
+      --arg slug "$slug" \
+      --arg name "$name" \
+      --arg adapter_id "$adapter_id" \
+      '{slug:$slug,name:$name,adapter_id:$adapter_id}')" >/dev/null
+  fi
+
+  template_type_id="$(management_api_get "${base_path}/template-types/${slug}" | jq -r '.id // empty')"
+  template_id="$(management_api_get "${base_path}/template-types/${slug}/templates" | jq -r '.items[0].id // empty')"
+  if [[ -z "$template_id" ]]; then
+    template_id="$(
+      management_api_expect "201" POST "${base_path}/templates" "$(jq -nc \
+        --arg template_type_id "$template_type_id" \
+        '{template_type_id:$template_type_id}')" | jq -r '.id // empty'
+    )"
+  fi
+
+  template_version_id="$(
+    management_api_expect "201" POST "${base_path}/templates/${template_id}/versions" "$(jq -nc \
+      --arg subject "$subject" \
+      --arg from_name "$from_name" \
+      --arg preview_text "$preview_text" \
+      --arg body_mjml "$body_mjml" \
+      '{subject:$subject,from_name:$from_name,preview_text:$preview_text,body_mjml:$body_mjml,default_locale:"en"}')" | jq -r '.id // empty'
+  )"
+
+  management_api_expect "204" POST "${base_path}/templates/${template_id}/versions/${template_version_id}/publish" >/dev/null || \
+    management_api_expect "409" POST "${base_path}/templates/${template_id}/versions/${template_version_id}/publish" >/dev/null
+
+  printf '%s %s %s\n' "$template_type_id" "$template_id" "$template_version_id"
+}
+
+ui_template_subject() {
+  cat <<'EOF'
+Brand={{ injector.brand.company_name }} | Workspace={{ injector.workspace_profile.workspace_label }} | Student={{ injector.student.name }} | Locked={{ injector.student.locked }}
+EOF
+}
+
+ui_template_body() {
+  cat <<'EOF'
+<mjml><mj-body><mj-section><mj-column><mj-text font-size="20px">Brand={{ injector.brand.company_name }}</mj-text><mj-text>Workspace={{ injector.workspace_profile.workspace_label }} | Env={{ injector.workspace_profile.environment_name }}</mj-text><mj-image src="{{ injector.brand.hero_image_url }}" alt="Hero image" /><mj-text><a href="{{ injector.brand.policy_url }}">Policy link</a></mj-text><mj-text>{{ injector.brand.footer_html }}</mj-text><mj-text>{{ injector.workspace_profile.environment_badge_html }}</mj-text><mj-divider /><mj-text>Student={{ injector.student.name }} | Locked={{ injector.student.locked }} | Status={{ injector.student.status }} | Cohort={{ injector.student.cohort }}</mj-text><mj-text>Runtime only → ENV={{ injector.request_debug.environment }} | NOTE={{ injector.request_debug.request_note }} | EVENT={{ event.user_name }}</mj-text></mj-column></mj-section></mj-body></mjml>
+EOF
+}
+
+runtime_template_subject() {
+  cat <<'EOF'
+Runtime={{ injector.student.name }} | Status={{ injector.student.status }} | Env={{ injector.request_debug.environment }}
+EOF
+}
+
+runtime_template_body() {
+  cat <<'EOF'
+<mjml><mj-body><mj-section><mj-column><mj-text>NAME={{ injector.student.name }}|STATUS={{ injector.student.status }}|COHORT={{ injector.student.cohort }}|WORKSPACE={{ injector.request_debug.workspace_code }}|ENV={{ injector.request_debug.environment }}|REQUEST={{ injector.request_debug.request_note }}|EVENT={{ event.user_name }}</mj-text></mj-column></mj-section></mj-body></mjml>
+EOF
+}
+
+write_summary() {
+  local ui_template_id="$1"
+  local ui_template_version_id="$2"
+  local runtime_template_slug="$3"
+  local runtime_template_id="$4"
+  local runtime_template_version_id="$5"
+
+  local ui_editor_url runtime_editor_url api_key
+  ui_editor_url="${FRONTEND_BASE_URL}/t/${TENANT_CODE}/w/${WORKSPACE_CODE}/templates/${TEMPLATE_TYPE_SLUG}/edit?templateId=${ui_template_id}&versionId=${ui_template_version_id}"
+  runtime_editor_url="${FRONTEND_BASE_URL}/t/${TENANT_CODE}/w/${WORKSPACE_CODE}/templates/${RUNTIME_TEMPLATE_TYPE_SLUG}/edit?templateId=${runtime_template_id}&versionId=${runtime_template_version_id}"
+  api_key="$(grep '^API_KEY=' "$RUNTIME_ENV_FILE" | cut -d= -f2-)"
+
+  cat >"$SUMMARY_PATH" <<EOF
+# Local Code Injector Demo
+
+## URLs
+
+- Frontend: ${FRONTEND_BASE_URL}
+- API: ${SENDA_BASE_URL}
+- Keycloak: ${KEYCLOAK_BASE_URL}
+- Mailpit UI: ${MAILPIT_BASE_URL}
+- UI demo editor: ${ui_editor_url}
+- Runtime demo editor: ${runtime_editor_url}
+
+## Credentials
+
+- Superadmin: ${SUPERADMIN_EMAIL} / ${SUPERADMIN_PASSWORD}
+- Workspace admin: ${WORKSPACE_ADMIN_EMAIL} / ${WORKSPACE_ADMIN_PASSWORD}
+
+## Scope
+
+- Tenant: ${TENANT_CODE}
+- Workspace: ${WORKSPACE_CODE}
+- API key: ${api_key}
+
+## Registered code injectors
+
+### Static / catalog-visible
+
+- \`brand\`
+  - \`company_name\` (text)
+  - \`policy_url\` (url)
+  - \`logo_url\` (img)
+  - \`hero_image_url\` (img)
+  - \`footer_html\` (html)
+- \`workspace_profile\`
+  - \`workspace_code\` (text)
+  - \`workspace_label\` (text)
+  - \`environment_name\` (text)
+  - \`environment_badge_html\` (html)
+
+### Dynamic / runtime-only
+
+- \`student\`
+  - \`name\`
+  - \`status\`
+  - \`cohort\`
+  - \`age\`
+- \`request_debug\`
+  - \`workspace_code\`
+  - \`environment\`
+  - \`event_user_name\`
+  - \`request_note\`
+
+## DB injector fixture
+
+- \`${INJECTOR_NAME}\`
+  - \`name\` overwriteable default = \`Default Student\`
+  - \`locked\` locked default = \`LOCKED-DEFAULT\`
+  - \`status\` overwriteable default = \`DEFAULT-STATUS\`
+  - \`cohort\` overwriteable default = \`DB-COHORT\`
+
+## What to verify in the UI
+
+1. Open the **UI demo editor**.
+2. In the builder variable panel:
+   - \`brand.*\` and \`workspace_profile.*\` should appear as **code + static**.
+   - \`${INJECTOR_NAME}.*\` should appear from the DB injector.
+   - \`request_debug.*\` should **not** appear because it is runtime-only.
+3. In preview:
+   - static code injectors and locked DB defaults should render directly;
+   - overwriteable/runtime fields should remain unresolved until send.
+4. In **Send Test**:
+   - only overwriteable DB fields from \`${INJECTOR_NAME}\` should appear;
+   - static code injectors should not appear.
+5. Open Mailpit and inspect the sent email.
+
+## Runtime send examples
+
+### Default runtime send
+
+\`\`\`bash
+curl -X POST "${SENDA_BASE_URL}/api/v1/send" \\
+  -H "Authorization: Bearer ${api_key}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "ref": "${TENANT_CODE}:${WORKSPACE_CODE}:${runtime_template_slug}",
+    "to": ["runtime-default@test.example.com"],
+    "variables": {"user_name": "Local Tester"}
+  }'
+\`\`\`
+
+### Runtime send with injector overrides
+
+\`\`\`bash
+curl -X POST "${SENDA_BASE_URL}/api/v1/send" \\
+  -H "Authorization: Bearer ${api_key}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "ref": "${TENANT_CODE}:${WORKSPACE_CODE}:${runtime_template_slug}",
+    "to": ["runtime-override@test.example.com"],
+    "variables": {"user_name": "Override Tester"},
+    "injectors": {
+      "student": {
+        "name": "Ada Lovelace",
+        "status": "manual-status",
+        "cohort": "manual-cohort"
+      },
+      "request_debug": {
+        "request_note": "manual-note"
+      }
+    }
+  }'
+\`\`\`
+
+## Mailpit
+
+- UI: ${MAILPIT_BASE_URL}
+- API list: ${MAILPIT_BASE_URL}/api/v1/messages
+
+## Stop commands
+
+\`\`\`bash
+cd ${ROOT_DIR}
+bash test/system/subagents/infra-orchestrator.sh down ${ENV_REPORT_FILE}
+if [[ -f ${FRONTEND_PID_FILE} ]]; then kill "\$(cat ${FRONTEND_PID_FILE})"; fi
+\`\`\`
+EOF
+}
+
+main() {
+  bash "$ROOT_DIR/test/system/subagents/infra-orchestrator.sh" up "$ENV_REPORT_FILE"
+  load_env_report
+
+  systemtest keycloak-seed \
+    --base-url "$KEYCLOAK_BASE_URL" \
+    --realm "$KEYCLOAK_REALM" \
+    --admin-user "$KEYCLOAK_ADMIN_USER" \
+    --admin-pass "$KEYCLOAK_ADMIN_PASS" \
+    --users "${NO_MEMBER_EMAIL}:${NO_MEMBER_PASSWORD}" >/dev/null || true
+
+  systemtest seed-rbac \
+    --base-url "$SENDA_BASE_URL" \
+    --email "$SUPERADMIN_EMAIL" \
+    --secret "$SENDA_E2E_JWT_SECRET" \
+    --tenant-code "$TENANT_CODE" \
+    --tenant-name "$TENANT_NAME" \
+    --workspace-code "$WORKSPACE_CODE" \
+    --workspace-name "$WORKSPACE_NAME" \
+    --superadmin-email "$SUPERADMIN_EMAIL" \
+    --tenant-admin-email "$TENANT_ADMIN_EMAIL" \
+    --workspace-admin-email "$WORKSPACE_ADMIN_EMAIL" \
+    --workspace-editor-email "$WORKSPACE_EDITOR_EMAIL" \
+    --workspace-viewer-email "$WORKSPACE_VIEWER_EMAIL" \
+    --no-member-email "$NO_MEMBER_EMAIL" >/dev/null
+
+  start_managed_frontend "$FRONTEND_PID_FILE" "$FRONTEND_LOG_FILE" "local-code-injector-demo"
+
+  ensure_runtime_env
+  ensure_student_injector_fixture
+
+  local ui_ids runtime_ids
+  ui_ids="$(ensure_template_fixture "$TEMPLATE_TYPE_SLUG" "$TEMPLATE_TYPE_NAME" "$(ui_template_subject)" "Demo {{ injector.brand.company_name }}" "UI demo for code injectors" "$(ui_template_body)")"
+  runtime_ids="$(ensure_template_fixture "$RUNTIME_TEMPLATE_TYPE_SLUG" "$RUNTIME_TEMPLATE_TYPE_NAME" "$(runtime_template_subject)" "Runtime {{ injector.student.name }}" "Runtime-only code injector demo" "$(runtime_template_body)")"
+
+  read -r _ UI_TEMPLATE_ID UI_TEMPLATE_VERSION_ID <<<"$ui_ids"
+  read -r _ RUNTIME_TEMPLATE_ID RUNTIME_TEMPLATE_VERSION_ID <<<"$runtime_ids"
+
+  write_summary "$UI_TEMPLATE_ID" "$UI_TEMPLATE_VERSION_ID" "$RUNTIME_TEMPLATE_TYPE_SLUG" "$RUNTIME_TEMPLATE_ID" "$RUNTIME_TEMPLATE_VERSION_ID"
+
+  printf 'artifact_dir=%s\n' "$ARTIFACT_DIR"
+  printf 'summary=%s\n' "$SUMMARY_PATH"
+  printf 'frontend=%s\n' "$FRONTEND_BASE_URL"
+  printf 'api=%s\n' "$SENDA_BASE_URL"
+  printf 'mailpit=%s\n' "$MAILPIT_BASE_URL"
+}
+
+main "$@"

--- a/sdk/engine.go
+++ b/sdk/engine.go
@@ -12,13 +12,14 @@ import (
 	"github.com/rendis/senda/config"
 	"github.com/rendis/senda/internal/app"
 	"github.com/rendis/senda/internal/metrics"
+	"github.com/rendis/senda/internal/port"
 )
 
 // Engine is the main entry point for running Senda as a library.
 // Create one with New or NewWithConfig, register extensions, then call Run.
 type Engine struct {
 	configPath                 string
-	injectors                  []Injector
+	injectors                  []InjectorRegistration
 	initFunc                   InitFunc
 	externalAuthMethods        []ExternalAuthMethod
 	externalWorkspaceResolvers []ExternalWorkspaceResolver
@@ -36,9 +37,12 @@ func NewWithConfig(configPath string) *Engine {
 	return &Engine{configPath: configPath}
 }
 
-// RegisterInjector adds a custom code injector. Each must have a unique Code().
-func (e *Engine) RegisterInjector(inj Injector) *Engine {
-	e.injectors = append(e.injectors, inj)
+// RegisterInjector adds a custom injector registration. Static registrations
+// are catalogable and read-only in the UI; dynamic registrations remain
+// runtime-only.
+func (e *Engine) RegisterInjector(reg InjectorRegistration) *Engine {
+	validateInjectorRegistration(reg)
+	e.injectors = append(e.injectors, reg)
 	return e
 }
 
@@ -140,11 +144,58 @@ func (e *Engine) buildExtensions() *app.Extensions {
 	if len(e.injectors) == 0 && e.initFunc == nil && len(e.externalAuthMethods) == 0 && len(e.externalWorkspaceResolvers) == 0 {
 		return nil
 	}
+	injectors := make([]port.CodeInjector, 0, len(e.injectors))
+	for _, reg := range e.injectors {
+		injectors = append(injectors, registeredInjector{registration: reg})
+	}
 	return &app.Extensions{
-		Injectors:                  e.injectors,
+		Injectors:                  injectors,
 		InitFunc:                   e.initFunc,
 		ExternalAuthMethods:        e.externalAuthMethods,
 		ExternalWorkspaceResolvers: e.externalWorkspaceResolvers,
+	}
+}
+
+type registeredInjector struct {
+	registration InjectorRegistration
+}
+
+func (r registeredInjector) displayName() string {
+	if r.registration.Name != "" {
+		return r.registration.Name
+	}
+	return r.registration.Code
+}
+func (r registeredInjector) Code() string { return r.registration.Code }
+
+func (r registeredInjector) Resolve() (port.CodeResolveFunc, []string) {
+	return r.registration.Resolve, r.registration.Dependencies
+}
+
+func (r registeredInjector) IsCritical() bool { return r.registration.Critical }
+
+func (r registeredInjector) Timeout() time.Duration { return r.registration.Timeout }
+
+func (r registeredInjector) Catalog() port.InjectorCatalog {
+	return port.InjectorCatalog{
+		Code:        r.registration.Code,
+		Name:        r.displayName(),
+		Description: r.registration.Description,
+		Static:      r.registration.Static,
+		TTL:         r.registration.TTL,
+		Fields:      r.registration.Fields,
+	}
+}
+
+func validateInjectorRegistration(reg InjectorRegistration) {
+	if reg.Code == "" {
+		panic("sdk: injector registration requires Code")
+	}
+	if reg.Resolve == nil {
+		panic("sdk: injector registration requires Resolve")
+	}
+	if reg.Static && len(reg.Fields) == 0 {
+		panic("sdk: static injector registration requires at least one field")
 	}
 }
 

--- a/sdk/external_extensions_test.go
+++ b/sdk/external_extensions_test.go
@@ -3,7 +3,6 @@ package sdk
 import (
 	"context"
 	"testing"
-	"time"
 )
 
 type testExternalAuthMethod struct {
@@ -85,7 +84,7 @@ func TestEngineBuildExtensions_NoExternalRegistrations(t *testing.T) {
 
 func TestEngineExternalRegistration_DoesNotAffectExistingInjectorAPIs(t *testing.T) {
 	engine := New()
-	engine.RegisterInjector(&dummyInjector{}).RegisterExternalAuthMethod(&testExternalAuthMethod{name: "auth", description: "desc"})
+	engine.RegisterInjector(dummyRegistration()).RegisterExternalAuthMethod(&testExternalAuthMethod{name: "auth", description: "desc"})
 
 	ext := engine.buildExtensions()
 	if ext == nil {
@@ -99,13 +98,48 @@ func TestEngineExternalRegistration_DoesNotAffectExistingInjectorAPIs(t *testing
 	}
 }
 
-type dummyInjector struct{}
+func TestEngineRegisterInjector_StaticRequiresFields(t *testing.T) {
+	engine := New()
 
-func (d *dummyInjector) Code() string { return "dummy" }
-func (d *dummyInjector) Resolve() (ResolveFunc, []string) {
-	return func(context.Context, *InjectorContext) (map[string]any, error) {
-		return map[string]any{"ok": true}, nil
-	}, nil
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for static injector without fields")
+		}
+	}()
+
+	engine.RegisterInjector(InjectorRegistration{
+		Code:   "school",
+		Static: true,
+		Resolve: func(context.Context, *InjectorContext) (map[string]any, error) {
+			return map[string]any{"name": "Acme School"}, nil
+		},
+	})
 }
-func (d *dummyInjector) IsCritical() bool       { return false }
-func (d *dummyInjector) Timeout() time.Duration { return time.Second }
+
+func TestEngineRegisterInjector_DynamicRegistrationUsesCodeNamespace(t *testing.T) {
+	engine := New()
+	engine.RegisterInjector(InjectorRegistration{
+		Code: "runtime_student",
+		Name: "Runtime Student",
+		Resolve: func(context.Context, *InjectorContext) (map[string]any, error) {
+			return map[string]any{"ok": true}, nil
+		},
+	})
+
+	ext := engine.buildExtensions()
+	if ext == nil || len(ext.Injectors) != 1 {
+		t.Fatal("expected one registered injector")
+	}
+	if got := ext.Injectors[0].Code(); got != "runtime_student" {
+		t.Fatalf("expected code namespace runtime_student, got %q", got)
+	}
+}
+
+func dummyRegistration() InjectorRegistration {
+	return InjectorRegistration{
+		Code: "dummy",
+		Resolve: func(context.Context, *InjectorContext) (map[string]any, error) {
+			return map[string]any{"ok": true}, nil
+		},
+	}
+}

--- a/sdk/interfaces.go
+++ b/sdk/interfaces.go
@@ -1,17 +1,45 @@
 package sdk
 
-import "github.com/rendis/senda/internal/port"
+import (
+	"time"
 
-// Injector is the interface users implement to provide custom injectable
-// values. Resolved fields merge with DB injectors and become available
-// in templates as {{ injector.CODE.field }}.
-//
-// See port.CodeInjector for the full method contract.
-type Injector = port.CodeInjector
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/port"
+)
+
+// InjectorFieldType is the public field type enum for injector catalog fields.
+type InjectorFieldType = domain.InjectorFieldType
+
+const (
+	FieldTypeText   = domain.FieldTypeText
+	FieldTypeNumber = domain.FieldTypeNumber
+	FieldTypeBool   = domain.FieldTypeBool
+	FieldTypeImg    = domain.FieldTypeImg
+	FieldTypeURL    = domain.FieldTypeURL
+	FieldTypeHTML   = domain.FieldTypeHTML
+)
 
 // ResolveFunc executes injector logic and returns field-name → value pairs.
 // See port.CodeResolveFunc for the full signature.
 type ResolveFunc = port.CodeResolveFunc
+
+// InjectorFieldSpec describes one field exposed by a catalogable injector.
+type InjectorFieldSpec = port.InjectorFieldSpec
+
+// InjectorRegistration is the single public registration contract for
+// injectors. Static registrations are catalogable and read-only in the UI.
+type InjectorRegistration struct {
+	Code         string
+	Name         string
+	Description  string
+	Static       bool
+	TTL          time.Duration
+	Fields       []InjectorFieldSpec
+	Resolve      ResolveFunc
+	Dependencies []string
+	Critical     bool
+	Timeout      time.Duration
+}
 
 // InitFunc runs once per send request before code injectors.
 // See port.CodeInitFunc for the full signature.

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -9,47 +9,44 @@ import (
 	"github.com/rendis/senda/sdk"
 )
 
-// testInjector is a minimal Injector implementation for compile verification.
-type testInjector struct{}
-
-func (t *testInjector) Code() string { return "test_inj" }
-func (t *testInjector) Resolve() (sdk.ResolveFunc, []string) {
-	return func(ctx context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
-		return map[string]any{
-			"greeting": "Hello from code injector!",
-			"source":   injCtx.Header("X-Source"),
-		}, nil
-	}, nil
+func testInjectorRegistration() sdk.InjectorRegistration {
+	return sdk.InjectorRegistration{
+		Code: "test_inj",
+		Resolve: func(_ context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
+			return map[string]any{
+				"greeting": "Hello from code injector!",
+				"source":   injCtx.Header("X-Source"),
+			}, nil
+		},
+		Timeout: 5 * time.Second,
+	}
 }
-func (t *testInjector) IsCritical() bool        { return false }
-func (t *testInjector) Timeout() time.Duration   { return 5 * time.Second }
 
-// testDependentInjector depends on testInjector.
-type testDependentInjector struct{}
-
-func (t *testDependentInjector) Code() string { return "dependent" }
-func (t *testDependentInjector) Resolve() (sdk.ResolveFunc, []string) {
-	return func(ctx context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
-		parent, _ := injCtx.GetResolved("test_inj")
-		greeting := ""
-		if parent != nil {
-			if g, ok := parent["greeting"].(string); ok {
-				greeting = g
+func dependentInjectorRegistration() sdk.InjectorRegistration {
+	return sdk.InjectorRegistration{
+		Code: "dependent",
+		Resolve: func(_ context.Context, injCtx *sdk.InjectorContext) (map[string]any, error) {
+			parent, _ := injCtx.GetResolved("test_inj")
+			greeting := ""
+			if parent != nil {
+				if g, ok := parent["greeting"].(string); ok {
+					greeting = g
+				}
 			}
-		}
-		return map[string]any{
-			"derived": greeting + " (extended)",
-		}, nil
-	}, []string{"test_inj"}
+			return map[string]any{
+				"derived": greeting + " (extended)",
+			}, nil
+		},
+		Dependencies: []string{"test_inj"},
+		Critical:     true,
+	}
 }
-func (t *testDependentInjector) IsCritical() bool        { return true }
-func (t *testDependentInjector) Timeout() time.Duration   { return 0 }
 
 func TestEngineRegistration(t *testing.T) {
 	engine := sdk.New()
 
-	engine.RegisterInjector(&testInjector{})
-	engine.RegisterInjector(&testDependentInjector{})
+	engine.RegisterInjector(testInjectorRegistration())
+	engine.RegisterInjector(dependentInjectorRegistration())
 
 	engine.SetInitFunc(func(ctx context.Context, injCtx *sdk.InjectorContext) (any, error) {
 		return map[string]string{"loaded": "true"}, nil
@@ -79,9 +76,8 @@ func TestEngineRegistration(t *testing.T) {
 func TestEngineFluentAPI(t *testing.T) {
 	engine := sdk.New()
 
-	// Every method should return the same *Engine for chaining.
 	got := engine.
-		RegisterInjector(&testInjector{}).
+		RegisterInjector(testInjectorRegistration()).
 		SetInitFunc(func(_ context.Context, _ *sdk.InjectorContext) (any, error) { return nil, nil }).
 		OnStart(func(_ context.Context) error { return nil }).
 		OnShutdown(func(_ context.Context) error { return nil })
@@ -94,7 +90,6 @@ func TestEngineFluentAPI(t *testing.T) {
 func TestInjectorContext_NilHeaders(t *testing.T) {
 	ctx := sdk.NewInjectorContext(nil, "", nil, [16]byte{}, [16]byte{}, domain.EnvironmentProd, "")
 
-	// Should not panic.
 	if got := ctx.Header("X-Anything"); got != "" {
 		t.Errorf("Header on nil headers = %q, want empty", got)
 	}
@@ -109,12 +104,10 @@ func TestInjectorContext_HeadersCopy(t *testing.T) {
 	original := map[string]string{"Key": "value"}
 	ctx := sdk.NewInjectorContext(original, "", nil, [16]byte{}, [16]byte{}, domain.EnvironmentProd, "")
 
-	// Modify the returned copy.
 	copy := ctx.Headers()
 	copy["Key"] = "mutated"
 	copy["New"] = "injected"
 
-	// Original should be unchanged.
 	if ctx.Header("Key") != "value" {
 		t.Error("Headers() should return a copy, not a reference")
 	}
@@ -135,7 +128,7 @@ func TestInjectorContext_Concurrency(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ctx.GetResolved("writer")
 		_ = ctx.InitData()
 		_ = ctx.AllResolved()
@@ -173,23 +166,19 @@ func TestInjectorContext(t *testing.T) {
 		t.Errorf("Environment() = %q, want %q", got, domain.EnvironmentProd)
 	}
 
-	// InitData starts nil.
 	if ctx.InitData() != nil {
 		t.Error("InitData() should be nil initially")
 	}
 
-	// Set and retrieve init data.
 	ctx.SetInitData("my-data")
 	if ctx.InitData() != "my-data" {
 		t.Errorf("InitData() = %v, want %q", ctx.InitData(), "my-data")
 	}
 
-	// Resolved starts empty.
 	if _, ok := ctx.GetResolved("test"); ok {
 		t.Error("GetResolved should return false for unset code")
 	}
 
-	// Set and retrieve resolved.
 	ctx.SetResolved("brand", map[string]any{"name": "Acme"})
 	fields, ok := ctx.GetResolved("brand")
 	if !ok {
@@ -199,7 +188,6 @@ func TestInjectorContext(t *testing.T) {
 		t.Errorf("GetResolved(brand)[name] = %v, want %q", fields["name"], "Acme")
 	}
 
-	// MergeDBInjectors.
 	ctx.MergeDBInjectors(map[string]map[string]any{
 		"company": {"logo": "https://logo.png"},
 	})

--- a/test/system/subagents/ui-injector-flow-tester.sh
+++ b/test/system/subagents/ui-injector-flow-tester.sh
@@ -230,6 +230,14 @@ assert_visible() {
   fi
 }
 
+assert_not_present() {
+  local selector="$1"
+  if ! ab_json eval "(() => document.querySelector('${selector}') === null)()" | jq -e '.data.result == true' >/dev/null; then
+    echo "expected ${selector} to be absent" >&2
+    return 1
+  fi
+}
+
 click_selector() {
   local selector="$1"
   if ! ab_json eval "(() => {
@@ -535,9 +543,8 @@ verify_injector_builder_and_test_send() {
   ab wait --text "Send Test Email" >/dev/null
 
   assert_input_value "[data-testid=\"test-send-field-${INJECTOR_NAME}-name\"]" "Default Student"
-  assert_input_value "[data-testid=\"test-send-field-${INJECTOR_NAME}-locked\"]" "LOCKED-DEFAULT"
   assert_input_value "[data-testid=\"test-send-field-${INJECTOR_NAME}-status\"]" "DEFAULT-STATUS"
-  assert_input_disabled "[data-testid=\"test-send-field-${INJECTOR_NAME}-locked\"]"
+  assert_not_present "[data-testid=\"test-send-field-${INJECTOR_NAME}-locked\"]"
   ab screenshot "$SCREENSHOT_DIR/test-send-modal-defaults.png" >/dev/null
 
   mailpit_clear
@@ -649,7 +656,7 @@ cat >"$REPORT_PATH" <<EOF_MD
 - Workspace admin can create the injector catalog from the UI.
 - Locked fields block creation until a non-empty default is provided.
 - The template editor exposes workspace injector tokens in the builder.
-- Test Send recognizes injector fields, keeps locked fields read-only, and resolves default/code/request precedence correctly.
+- Test Send recognizes only overwriteable injector fields, hides locked/static fields, and resolves default/code/request precedence correctly.
 - Bulk Send accepts per-item injector overrides from UI-uploaded JSON and renders each item with the expected precedence.
 - Mailpit confirms rendered content for the default, partial override, explicit empty override, and bulk-send scenarios.
 EOF_MD

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -203,7 +203,8 @@
       "forkedFromDefault": "Forked from Default",
       "readOnly": "Read-only",
       "workspace": "Workspace",
-      "global": "Global"
+      "global": "Global",
+      "code": "Code"
     }
   },
   "scopeIndicator": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -203,7 +203,8 @@
       "forkedFromDefault": "Fork derivado del default",
       "readOnly": "Solo lectura",
       "workspace": "Workspace",
-      "global": "Global"
+      "global": "Global",
+      "code": "Code"
     }
   },
   "scopeIndicator": {

--- a/web/src/components/shared/resource-state-badges.tsx
+++ b/web/src/components/shared/resource-state-badges.tsx
@@ -19,6 +19,8 @@ const badgeClassByKey: Record<ResourceStateBadge, string> = {
     "border-slate-500/30 bg-slate-500/10 text-slate-700 dark:text-slate-300",
   global:
     "border-zinc-500/30 bg-zinc-500/10 text-zinc-700 dark:text-zinc-300",
+  code:
+    "border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
 };
 
 export function ResourceStateBadges({

--- a/web/src/components/templates/injector-variable-presentation.test.ts
+++ b/web/src/components/templates/injector-variable-presentation.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  buildInjectorTooltipSections,
+  injectorFieldTypeIconName,
+  injectorFieldTypeLabel,
+} = await import(new URL("./injector-variable-presentation.ts", import.meta.url).href);
+
+test("injectorFieldTypeLabel returns user-facing labels", () => {
+  assert.equal(injectorFieldTypeLabel("text"), "Text");
+  assert.equal(injectorFieldTypeLabel("number"), "Number");
+  assert.equal(injectorFieldTypeLabel("bool"), "Boolean");
+  assert.equal(injectorFieldTypeLabel("img"), "Image");
+  assert.equal(injectorFieldTypeLabel("url"), "URL");
+  assert.equal(injectorFieldTypeLabel("html"), "HTML");
+});
+
+test("injectorFieldTypeIconName maps field types to stable icon names", () => {
+  assert.equal(injectorFieldTypeIconName("text"), "type");
+  assert.equal(injectorFieldTypeIconName("number"), "hash");
+  assert.equal(injectorFieldTypeIconName("bool"), "toggle-right");
+  assert.equal(injectorFieldTypeIconName("img"), "image");
+  assert.equal(injectorFieldTypeIconName("url"), "link");
+  assert.equal(injectorFieldTypeIconName("html"), "code-2");
+});
+
+test("buildInjectorTooltipSections exposes descriptive metadata for builder tooltips", () => {
+  assert.deepEqual(
+    buildInjectorTooltipSections({
+      fullLabel: "brand.company_name",
+      fieldLabel: "company_name",
+      fieldType: "text",
+      fieldDescription: "Brand/company display name",
+      injectorDescription:
+        "Static brand assets and legal/footer content for the active workspace.",
+      static: true,
+      inheritedFromSystem: true,
+      source: "code",
+    }),
+    {
+      name: "brand.company_name",
+      description: "Brand/company display name",
+      injectorDescription:
+        "Static brand assets and legal/footer content for the active workspace.",
+      details: [
+        { label: "Static", value: "Yes" },
+        { label: "Type", value: "Text" },
+        { label: "Inherited", value: "Yes" },
+        { label: "Source", value: "Code" },
+      ],
+    },
+  );
+});

--- a/web/src/components/templates/injector-variable-presentation.ts
+++ b/web/src/components/templates/injector-variable-presentation.ts
@@ -1,0 +1,91 @@
+import type { OwnerScope } from "@/types/api";
+import type { InjectorFieldType } from "@/types/injectors";
+
+export type BuilderInjectorVariablePresentation = {
+  fullLabel: string;
+  fieldLabel: string;
+  fieldType: InjectorFieldType;
+  fieldDescription?: string;
+  injectorDescription?: string;
+  static?: boolean;
+  inheritedFromSystem?: boolean;
+  ownerScope?: OwnerScope;
+  source?: "database" | "code";
+};
+
+export function injectorFieldTypeLabel(fieldType: InjectorFieldType): string {
+  switch (fieldType) {
+    case "bool":
+      return "Boolean";
+    case "img":
+      return "Image";
+    case "url":
+      return "URL";
+    case "html":
+      return "HTML";
+    case "number":
+      return "Number";
+    default:
+      return "Text";
+  }
+}
+
+export function builderInjectorStaticLabel(isStatic: boolean): string {
+  return isStatic ? "Yes" : "No";
+}
+
+export function builderInjectorInheritedLabel(isInherited: boolean): string {
+  return isInherited ? "Yes" : "No";
+}
+
+export function builderInjectorSourceLabel(source?: "database" | "code"): string {
+  if (source === "code") {
+    return "Code";
+  }
+  return "Database";
+}
+
+export function buildInjectorTooltipSections(
+  variable: BuilderInjectorVariablePresentation,
+) {
+  return {
+    name: variable.fullLabel,
+    description: variable.fieldDescription?.trim() || undefined,
+    injectorDescription: variable.injectorDescription?.trim() || undefined,
+    details: [
+      {
+        label: "Static",
+        value: builderInjectorStaticLabel(Boolean(variable.static)),
+      },
+      {
+        label: "Type",
+        value: injectorFieldTypeLabel(variable.fieldType),
+      },
+      {
+        label: "Inherited",
+        value: builderInjectorInheritedLabel(Boolean(variable.inheritedFromSystem)),
+      },
+      {
+        label: "Source",
+        value: builderInjectorSourceLabel(variable.source),
+      },
+    ],
+  };
+}
+
+export function injectorFieldTypeIconName(fieldType: InjectorFieldType): string {
+  switch (fieldType) {
+    case "number":
+      return "hash";
+    case "bool":
+      return "toggle-right";
+    case "img":
+      return "image";
+    case "url":
+      return "link";
+    case "html":
+      return "code-2";
+    default:
+      return "type";
+  }
+}

--- a/web/src/components/templates/metadata-token-input-styles.test.ts
+++ b/web/src/components/templates/metadata-token-input-styles.test.ts
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { METADATA_TOKEN_INPUT_EDITOR_CLASSNAME } = await import(
+  new URL("./metadata-token-input-styles.ts", import.meta.url).href
+);
+
+test("metadata token input wraps chip content instead of forcing horizontal scroll", () => {
+  assert.match(METADATA_TOKEN_INPUT_EDITOR_CLASSNAME, /whitespace-pre-wrap/);
+  assert.doesNotMatch(METADATA_TOKEN_INPUT_EDITOR_CLASSNAME, /overflow-x-auto/);
+  assert.doesNotMatch(METADATA_TOKEN_INPUT_EDITOR_CLASSNAME, /whitespace-nowrap/);
+});

--- a/web/src/components/templates/metadata-token-input-styles.ts
+++ b/web/src/components/templates/metadata-token-input-styles.ts
@@ -1,0 +1,2 @@
+export const METADATA_TOKEN_INPUT_EDITOR_CLASSNAME =
+  "min-h-5 min-w-0 w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere] text-sm outline-none empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground";

--- a/web/src/components/templates/metadata-token-input.tsx
+++ b/web/src/components/templates/metadata-token-input.tsx
@@ -1,0 +1,794 @@
+"use client";
+
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+} from "react";
+import { cn } from "@/lib/utils";
+import { METADATA_TOKEN_INPUT_EDITOR_CLASSNAME } from "./metadata-token-input-styles";
+import type {
+  TemplateTokenSegment,
+  TokenCategory,
+} from "./template-token-segments";
+import {
+  createTextSegment,
+  createTokenSegment,
+  ensureUniqueSegmentIds,
+  getTokenChipClassName,
+  getTokenChipText,
+  guessSegmentCategory,
+  mergeAdjacentTextSegments,
+  normalizeVariableToken,
+  parseTextChunkToSegments,
+  renderSegmentsToText,
+} from "./template-token-segments";
+
+const VARIABLE_DND_MIME = "application/x-senda-variable";
+const CLIPBOARD_SEGMENTS_MIME = "application/x-senda-segments";
+const MIME_TEXT_PLAIN = "text/plain";
+const TOKEN_SEGMENT_KIND = "token";
+
+type InsertVariablePayload = {
+  token: string;
+  label: string;
+  category: TokenCategory;
+};
+
+export interface MetadataTokenInputHandle {
+  insertVariable: (attrs: InsertVariablePayload) => void;
+}
+
+interface MetadataTokenInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onFocus?: () => void;
+  disabled?: boolean;
+  placeholder?: string;
+  ariaLabel: string;
+  ariaInvalid?: boolean;
+  describedBy?: string;
+  resolveTokenMeta?: (token: string) => {
+    label?: string;
+    static?: boolean;
+    source?: "database" | "code";
+  } | undefined;
+  className?: string;
+}
+
+function isTokenChipNode(node: Node): node is HTMLElement {
+  return (
+    node.nodeType === Node.ELEMENT_NODE &&
+    (node as HTMLElement).dataset.segmentKind === TOKEN_SEGMENT_KIND
+  );
+}
+
+function countSegmentUnits(segment: TemplateTokenSegment) {
+  if (segment.kind === "token") return 1;
+  return segment.text.length;
+}
+
+function countSegmentsUnits(segments: TemplateTokenSegment[]) {
+  return segments.reduce((total, segment) => total + countSegmentUnits(segment), 0);
+}
+
+function countUnitsInDomNode(node: Node): number {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent?.length ?? 0;
+  }
+
+  if (isTokenChipNode(node)) {
+    return 1;
+  }
+
+  let total = 0;
+  node.childNodes.forEach((child) => {
+    total += countUnitsInDomNode(child);
+  });
+  return total;
+}
+
+function getSelectionInsideEditor(editor: HTMLElement) {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return null;
+  }
+  const range = selection.getRangeAt(0);
+  if (!editor.contains(range.commonAncestorContainer)) {
+    return null;
+  }
+  return selection;
+}
+
+function getPointUnitOffset(editor: HTMLElement, container: Node, offset: number): number {
+  if (!editor.contains(container)) {
+    return countUnitsInDomNode(editor);
+  }
+  const range = editor.ownerDocument.createRange();
+  range.selectNodeContents(editor);
+  try {
+    range.setEnd(container, offset);
+  } catch {
+    return countUnitsInDomNode(editor);
+  }
+  const fragment = range.cloneContents();
+  return countUnitsInDomNode(fragment);
+}
+
+function getSelectionUnitRange(editor: HTMLElement) {
+  const selection = getSelectionInsideEditor(editor);
+  const end = countUnitsInDomNode(editor);
+  if (!selection || selection.rangeCount === 0) {
+    return { start: end, end };
+  }
+  const range = selection.getRangeAt(0);
+  const start = getPointUnitOffset(editor, range.startContainer, range.startOffset);
+  const finish = getPointUnitOffset(editor, range.endContainer, range.endOffset);
+  return start <= finish ? { start, end: finish } : { start: finish, end: start };
+}
+
+function resolveCaretDomPoint(editor: HTMLElement, unitOffset: number) {
+  const totalUnits = countUnitsInDomNode(editor);
+  let remaining = Math.max(0, Math.min(unitOffset, totalUnits));
+
+  function walk(node: Node): { container: Node; offset: number } | null {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent ?? "";
+      if (remaining <= text.length) {
+        return { container: node, offset: remaining };
+      }
+      remaining -= text.length;
+      return null;
+    }
+
+    if (isTokenChipNode(node)) {
+      const parent = node.parentNode;
+      if (!parent) return null;
+      const index = Array.prototype.indexOf.call(parent.childNodes, node);
+      if (remaining === 0) {
+        return { container: parent, offset: index };
+      }
+      remaining -= 1;
+      if (remaining === 0) {
+        return { container: parent, offset: index + 1 };
+      }
+      return null;
+    }
+
+    for (const child of Array.from(node.childNodes)) {
+      const point = walk(child);
+      if (point) return point;
+    }
+    return null;
+  }
+
+  const point = walk(editor);
+  if (point) return point;
+  return { container: editor, offset: editor.childNodes.length };
+}
+
+function setEditorCaretByUnitOffset(editor: HTMLElement, unitOffset: number) {
+  const selection = window.getSelection();
+  if (!selection) return;
+  const point = resolveCaretDomPoint(editor, unitOffset);
+  const range = editor.ownerDocument.createRange();
+  range.setStart(point.container, point.offset);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function placeEditorCaretAtEnd(editor: HTMLElement) {
+  const selection = window.getSelection();
+  if (!selection) return;
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function placeEditorCaretFromPoint(editor: HTMLElement, x: number, y: number) {
+  const doc = editor.ownerDocument;
+  let range: Range | null = null;
+  const docWithCaretRange = doc as Document & {
+    caretRangeFromPoint?: (clientX: number, clientY: number) => Range | null;
+  };
+
+  try {
+    if (typeof docWithCaretRange.caretRangeFromPoint === "function") {
+      range = docWithCaretRange.caretRangeFromPoint(x, y);
+    } else if (typeof doc.caretPositionFromPoint === "function") {
+      const position = doc.caretPositionFromPoint(x, y);
+      if (position) {
+        range = doc.createRange();
+        range.setStart(position.offsetNode, position.offset);
+        range.collapse(true);
+      }
+    }
+  } catch {
+    return false;
+  }
+
+  if (!range || !editor.contains(range.startContainer)) {
+    return false;
+  }
+
+  const selection = window.getSelection();
+  if (!selection) return false;
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return true;
+}
+
+function splitSegmentsAtUnitOffset(segments: TemplateTokenSegment[], unitOffset: number) {
+  const clamped = Math.max(0, Math.min(unitOffset, countSegmentsUnits(segments)));
+  let remaining = clamped;
+  const left: TemplateTokenSegment[] = [];
+  const right: TemplateTokenSegment[] = [];
+
+  for (const segment of segments) {
+    const segmentUnits = countSegmentUnits(segment);
+
+    if (remaining <= 0) {
+      right.push(segment);
+      continue;
+    }
+
+    if (remaining >= segmentUnits) {
+      left.push(segment);
+      remaining -= segmentUnits;
+      continue;
+    }
+
+    if (segment.kind === "text") {
+      const leftText = segment.text.slice(0, remaining);
+      const rightText = segment.text.slice(remaining);
+      if (leftText.length) {
+        left.push({ ...segment, text: leftText });
+      }
+      if (rightText.length) {
+        right.push(createTextSegment(rightText));
+      }
+      remaining = 0;
+      continue;
+    }
+
+    right.push(segment);
+    remaining = 0;
+  }
+
+  return { left, right };
+}
+
+function replaceSegmentsUnitRange(
+  segments: TemplateTokenSegment[],
+  start: number,
+  end: number,
+  inserted: TemplateTokenSegment[],
+) {
+  const total = countSegmentsUnits(segments);
+  const from = Math.max(0, Math.min(start, total));
+  const to = Math.max(from, Math.min(end, total));
+
+  const firstSplit = splitSegmentsAtUnitOffset(segments, from);
+  const secondSplit = splitSegmentsAtUnitOffset(firstSplit.right, to - from);
+  return ensureUniqueSegmentIds(
+    mergeAdjacentTextSegments([
+      ...firstSplit.left,
+      ...inserted,
+      ...secondSplit.right,
+    ]),
+  );
+}
+
+function sliceSegmentsByUnitRange(
+  segments: TemplateTokenSegment[],
+  start: number,
+  end: number,
+) {
+  const total = countSegmentsUnits(segments);
+  const from = Math.max(0, Math.min(start, total));
+  const to = Math.max(from, Math.min(end, total));
+  const firstSplit = splitSegmentsAtUnitOffset(segments, from);
+  const secondSplit = splitSegmentsAtUnitOffset(firstSplit.right, to - from);
+  return ensureUniqueSegmentIds(mergeAdjacentTextSegments(secondSplit.left));
+}
+
+function parseClipboardSegments(raw: string): TemplateTokenSegment[] | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as
+      | {
+          segments?: Array<{
+            kind?: unknown;
+            text?: unknown;
+            token?: unknown;
+            label?: unknown;
+            category?: unknown;
+          }>;
+        }
+      | null;
+    if (!parsed || !Array.isArray(parsed.segments)) {
+      return null;
+    }
+
+    const segments: TemplateTokenSegment[] = [];
+    for (const segment of parsed.segments) {
+      if (segment.kind === "text" && typeof segment.text === "string") {
+        segments.push(createTextSegment(segment.text));
+        continue;
+      }
+      if (segment.kind === "token" && typeof segment.token === "string") {
+        segments.push(
+          createTokenSegment(
+            segment.token,
+            segment.category === "injector" ? "injector" : "event",
+            typeof segment.label === "string" ? segment.label : segment.token,
+          ),
+        );
+      }
+    }
+    return segments.length ? mergeAdjacentTextSegments(segments) : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseSegmentsFromEditorNode(root: HTMLElement) {
+  const segments: TemplateTokenSegment[] = [];
+
+  function collect(nodes: NodeListOf<ChildNode> | ChildNode[]) {
+    for (const node of nodes) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        segments.push(
+          ...parseTextChunkToSegments((node.textContent ?? "").replace(/\s*\n+\s*/g, " ")),
+        );
+        continue;
+      }
+
+      if (node.nodeType !== Node.ELEMENT_NODE) {
+        continue;
+      }
+
+      const element = node as HTMLElement;
+      if (element.dataset.segmentKind === TOKEN_SEGMENT_KIND) {
+        const token = normalizeVariableToken(
+          element.dataset.token ?? element.textContent ?? "",
+        );
+        if (!token) {
+          continue;
+        }
+        segments.push({
+          kind: "token",
+          id: element.dataset.segmentId?.trim() || crypto.randomUUID(),
+          token,
+          label: element.dataset.label?.trim() || token,
+          category: element.dataset.category === "injector" ? "injector" : "event",
+        });
+        continue;
+      }
+
+      collect(element.childNodes);
+    }
+  }
+
+  collect(root.childNodes);
+  return ensureUniqueSegmentIds(mergeAdjacentTextSegments(segments));
+}
+
+function segmentsMeaningfullyEqual(a: TemplateTokenSegment[], b: TemplateTokenSegment[]) {
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index += 1) {
+    const left = a[index];
+    const right = b[index];
+    if (!left || !right || left.kind !== right.kind) return false;
+    if (left.kind === "text" && right.kind === "text" && left.text !== right.text) {
+      return false;
+    }
+    if (
+      left.kind === "token" &&
+      right.kind === "token" &&
+      (left.token !== right.token ||
+        left.label !== right.label ||
+        left.category !== right.category)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function renderSegmentsToEditorNode(
+  editor: HTMLElement,
+  segments: TemplateTokenSegment[],
+  resolveTokenMeta?: MetadataTokenInputProps["resolveTokenMeta"],
+) {
+  const doc = editor.ownerDocument;
+  const fragment = doc.createDocumentFragment();
+
+  for (const segment of segments) {
+    if (segment.kind === "text") {
+      if (!segment.text) continue;
+      fragment.appendChild(doc.createTextNode(segment.text));
+      continue;
+    }
+
+    const chip = doc.createElement("span");
+    const tokenMeta = resolveTokenMeta?.(segment.token);
+    const displayLabel = tokenMeta?.label?.trim()
+      ? tokenMeta.label
+      : getTokenChipText(segment);
+    const chipClassName =
+      tokenMeta?.source === "code"
+        ? "inline-flex max-w-full items-center rounded border border-dashed border-fuchsia-500 bg-fuchsia-50 px-1.5 py-0.5 text-xs align-middle select-none truncate text-fuchsia-700 dark:border-fuchsia-600 dark:bg-fuchsia-950 dark:text-fuchsia-300"
+        : getTokenChipClassName(segment.category);
+    chip.className = cn(
+      chipClassName,
+      tokenMeta?.static && "ring-1 ring-amber-500/60 ring-inset",
+    );
+    chip.contentEditable = "false";
+    chip.dataset.segmentKind = TOKEN_SEGMENT_KIND;
+    chip.dataset.segmentId = segment.id;
+    chip.dataset.token = segment.token;
+    chip.dataset.label = displayLabel;
+    chip.dataset.category = segment.category;
+    chip.textContent = displayLabel;
+    chip.title = [
+      segment.token,
+      tokenMeta?.static ? "static default" : null,
+      tokenMeta?.source === "code" ? "code injector" : null,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    fragment.appendChild(chip);
+  }
+
+  editor.replaceChildren(fragment);
+}
+
+function resolveVariableFromDrop(event: React.DragEvent<HTMLElement>): InsertVariablePayload | null {
+  const rawJson =
+    event.dataTransfer.getData(VARIABLE_DND_MIME) ||
+    event.dataTransfer.getData("application/json");
+  if (rawJson) {
+    try {
+      const parsed = JSON.parse(rawJson) as
+        | {
+            token?: unknown;
+            label?: unknown;
+            category?: unknown;
+          }
+        | null;
+
+      if (parsed && typeof parsed.token === "string" && parsed.token.trim()) {
+        const token = normalizeVariableToken(parsed.token);
+        return {
+          token,
+          label:
+            typeof parsed.label === "string" && parsed.label.trim()
+              ? parsed.label
+              : token,
+          category: parsed.category === "injector" ? "injector" : "event",
+        };
+      }
+    } catch {
+      // no-op
+    }
+  }
+
+  const token = normalizeVariableToken(event.dataTransfer.getData(MIME_TEXT_PLAIN));
+  if (!token || !token.includes(".")) return null;
+
+  return {
+    token,
+    label: token,
+    category: guessSegmentCategory(token),
+  };
+}
+
+function isVariableDragEvent(dataTransfer: DataTransfer) {
+  const types = Array.from(dataTransfer.types);
+  return (
+    types.includes(VARIABLE_DND_MIME) ||
+    types.includes("application/json") ||
+    types.includes(MIME_TEXT_PLAIN)
+  );
+}
+
+export const MetadataTokenInput = forwardRef<
+  MetadataTokenInputHandle,
+  MetadataTokenInputProps
+>(function MetadataTokenInput(
+  {
+    value,
+    onChange,
+    onFocus,
+    disabled = false,
+    placeholder,
+    ariaLabel,
+    ariaInvalid = false,
+    describedBy,
+    resolveTokenMeta,
+    className,
+  },
+  ref,
+) {
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  const pendingCaretRestoreRef = useRef<number | null>(null);
+
+  const applySegments = useCallback(
+    (segments: TemplateTokenSegment[], nextCaret?: number) => {
+      onChange(renderSegmentsToText(segments));
+      if (typeof nextCaret === "number") {
+        pendingCaretRestoreRef.current = nextCaret;
+      }
+    },
+    [onChange],
+  );
+
+  const insertVariable = useCallback(
+    (variable: InsertVariablePayload) => {
+      const editor = editorRef.current;
+      if (!editor || disabled) return;
+      editor.focus();
+      const tokenSegment = createTokenSegment(variable.token, variable.category, variable.label);
+      const liveSegments = parseSegmentsFromEditorNode(editor);
+      const selection = getSelectionUnitRange(editor);
+      const nextSegments = replaceSegmentsUnitRange(
+        liveSegments,
+        selection.start,
+        selection.end,
+        [tokenSegment],
+      );
+      applySegments(nextSegments, selection.start + 1);
+    },
+    [applySegments, disabled],
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      insertVariable,
+    }),
+    [insertVariable],
+  );
+
+  useLayoutEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      pendingCaretRestoreRef.current = null;
+      return;
+    }
+    const nextSegments = parseTextChunkToSegments(value.replace(/\s*\n+\s*/g, " "));
+    const normalizedNext =
+      nextSegments.length > 0
+        ? ensureUniqueSegmentIds(mergeAdjacentTextSegments(nextSegments))
+        : [createTextSegment("")];
+    const liveSegments = parseSegmentsFromEditorNode(editor);
+    if (!segmentsMeaningfullyEqual(liveSegments, normalizedNext)) {
+      renderSegmentsToEditorNode(editor, normalizedNext, resolveTokenMeta);
+    }
+    const pendingCaret = pendingCaretRestoreRef.current;
+    if (typeof pendingCaret === "number") {
+      setEditorCaretByUnitOffset(editor, pendingCaret);
+      pendingCaretRestoreRef.current = null;
+    }
+  }, [resolveTokenMeta, value]);
+
+  return (
+    <div
+      className={cn(
+        "min-w-0 rounded-md border border-input bg-background px-2 py-1.5 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+        disabled && "cursor-not-allowed opacity-70",
+        className,
+      )}
+    >
+      <div
+        ref={editorRef}
+        role="textbox"
+        aria-label={ariaLabel}
+        aria-multiline="false"
+        aria-invalid={ariaInvalid || undefined}
+        aria-describedby={describedBy}
+        contentEditable={!disabled}
+        suppressContentEditableWarning
+        className={METADATA_TOKEN_INPUT_EDITOR_CLASSNAME}
+        data-placeholder={placeholder}
+        onFocus={() => onFocus?.()}
+        onInput={(event) => {
+          const segments = parseSegmentsFromEditorNode(event.currentTarget);
+          applySegments(segments);
+        }}
+        onClick={(event) => {
+          const target = event.target as HTMLElement | null;
+          if (!target || target.dataset.segmentKind !== TOKEN_SEGMENT_KIND) {
+            return;
+          }
+          const selection = window.getSelection();
+          if (!selection) return;
+          const range = document.createRange();
+          range.selectNode(target);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }}
+        onKeyDown={(event) => {
+          if (disabled) return;
+          if (event.key === "Enter") {
+            event.preventDefault();
+            return;
+          }
+          if (event.key !== "Backspace" && event.key !== "Delete") {
+            return;
+          }
+
+          const editor = event.currentTarget;
+          const liveSegments = parseSegmentsFromEditorNode(editor);
+          const selectionRange = getSelectionUnitRange(editor);
+          const totalUnits = countSegmentsUnits(liveSegments);
+          const hasSelection = selectionRange.start !== selectionRange.end;
+
+          let deleteStart = selectionRange.start;
+          let deleteEnd = selectionRange.end;
+
+          if (!hasSelection) {
+            if (event.key === "Backspace") {
+              if (selectionRange.start <= 0) return;
+              deleteStart = selectionRange.start - 1;
+              deleteEnd = selectionRange.start;
+            } else {
+              if (selectionRange.start >= totalUnits) return;
+              deleteStart = selectionRange.start;
+              deleteEnd = selectionRange.start + 1;
+            }
+          }
+
+          if (deleteStart === deleteEnd) {
+            return;
+          }
+
+          event.preventDefault();
+          const nextSegments = replaceSegmentsUnitRange(
+            liveSegments,
+            deleteStart,
+            deleteEnd,
+            [],
+          );
+          applySegments(nextSegments, deleteStart);
+        }}
+        onCopy={(event) => {
+          const editor = event.currentTarget;
+          const liveSegments = parseSegmentsFromEditorNode(editor);
+          const selectionRange = getSelectionUnitRange(editor);
+          if (selectionRange.start === selectionRange.end) {
+            return;
+          }
+          const copiedSegments = sliceSegmentsByUnitRange(
+            liveSegments,
+            selectionRange.start,
+            selectionRange.end,
+          );
+          const plain = renderSegmentsToText(copiedSegments);
+
+          event.preventDefault();
+          event.clipboardData.setData(MIME_TEXT_PLAIN, plain);
+          event.clipboardData.setData(
+            CLIPBOARD_SEGMENTS_MIME,
+            JSON.stringify({
+              segments: copiedSegments.map((segment) =>
+                segment.kind === "text"
+                  ? { kind: "text", text: segment.text }
+                  : {
+                      kind: "token",
+                      token: segment.token,
+                      label: segment.label,
+                      category: segment.category,
+                    },
+              ),
+            }),
+          );
+        }}
+        onCut={(event) => {
+          if (disabled) return;
+          const editor = event.currentTarget;
+          const liveSegments = parseSegmentsFromEditorNode(editor);
+          const selectionRange = getSelectionUnitRange(editor);
+          if (selectionRange.start === selectionRange.end) {
+            return;
+          }
+          const copiedSegments = sliceSegmentsByUnitRange(
+            liveSegments,
+            selectionRange.start,
+            selectionRange.end,
+          );
+          const plain = renderSegmentsToText(copiedSegments);
+
+          event.preventDefault();
+          event.clipboardData.setData(MIME_TEXT_PLAIN, plain);
+          event.clipboardData.setData(
+            CLIPBOARD_SEGMENTS_MIME,
+            JSON.stringify({
+              segments: copiedSegments.map((segment) =>
+                segment.kind === "text"
+                  ? { kind: "text", text: segment.text }
+                  : {
+                      kind: "token",
+                      token: segment.token,
+                      label: segment.label,
+                      category: segment.category,
+                    },
+              ),
+            }),
+          );
+          const nextSegments = replaceSegmentsUnitRange(
+            liveSegments,
+            selectionRange.start,
+            selectionRange.end,
+            [],
+          );
+          applySegments(nextSegments, selectionRange.start);
+        }}
+        onPaste={(event) => {
+          if (disabled) return;
+          const editor = event.currentTarget;
+          const clipboardSegments = parseClipboardSegments(
+            event.clipboardData.getData(CLIPBOARD_SEGMENTS_MIME),
+          );
+          const fallbackText = event.clipboardData
+            .getData(MIME_TEXT_PLAIN)
+            .replace(/\s*\n+\s*/g, " ");
+          const textPayload =
+            clipboardSegments && clipboardSegments.length > 0
+              ? renderSegmentsToText(clipboardSegments)
+              : fallbackText;
+          if (!textPayload) {
+            return;
+          }
+
+          event.preventDefault();
+          const liveSegments = parseSegmentsFromEditorNode(editor);
+          const selectionRange = getSelectionUnitRange(editor);
+          const insertedSegments = parseTextChunkToSegments(textPayload);
+          const nextSegments = replaceSegmentsUnitRange(
+            liveSegments,
+            selectionRange.start,
+            selectionRange.end,
+            insertedSegments,
+          );
+          const nextCaret = selectionRange.start + countSegmentsUnits(insertedSegments);
+          applySegments(nextSegments, nextCaret);
+        }}
+        onDragOver={(event) => {
+          if (disabled || !isVariableDragEvent(event.dataTransfer)) {
+            return;
+          }
+          event.preventDefault();
+          event.stopPropagation();
+          event.dataTransfer.dropEffect = "copy";
+          const editor = event.currentTarget;
+          editor.focus();
+          placeEditorCaretFromPoint(editor, event.clientX, event.clientY);
+        }}
+        onDrop={(event) => {
+          if (disabled || !isVariableDragEvent(event.dataTransfer)) {
+            return;
+          }
+          event.preventDefault();
+          event.stopPropagation();
+          const editor = event.currentTarget;
+          editor.focus();
+          if (!placeEditorCaretFromPoint(editor, event.clientX, event.clientY)) {
+            placeEditorCaretAtEnd(editor);
+          }
+          const variable = resolveVariableFromDrop(event);
+          if (!variable) {
+            return;
+          }
+          insertVariable(variable);
+        }}
+      />
+    </div>
+  );
+});

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -9,6 +9,7 @@ import {
   type SyntheticEvent as ReactSyntheticEvent,
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -44,8 +45,33 @@ import {
   List,
   LayoutTemplate,
   X,
+  Lock,
+  Cpu,
+  Hash,
+  ToggleRight,
+  Code2,
+  Link2,
 } from "lucide-react";
 import { TextBlockEditor, type TextBlockEditorHandle } from "./text-block-editor";
+import {
+  MetadataTokenInput,
+  type MetadataTokenInputHandle,
+} from "./metadata-token-input";
+import {
+  getTokenChipClassName,
+  getTokenChipText,
+} from "./template-token-segments";
+import {
+  decoratePreviewDocumentPlaceholders,
+  type PreviewTokenMeta,
+} from "./preview-token-badges";
+import {
+  buildInjectorTooltipSections,
+  injectorFieldTypeIconName,
+  type BuilderInjectorVariablePresentation,
+} from "./injector-variable-presentation";
+import { mjmlVarsToTiptapHtml } from "./template-variable-html";
+import { renderTextBlockToMjml } from "./text-block-mjml";
 import {
   extractOriginalThumbnailUrl,
   extractVideoThumbnail,
@@ -93,7 +119,7 @@ import {
 } from "@/components/ui/popover";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
-import type { InjectorDefinition } from "@/types/injectors";
+import type { InjectorDefinition, InjectorFieldType } from "@/types/injectors";
 
 const metadataSchema = z.object({
   subject: z.string().min(1, { message: "Subject is required" }),
@@ -103,6 +129,7 @@ const metadataSchema = z.object({
 });
 
 type MetadataForm = z.infer<typeof metadataSchema>;
+type TokenizableMetadataFieldKey = "subject" | "from_name";
 
 type BuilderBlockType = "text" | "button" | "image" | "divider" | "spacer" | "banner" | "video" | "list";
 
@@ -237,6 +264,13 @@ type TemplateVariable = {
   label: string;
   hint: string;
   category: "event" | "injector";
+  static?: boolean;
+  source?: "database" | "code";
+  fieldType?: InjectorFieldType;
+  fieldDescription?: string;
+  injectorDescription?: string;
+  inheritedFromSystem?: boolean;
+  ownerScope?: InjectorDefinition["owner_scope"];
 };
 
 type PreviewStageSize = { width: number; height: number };
@@ -255,8 +289,6 @@ const BLOCK_DND_MIME = "application/x-senda-block-id";
 const LIST_ITEM_DND_MIME = "application/x-senda-list-item";
 const CLIPBOARD_SEGMENTS_MIME = "application/x-senda-segments";
 const TOKEN_SEGMENT_KIND = "token";
-const TOKEN_CHIP_CLASSNAME =
-  "inline-flex items-center rounded border border-dashed border-input bg-muted px-1.5 py-0.5 text-xs align-middle select-none";
 const MIN_PREVIEW_SCALE = 0.01;
 const BANNER_MODE_FIXED = "fixed-height";
 const BANNER_MODE_FLUID = "fluid-height";
@@ -870,14 +902,15 @@ function renderSegmentsToEditorNode(editor: HTMLElement, segments: BuilderSegmen
     }
 
     const chip = doc.createElement("span");
-    chip.className = TOKEN_CHIP_CLASSNAME;
+    chip.className = getTokenChipClassName(segment.category);
     chip.contentEditable = "false";
     chip.dataset.segmentKind = TOKEN_SEGMENT_KIND;
     chip.dataset.segmentId = segment.id;
     chip.dataset.token = segment.token;
     chip.dataset.label = segment.label;
     chip.dataset.category = segment.category;
-    chip.textContent = variableToPlaceholder(segment.token);
+    chip.textContent = getTokenChipText(segment);
+    chip.title = segment.token;
     fragment.appendChild(chip);
   }
 
@@ -1226,6 +1259,28 @@ function sanitizePreviewHtml(rawHtml: string) {
   return html;
 }
 
+function InjectorFieldTypeIcon({
+  fieldType,
+}: {
+  fieldType?: InjectorFieldType;
+}) {
+  const className = "h-3.5 w-3.5 shrink-0 text-muted-foreground";
+  switch (injectorFieldTypeIconName(fieldType ?? "text")) {
+    case "hash":
+      return <Hash className={className} />;
+    case "toggle-right":
+      return <ToggleRight className={className} />;
+    case "image":
+      return <ImageIcon className={className} />;
+    case "link":
+      return <Link2 className={className} />;
+    case "code-2":
+      return <Code2 className={className} />;
+    default:
+      return <Type className={className} />;
+  }
+}
+
 function getPreviewScale(contentSize: PreviewDocumentSize, stage: PreviewStageSize) {
   const safeWidth = Math.max(1, contentSize.width);
   if (stage.width <= 0) {
@@ -1325,24 +1380,6 @@ function stripMjmlInlineTags(raw: string) {
     .replace(/<\/p\s*>/gi, "\n");
   const withoutTags = withLineBreaks.replace(/<[^>]+>/g, "");
   return decodeMjmlEntities(withoutTags).trim();
-}
-
-/** Convert {{event.x}} / {{injector.x}} in HTML to TipTap VariableToken spans */
-function mjmlVarsToTiptapHtml(html: string): string {
-  return html.replace(/\{\{([^}]+)\}\}/g, (_match, rawToken: string) => {
-    const token = normalizeVariableToken(rawToken.trim());
-    const category = guessSegmentCategory(token);
-    const label = token;
-    return `<span data-variable-token="${token}" data-category="${category}">${label}</span>`;
-  });
-}
-
-/** Convert TipTap VariableToken spans back to {{token}} placeholders for MJML */
-function tiptapHtmlToMjmlVars(html: string): string {
-  return html.replace(
-    /<span[^>]*data-variable-token="([^"]*)"[^>]*>[^<]*<\/span>/g,
-    (_match, token: string) => `{{${token}}}`,
-  );
 }
 
 function parseColumnChildToBlock(child: Element): BuilderBlock | null {
@@ -1553,11 +1590,7 @@ function parseBuilderDocumentFromMjml(rawMjml: string): BuilderDocument | null {
 function renderColumnBlockToMjml(block: BuilderBlock): string {
   switch (block.type) {
     case "text": {
-      // Replace &quot; with ' so gomjml output doesn't produce unescaped "
-      // inside style="..." attributes (breaks font-family: "Courier New" etc.)
-      const inner = tiptapHtmlToMjmlVars(block.content).replace(/&quot;/g, "'").trim() || " ";
-      const alignAttr = block.align !== "left" ? ` align="${block.align}"` : "";
-      return `<mj-text${alignAttr}>${inner}</mj-text>`;
+      return renderTextBlockToMjml(block.content, block.align);
     }
     case "button":
       return `<mj-button href="${block.href || "#"}">${renderSegmentsToText(
@@ -1774,6 +1807,8 @@ export function MjmlEditor({
   );
   const [codeOverride, setCodeOverride] = useState("");
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
+  const [selectedMetadataField, setSelectedMetadataField] =
+    useState<TokenizableMetadataFieldKey | null>(null);
   const [collapsedBlocks, setCollapsedBlocks] = useState<Record<string, boolean>>({});
   const [previewSplitMode, setPreviewSplitMode] =
     useState<PreviewSplitMode>("ratio");
@@ -1790,6 +1825,10 @@ export function MjmlEditor({
   const previewPanelWrapRef = useRef<HTMLDivElement | null>(null);
   const blockEditorRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const textBlockEditorRefs = useRef<Record<string, TextBlockEditorHandle | null>>({});
+  const metadataFieldRefs = useRef<
+    Partial<Record<TokenizableMetadataFieldKey, MetadataTokenInputHandle | null>>
+  >({});
+  const metadataPanelId = useId();
   const previewStageRef = useRef<HTMLDivElement | null>(null);
   const previewStageObserverRef = useRef<ResizeObserver | null>(null);
   const previewIframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -1806,9 +1845,9 @@ export function MjmlEditor({
   } | null>(null);
 
   const {
-    register,
     getValues,
     reset,
+    setValue,
     watch,
     formState: { errors },
   } = useForm<MetadataForm>({
@@ -2015,6 +2054,34 @@ export function MjmlEditor({
   const templateVariables = useMemo(() => {
     return [...eventVariableTokens, ...injectorVariableTokens];
   }, [eventVariableTokens, injectorVariableTokens]);
+  const resolveTemplateTokenMeta = useCallback(
+    (token: string) => {
+      const normalized = normalizeVariableToken(token);
+      const variable = templateVariables.find(
+        (item) => normalizeVariableToken(item.token) === normalized,
+      );
+      if (!variable) return undefined;
+      return {
+        label: variable.label,
+        category: variable.category,
+        static: variable.static,
+        source: variable.source,
+      } satisfies PreviewTokenMeta;
+    },
+    [templateVariables],
+  );
+  const resolveMetadataTokenMeta = useCallback(
+    (token: string) => {
+      const meta = resolveTemplateTokenMeta(token);
+      if (!meta) return undefined;
+      return {
+        label: meta.label,
+        static: meta.static,
+        source: meta.source,
+      };
+    },
+    [resolveTemplateTokenMeta],
+  );
 
   const triggerPreview = useCallback(
     (code: string) => {
@@ -2103,6 +2170,13 @@ export function MjmlEditor({
             fallbackHint: t("variableHintInjector"),
           }),
           category: "injector",
+          static: injector.static || !field.allow_overwrite,
+          source: injector.source,
+          fieldType: field.field_type,
+          fieldDescription: field.description,
+          injectorDescription: injector.description,
+          inheritedFromSystem: injector.inherited_from_system,
+          ownerScope: injector.owner_scope,
         });
       }
       return acc;
@@ -2445,6 +2519,14 @@ export function MjmlEditor({
   }
 
   function handlePreviewIframeLoad(event: ReactSyntheticEvent<HTMLIFrameElement>) {
+    try {
+      const doc = event.currentTarget.contentDocument;
+      if (doc) {
+        decoratePreviewDocumentPlaceholders(doc, resolveTemplateTokenMeta);
+      }
+    } catch {
+      // Ignore preview decoration failures and preserve compiled preview HTML.
+    }
     bindIframeSizeObserver(event.currentTarget, previewObserverCleanupRef);
   }
 
@@ -2461,9 +2543,7 @@ export function MjmlEditor({
         codeMjml,
         metadataValues: [
           watchedSubject,
-          watchedPreviewText,
           watchedFromName,
-          watchedReplyTo,
         ],
       }),
     [
@@ -2471,8 +2551,6 @@ export function MjmlEditor({
       builderDocument,
       codeMjml,
       watchedFromName,
-      watchedPreviewText,
-      watchedReplyTo,
       watchedSubject,
     ],
   );
@@ -2502,6 +2580,20 @@ export function MjmlEditor({
     setCodeOverride(value);
     triggerPreview(value);
     autoSave.scheduleSave();
+  }
+
+  function handleMetadataFieldChange(field: keyof MetadataForm, value: string) {
+    setValue(field, value, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: field !== "preview_text" && field !== "reply_to",
+    });
+    autoSave.scheduleSave();
+  }
+
+  function focusMetadataField(field: TokenizableMetadataFieldKey) {
+    setSelectedMetadataField(field);
+    setSelectedBlockId(null);
   }
 
 
@@ -2807,6 +2899,7 @@ export function MjmlEditor({
     if (!targetBlock) return;
     const targetId = targetBlock.id;
 
+    setSelectedMetadataField(null);
     setSelectedBlockId(targetId);
 
     const token = normalizeVariableToken(variable.token);
@@ -2847,6 +2940,43 @@ export function MjmlEditor({
       tokenSegment,
     ]);
     updateButtonBlockSegments(targetId, nextSegments, end + 1);
+  }
+
+  function appendTemplateVariableToMetadataField(
+    field: TokenizableMetadataFieldKey,
+    variable: TemplateVariable,
+  ) {
+    if (!canEditDraft) return;
+
+    focusMetadataField(field);
+
+    const token = normalizeVariableToken(variable.token);
+    if (!token) return;
+
+    const editor = metadataFieldRefs.current[field];
+    if (editor) {
+      editor.insertVariable({
+        token,
+        label: variable.label,
+        category: variable.category,
+      });
+      return;
+    }
+
+    const currentValue = getValues(field) ?? "";
+    const prefix = currentValue && !/\s$/.test(currentValue) ? " " : "";
+    handleMetadataFieldChange(
+      field,
+      `${currentValue}${prefix}${variableToPlaceholder(token)}`,
+    );
+  }
+
+  function appendTemplateVariable(variable: TemplateVariable) {
+    if (selectedMetadataField) {
+      appendTemplateVariableToMetadataField(selectedMetadataField, variable);
+      return;
+    }
+    appendTemplateVariableToBlock(selectedBlockId ?? "", variable);
   }
 
   function handleBlockEditorTokenClick(event: ReactMouseEvent<HTMLElement>) {
@@ -3025,6 +3155,7 @@ export function MjmlEditor({
     const editor = event.currentTarget;
     editor.focus();
     placeEditorCaretFromPoint(editor, event.clientX, event.clientY);
+    setSelectedMetadataField(null);
     setSelectedBlockId(blockId);
   }
 
@@ -3050,6 +3181,7 @@ export function MjmlEditor({
       return;
     }
     insertVariableIntoSegmentEditor(blockId, editor, variable);
+    setSelectedMetadataField(null);
     setSelectedBlockId(blockId);
   }
 
@@ -3509,6 +3641,7 @@ export function MjmlEditor({
       ...builderDocument,
       blocks: nextBlocks,
     });
+    setSelectedMetadataField(null);
     setSelectedBlockId(blockId);
   }
 
@@ -3878,7 +4011,7 @@ export function MjmlEditor({
                         className="w-full rounded-md border bg-background p-2 text-xs text-left disabled:opacity-60 disabled:cursor-not-allowed"
                         draggable={editorMode === "visual"}
                         onDragStart={editorMode === "visual" ? (event) => onVariableCardDragStart(event, item) : undefined}
-                        onClick={() => appendTemplateVariableToBlock(selectedBlockId ?? "", item)}
+                        onClick={() => appendTemplateVariable(item)}
                         disabled={!canEditDraft}
                       >
                         <div className="font-mono text-[11px] truncate">{item.label}</div>
@@ -3952,6 +4085,17 @@ export function MjmlEditor({
                                 <div className="space-y-1.5 pl-4 mt-1">
                                   {items.map((item) => {
                                     const fieldName = item.label.split(".").slice(1).join(".");
+                                    const tooltip = buildInjectorTooltipSections({
+                                      fullLabel: item.label,
+                                      fieldLabel: fieldName,
+                                      fieldType: item.fieldType ?? "text",
+                                      fieldDescription: item.fieldDescription,
+                                      injectorDescription: item.injectorDescription,
+                                      static: item.static,
+                                      inheritedFromSystem: item.inheritedFromSystem,
+                                      ownerScope: item.ownerScope,
+                                      source: item.source,
+                                    } satisfies BuilderInjectorVariablePresentation);
                                     return (
                                       <Tooltip key={item.id}>
                                         <TooltipTrigger asChild>
@@ -3960,15 +4104,42 @@ export function MjmlEditor({
                                             className="w-full rounded-md border bg-background p-2 text-xs text-left disabled:opacity-60 disabled:cursor-not-allowed"
                                             draggable={editorMode === "visual"}
                                             onDragStart={editorMode === "visual" ? (event) => onVariableCardDragStart(event, item) : undefined}
-                                            onClick={() => appendTemplateVariableToBlock(selectedBlockId ?? "", item)}
+                                            onClick={() => appendTemplateVariable(item)}
                                             disabled={!canEditDraft}
                                           >
-                                            <div className="font-mono text-[11px] truncate">{fieldName}</div>
+                                            <div className="flex items-center gap-1.5">
+                                              <InjectorFieldTypeIcon fieldType={item.fieldType} />
+                                              <div className="font-mono text-[11px] truncate">{fieldName}</div>
+                                              {item.static ? <Lock className="h-3 w-3 shrink-0 text-amber-500" /> : null}
+                                              {item.source === "code" ? <Cpu className="h-3 w-3 shrink-0 text-fuchsia-500" /> : null}
+                                            </div>
                                           </button>
                                         </TooltipTrigger>
-                                        <TooltipContent side="right">
-                                          <p className="font-mono font-semibold text-[11px]">{item.label}</p>
-                                          {item.hint && <p className="text-[10px] opacity-80">{item.hint}</p>}
+                                        <TooltipContent side="right" className="max-w-72 space-y-2">
+                                          <div className="space-y-1">
+                                            <p className="font-mono font-semibold text-[11px]">{tooltip.name}</p>
+                                            {tooltip.description ? (
+                                              <p className="text-[10px] leading-snug text-white/90">
+                                                {tooltip.description}
+                                              </p>
+                                            ) : null}
+                                            {tooltip.injectorDescription ? (
+                                              <p className="text-[10px] leading-snug text-white/75">
+                                                {tooltip.injectorDescription}
+                                              </p>
+                                            ) : null}
+                                          </div>
+                                          <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-[10px]">
+                                            {tooltip.details.map((detail) => (
+                                              <div
+                                                key={`${item.id}-${detail.label}`}
+                                                className="contents"
+                                              >
+                                                <span className="text-white/65">{detail.label}</span>
+                                                <span className="font-medium text-white">{detail.value}</span>
+                                              </div>
+                                            ))}
+                                          </div>
                                         </TooltipContent>
                                       </Tooltip>
                                     );
@@ -4100,7 +4271,10 @@ export function MjmlEditor({
                                 appendTemplateVariableToBlock(block.id, variable);
                               }
                             }}
-                            onClick={() => setSelectedBlockId(block.id)}
+                            onClick={() => {
+                              setSelectedMetadataField(null);
+                              setSelectedBlockId(block.id);
+                            }}
                           >
                             <div className="flex items-center justify-between mb-2">
                               <div className="flex items-center gap-1.5 text-xs text-muted-foreground min-w-0 flex-1">
@@ -4175,7 +4349,10 @@ export function MjmlEditor({
                                 onChange={(html, newAlign) => updateTextBlock(block.id, html, newAlign)}
                                 align={block.align}
                                 disabled={!canEditDraft}
-                                onFocus={() => setSelectedBlockId(block.id)}
+                                onFocus={() => {
+                                  setSelectedMetadataField(null);
+                                  setSelectedBlockId(block.id);
+                                }}
                               />
                             )}
 
@@ -4202,7 +4379,10 @@ export function MjmlEditor({
                                       handleBlockEditorKeyDown(block.id, event)
                                     }
                                     onClick={handleBlockEditorTokenClick}
-                                    onFocus={() => setSelectedBlockId(block.id)}
+                                    onFocus={() => {
+                                      setSelectedMetadataField(null);
+                                      setSelectedBlockId(block.id);
+                                    }}
                                     onCopy={(event) =>
                                       handleBlockEditorCopyOrCut(block.id, event, "copy")
                                     }
@@ -4362,7 +4542,10 @@ export function MjmlEditor({
                                         handleBlockEditorKeyDown(block.id, event)
                                       }
                                       onClick={handleBlockEditorTokenClick}
-                                      onFocus={() => setSelectedBlockId(block.id)}
+                                      onFocus={() => {
+                                        setSelectedMetadataField(null);
+                                        setSelectedBlockId(block.id);
+                                      }}
                                       onCopy={(event) =>
                                         handleBlockEditorCopyOrCut(block.id, event, "copy")
                                       }
@@ -4716,6 +4899,8 @@ export function MjmlEditor({
             <button
               type="button"
               className="flex items-center gap-1 w-full text-left mb-1"
+              aria-expanded={metadataOpen}
+              aria-controls={metadataPanelId}
               onClick={() => setMetadataOpen((prev) => !prev)}
             >
               {metadataOpen ? (
@@ -4726,57 +4911,99 @@ export function MjmlEditor({
               <h4 className="text-sm font-semibold">Metadata</h4>
             </button>
             {metadataOpen && (
-            <>
-            <p className="mb-3 text-xs text-muted-foreground">
+            <div id={metadataPanelId} className="space-y-3">
+            <p className="text-xs text-muted-foreground">
               Used for email headers and inbox preview in real sends.
             </p>
             <div className="grid grid-cols-2 gap-3">
               <div className="flex flex-col gap-1.5">
                 <Label className="text-xs font-medium">Subject</Label>
-                <Input
-                  {...register("subject")}
-                  className="h-8 text-sm"
-                  readOnly={isReadOnlyMode}
+                <MetadataTokenInput
+                  ref={(handle) => {
+                    metadataFieldRefs.current.subject = handle;
+                  }}
+                  value={watchedSubject}
+                  onChange={(value) => handleMetadataFieldChange("subject", value)}
+                  onFocus={() => focusMetadataField("subject")}
+                  disabled={isReadOnlyMode}
+                  ariaLabel="Subject"
+                  ariaInvalid={Boolean(errors.subject)}
+                  describedBy={errors.subject ? "template-subject-error" : undefined}
+                  placeholder="Subject"
+                  resolveTokenMeta={resolveMetadataTokenMeta}
                 />
                 {errors.subject && (
-                  <span className="text-xs text-destructive">
+                  <span
+                    id="template-subject-error"
+                    className="text-xs text-destructive"
+                  >
                     {errors.subject.message}
                   </span>
                 )}
               </div>
               <div className="flex flex-col gap-1.5">
-                <Label className="text-xs font-medium">Preview Text</Label>
+                <Label
+                  className="text-xs font-medium"
+                  htmlFor="template-preview-text"
+                >
+                  Preview Text
+                </Label>
                 <Input
-                  {...register("preview_text")}
+                  id="template-preview-text"
+                  value={watchedPreviewText ?? ""}
                   className="h-8 text-sm"
                   readOnly={isReadOnlyMode}
+                  onChange={(event) =>
+                    handleMetadataFieldChange("preview_text", event.target.value)
+                  }
                 />
               </div>
               <div className="flex flex-col gap-1.5">
                 <Label className="text-xs font-medium">From Name</Label>
-                <Input
-                  {...register("from_name")}
-                  className="h-8 text-sm"
-                  readOnly={isReadOnlyMode}
+                <MetadataTokenInput
+                  ref={(handle) => {
+                    metadataFieldRefs.current.from_name = handle;
+                  }}
+                  value={watchedFromName}
+                  onChange={(value) => handleMetadataFieldChange("from_name", value)}
+                  onFocus={() => focusMetadataField("from_name")}
+                  disabled={isReadOnlyMode}
+                  ariaLabel="From Name"
+                  ariaInvalid={Boolean(errors.from_name)}
+                  describedBy={errors.from_name ? "template-from-name-error" : undefined}
+                  placeholder="From name"
+                  resolveTokenMeta={resolveMetadataTokenMeta}
                 />
                 {errors.from_name && (
-                  <span className="text-xs text-destructive">
+                  <span
+                    id="template-from-name-error"
+                    className="text-xs text-destructive"
+                  >
                     {errors.from_name.message}
                   </span>
                 )}
               </div>
               {activeLocale === "default" && (
                 <div className="flex flex-col gap-1.5">
-                  <Label className="text-xs font-medium">Reply-To</Label>
+                  <Label
+                    className="text-xs font-medium"
+                    htmlFor="template-reply-to"
+                  >
+                    Reply-To
+                  </Label>
                   <Input
-                    {...register("reply_to")}
+                    id="template-reply-to"
+                    value={watchedReplyTo ?? ""}
                     className="h-8 text-sm"
                     readOnly={isReadOnlyMode}
+                    onChange={(event) =>
+                      handleMetadataFieldChange("reply_to", event.target.value)
+                    }
                   />
                 </div>
               )}
             </div>
-            </>
+            </div>
             )}
           </div>
         </div>

--- a/web/src/components/templates/preview-token-badges.test.ts
+++ b/web/src/components/templates/preview-token-badges.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  formatPreviewTokenLabel,
+  parsePreviewTextSegments,
+} = await import(new URL("./preview-token-badges.ts", import.meta.url).href);
+
+const USER_NAME_TOKEN = "event.user_name";
+
+test("formatPreviewTokenLabel removes moustache-oriented prefixes for unknown tokens", () => {
+  assert.equal(
+    formatPreviewTokenLabel("injector.request_debug.workspace_code"),
+    "request_debug.workspace_code",
+  );
+  assert.equal(
+    formatPreviewTokenLabel(USER_NAME_TOKEN),
+    "user_name",
+  );
+});
+
+test("parsePreviewTextSegments converts unresolved placeholders into readable badge segments", () => {
+  const segments = parsePreviewTextSegments(
+    "WORKSPACE={{ injector.request_debug.workspace_code }} | EVENT={{ event.user_name }}",
+    (token: string) => {
+      if (token === USER_NAME_TOKEN) {
+        return {
+          label: "user_name",
+          category: "event",
+        };
+      }
+      return undefined;
+    },
+  );
+
+  assert.deepEqual(segments, [
+    { kind: "text", text: "WORKSPACE=" },
+    {
+      kind: "token",
+      token: "injector.request_debug.workspace_code",
+      label: "request_debug.workspace_code",
+      title: "injector.request_debug.workspace_code",
+      category: "injector",
+      static: undefined,
+      source: undefined,
+    },
+    { kind: "text", text: " | EVENT=" },
+    {
+      kind: "token",
+      token: USER_NAME_TOKEN,
+      label: "user_name",
+      title: USER_NAME_TOKEN,
+      category: "event",
+      static: undefined,
+      source: undefined,
+    },
+  ]);
+});
+
+test("parsePreviewTextSegments preserves static/code metadata for known placeholders", () => {
+  const segments = parsePreviewTextSegments(
+    "{{ injector.workspace_profile.workspace_code }}",
+    () => ({
+      label: "workspace_profile.workspace_code",
+      category: "injector",
+      static: true,
+      source: "code",
+    }),
+  );
+
+  assert.deepEqual(segments, [
+    {
+      kind: "token",
+      token: "injector.workspace_profile.workspace_code",
+      label: "workspace_profile.workspace_code",
+      title: "injector.workspace_profile.workspace_code · static default · code injector",
+      category: "injector",
+      static: true,
+      source: "code",
+    },
+  ]);
+});

--- a/web/src/components/templates/preview-token-badges.ts
+++ b/web/src/components/templates/preview-token-badges.ts
@@ -1,0 +1,245 @@
+import {
+  guessSegmentCategory,
+  normalizeVariableToken,
+  type TokenCategory,
+} from "./template-token-segments.ts";
+
+export type PreviewTokenMeta = {
+  label?: string;
+  category?: TokenCategory;
+  static?: boolean;
+  source?: "database" | "code";
+};
+
+export type PreviewTextSegment =
+  | {
+      kind: "text";
+      text: string;
+    }
+  | {
+      kind: "token";
+      token: string;
+      label: string;
+      title: string;
+      category: TokenCategory;
+      static?: boolean;
+      source?: "database" | "code";
+    };
+
+const PREVIEW_PLACEHOLDER_PATTERN = /\{\{\s*([^}]+?)\s*\}\}/g;
+const PREVIEW_TOKEN_STYLE_ID = "senda-preview-token-badges";
+const TEXT_NODE_FILTER = 4;
+const PREVIEW_TOKEN_CLASSNAME = "senda-preview-token";
+const PREVIEW_TOKEN_INJECTOR_CLASSNAME = "senda-preview-token--injector";
+const PREVIEW_TOKEN_EVENT_CLASSNAME = "senda-preview-token--event";
+
+const PREVIEW_TOKEN_STYLES = `
+.${PREVIEW_TOKEN_CLASSNAME} {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px dashed #cbd5e1;
+  background: #f8fafc;
+  color: #0f172a;
+  padding: 0.05rem 0.4rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.85em;
+  font-weight: 500;
+  line-height: 1.35;
+  vertical-align: baseline;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.${PREVIEW_TOKEN_INJECTOR_CLASSNAME} {
+  border-color: #a78bfa;
+  background: #f5f3ff;
+  color: #6d28d9;
+}
+
+.${PREVIEW_TOKEN_EVENT_CLASSNAME} {
+  border-color: #cbd5e1;
+  background: #f8fafc;
+  color: #334155;
+}
+`;
+
+function formatPreviewTokenTitle(token: string, meta?: PreviewTokenMeta) {
+  const parts = [normalizeVariableToken(token)];
+  if (meta?.static) {
+    parts.push("static default");
+  }
+  if (meta?.source === "code") {
+    parts.push("code injector");
+  }
+  return parts.join(" · ");
+}
+
+export function formatPreviewTokenLabel(token: string, meta?: PreviewTokenMeta) {
+  const candidate = meta?.label?.trim();
+  if (candidate) {
+    return candidate;
+  }
+
+  const normalized = normalizeVariableToken(token);
+  if (normalized.startsWith("injector.")) {
+    return normalized.slice("injector.".length);
+  }
+  if (normalized.startsWith("event.")) {
+    return normalized.slice("event.".length);
+  }
+  return normalized;
+}
+
+export function parsePreviewTextSegments(
+  rawText: string,
+  resolveMeta?: (token: string) => PreviewTokenMeta | undefined,
+): PreviewTextSegment[] {
+  if (!rawText) {
+    return [];
+  }
+
+  const parts = rawText.split(/(\{\{\s*[^}]+?\s*\}\})/g);
+  const segments: PreviewTextSegment[] = [];
+
+  for (const part of parts) {
+    if (!part) {
+      continue;
+    }
+
+    if (/^\{\{\s*[^}]+?\s*\}\}$/.test(part.trim())) {
+      const token = normalizeVariableToken(part);
+      if (!token) {
+        continue;
+      }
+      const meta = resolveMeta?.(token);
+      segments.push({
+        kind: "token",
+        token,
+        label: formatPreviewTokenLabel(token, meta),
+        title: formatPreviewTokenTitle(token, meta),
+        category: meta?.category ?? guessSegmentCategory(token),
+        static: meta?.static,
+        source: meta?.source,
+      });
+      continue;
+    }
+
+    segments.push({
+      kind: "text",
+      text: part,
+    });
+  }
+
+  return segments;
+}
+
+function hasPreviewPlaceholderTokens(rawText: string) {
+  PREVIEW_PLACEHOLDER_PATTERN.lastIndex = 0;
+  return PREVIEW_PLACEHOLDER_PATTERN.test(rawText);
+}
+
+function shouldDecorateTextNode(node: Text) {
+  const parent = node.parentElement;
+  if (!parent) {
+    return false;
+  }
+
+  if (parent.closest("[data-senda-preview-token]")) {
+    return false;
+  }
+
+  const tagName = parent.tagName;
+  if (tagName === "SCRIPT" || tagName === "STYLE" || tagName === "NOSCRIPT" || tagName === "TEXTAREA") {
+    return false;
+  }
+
+  return hasPreviewPlaceholderTokens(node.textContent ?? "");
+}
+
+function ensurePreviewTokenStyles(doc: Document) {
+  if (doc.getElementById(PREVIEW_TOKEN_STYLE_ID)) {
+    return;
+  }
+
+  const style = doc.createElement("style");
+  style.id = PREVIEW_TOKEN_STYLE_ID;
+  style.textContent = PREVIEW_TOKEN_STYLES;
+  doc.head?.appendChild(style);
+}
+
+export function decoratePreviewDocumentPlaceholders(
+  doc: Document,
+  resolveMeta?: (token: string) => PreviewTokenMeta | undefined,
+) {
+  if (!doc.body) {
+    return false;
+  }
+
+  ensurePreviewTokenStyles(doc);
+
+  const view = doc.defaultView;
+  const filter = view?.NodeFilter;
+  const walker = doc.createTreeWalker(
+    doc.body,
+    filter?.SHOW_TEXT ?? TEXT_NODE_FILTER,
+    {
+      acceptNode(node) {
+        return shouldDecorateTextNode(node as Text)
+          ? filter?.FILTER_ACCEPT ?? 1
+          : filter?.FILTER_REJECT ?? 2;
+      },
+    },
+  );
+
+  const textNodes: Text[] = [];
+  let currentNode = walker.nextNode();
+  while (currentNode) {
+    textNodes.push(currentNode as Text);
+    currentNode = walker.nextNode();
+  }
+
+  if (textNodes.length === 0) {
+    return false;
+  }
+
+  for (const textNode of textNodes) {
+    const segments = parsePreviewTextSegments(textNode.textContent ?? "", resolveMeta);
+    if (!segments.some((segment) => segment.kind === "token")) {
+      continue;
+    }
+
+    const fragment = doc.createDocumentFragment();
+    for (const segment of segments) {
+      if (segment.kind === "text") {
+        fragment.appendChild(doc.createTextNode(segment.text));
+        continue;
+      }
+
+      const chip = doc.createElement("span");
+      chip.setAttribute("data-senda-preview-token", "true");
+      chip.className = [
+        PREVIEW_TOKEN_CLASSNAME,
+        segment.category === "injector"
+          ? PREVIEW_TOKEN_INJECTOR_CLASSNAME
+          : PREVIEW_TOKEN_EVENT_CLASSNAME,
+      ].join(" ");
+      chip.textContent = segment.label;
+      chip.title = segment.title;
+      chip.setAttribute("aria-label", segment.title);
+      if (segment.static) {
+        chip.dataset.static = "true";
+      }
+      if (segment.source) {
+        chip.dataset.source = segment.source;
+      }
+      fragment.appendChild(chip);
+    }
+
+    textNode.parentNode?.replaceChild(fragment, textNode);
+  }
+
+  return true;
+}

--- a/web/src/components/templates/template-token-segments.test.ts
+++ b/web/src/components/templates/template-token-segments.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  normalizeVariableToken,
+  parseContentToSegments,
+  renderSegmentsToText,
+  getTokenChipText,
+} = await import(new URL("./template-token-segments.ts", import.meta.url).href);
+
+test("normalizeVariableToken removes moustache syntax and collapses whitespace", () => {
+  assert.equal(
+    normalizeVariableToken("  {{   injector.student.name   }}  "),
+    "injector.student.name",
+  );
+});
+
+test("parseContentToSegments turns placeholders into token segments with readable labels", () => {
+  const segments = parseContentToSegments(
+    "Hola {{ injector.student.name }} desde {{ event.workspace_name }}",
+  );
+
+  assert.equal(segments.length, 4);
+  assert.deepEqual(
+    segments
+      .filter((segment: { kind: string }) => segment.kind === "token")
+      .map((segment: { token: string; label: string; category: string }) => ({
+        token: segment.token,
+        label: segment.label,
+        category: segment.category,
+      })),
+    [
+      {
+        token: "injector.student.name",
+        label: "injector.student.name",
+        category: "injector",
+      },
+      {
+        token: "event.workspace_name",
+        label: "event.workspace_name",
+        category: "event",
+      },
+    ],
+  );
+});
+
+test("renderSegmentsToText preserves placeholder syntax for storage", () => {
+  const segments = parseContentToSegments(
+    "Equipo {{ injector.school.name }} te saluda",
+  );
+
+  assert.equal(
+    renderSegmentsToText(segments),
+    "Equipo {{ injector.school.name }} te saluda",
+  );
+});
+
+test("getTokenChipText prefers the human-readable label instead of raw moustache", () => {
+  assert.equal(
+    getTokenChipText({
+      token: "injector.school.name",
+      label: "school.name",
+    }),
+    "school.name",
+  );
+});

--- a/web/src/components/templates/template-token-segments.ts
+++ b/web/src/components/templates/template-token-segments.ts
@@ -1,0 +1,178 @@
+export type TokenCategory = "event" | "injector";
+
+export type TemplateTokenSegment =
+  | {
+      kind: "text";
+      id: string;
+      text: string;
+    }
+  | {
+      kind: "token";
+      id: string;
+      token: string;
+      label: string;
+      category: TokenCategory;
+    };
+
+const EVENT_TOKEN_CHIP_CLASSNAME =
+  "inline-flex max-w-full items-center rounded border border-dashed border-input bg-muted px-1.5 py-0.5 text-xs align-middle select-none truncate text-foreground";
+
+const INJECTOR_TOKEN_CHIP_CLASSNAME =
+  "inline-flex max-w-full items-center rounded border border-dashed border-violet-400 bg-violet-50 px-1.5 py-0.5 text-xs align-middle select-none truncate text-violet-700 dark:border-violet-600 dark:bg-violet-950 dark:text-violet-300";
+
+function nowId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function normalizeVariableToken(raw: string) {
+  return raw
+    .replace(/^\s*\{\{\s*/, "")
+    .replace(/\s*\}\}\s*$/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function variableToPlaceholder(rawToken: string) {
+  return `{{ ${normalizeVariableToken(rawToken)} }}`;
+}
+
+export function createTextSegment(raw: string): TemplateTokenSegment {
+  return {
+    kind: "text",
+    id: nowId(),
+    text: raw,
+  };
+}
+
+export function createTokenSegment(
+  token: string,
+  category: TokenCategory,
+  label?: string,
+): TemplateTokenSegment {
+  const normalizedToken = normalizeVariableToken(token);
+  return {
+    kind: "token",
+    id: nowId(),
+    token: normalizedToken,
+    label: label ?? normalizedToken,
+    category,
+  };
+}
+
+export function guessSegmentCategory(rawToken: string): TokenCategory {
+  const token = normalizeVariableToken(rawToken);
+  if (token.startsWith("injector.")) return "injector";
+  return "event";
+}
+
+export function mergeAdjacentTextSegments(
+  segments: TemplateTokenSegment[],
+): TemplateTokenSegment[] {
+  const merged: TemplateTokenSegment[] = [];
+
+  for (const segment of segments) {
+    if (segment.kind === "text") {
+      const last = merged[merged.length - 1];
+      if (last?.kind === "text") {
+        last.text += segment.text;
+        continue;
+      }
+      merged.push({ ...segment });
+      continue;
+    }
+    merged.push(segment);
+  }
+
+  const compact = merged.filter(
+    (segment) => segment.kind !== "text" || segment.text.length > 0,
+  );
+  const hasText = compact.some((segment) => segment.kind === "text");
+
+  if (!compact.length) {
+    return [createTextSegment("")];
+  }
+  if (!hasText) {
+    return [...compact, createTextSegment("")];
+  }
+
+  return compact;
+}
+
+export function ensureUniqueSegmentIds(
+  segments: TemplateTokenSegment[],
+): TemplateTokenSegment[] {
+  const seen = new Set<string>();
+  return segments.map((segment) => {
+    if (!segment.id || seen.has(segment.id)) {
+      const nextId = nowId();
+      seen.add(nextId);
+      return {
+        ...segment,
+        id: nextId,
+      };
+    }
+    seen.add(segment.id);
+    return segment;
+  });
+}
+
+export function parseTextChunkToSegments(raw: string) {
+  if (!raw) return [];
+
+  const text = raw.replace(/\u200b/g, "");
+  if (!text) return [];
+
+  const parts = text.split(/(\{\{[^}]+\}\})/g);
+  const segments: TemplateTokenSegment[] = [];
+
+  for (const part of parts) {
+    if (!part) continue;
+    if (/^\{\{[^}]+\}\}$/.test(part.trim())) {
+      const normalized = normalizeVariableToken(part);
+      if (normalized) {
+        segments.push(
+          createTokenSegment(normalized, guessSegmentCategory(normalized), normalized),
+        );
+      }
+      continue;
+    }
+    segments.push(createTextSegment(part));
+  }
+
+  return segments;
+}
+
+export function parseContentToSegments(content: string): TemplateTokenSegment[] {
+  const raw = typeof content === "string" ? content : "";
+  if (!raw) {
+    return [createTextSegment("")];
+  }
+
+  const segments = parseTextChunkToSegments(raw);
+  if (!segments.length) {
+    return [createTextSegment("")];
+  }
+  return ensureUniqueSegmentIds(mergeAdjacentTextSegments(segments));
+}
+
+export function renderSegmentsToText(segments: TemplateTokenSegment[]) {
+  return segments
+    .map((segment) =>
+      segment.kind === "text" ? segment.text : variableToPlaceholder(segment.token),
+    )
+    .join("");
+}
+
+export function getTokenChipText(segment: Pick<Extract<TemplateTokenSegment, { kind: "token" }>, "label" | "token">) {
+  const label = segment.label?.trim();
+  return label && label.length > 0 ? label : normalizeVariableToken(segment.token);
+}
+
+export function getTokenChipClassName(category: TokenCategory) {
+  return category === "injector"
+    ? INJECTOR_TOKEN_CHIP_CLASSNAME
+    : EVENT_TOKEN_CHIP_CLASSNAME;
+}

--- a/web/src/components/templates/template-variable-html.test.ts
+++ b/web/src/components/templates/template-variable-html.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { mjmlVarsToTiptapHtml, tiptapHtmlToMjmlVars } = await import(
+  new URL("./template-variable-html.ts", import.meta.url).href
+);
+
+test("mjmlVarsToTiptapHtml converts placeholders into variable token spans", () => {
+  assert.equal(
+    mjmlVarsToTiptapHtml("Hola {{ injector.student.name }}"),
+    'Hola <span data-variable-token="injector.student.name" data-category="injector">injector.student.name</span>',
+  );
+});
+
+test("tiptapHtmlToMjmlVars converts flat variable token spans back to moustache placeholders", () => {
+  const html =
+    '<p><span data-variable-token="injector.student.name" data-category="injector">student.name</span></p>';
+
+  assert.equal(tiptapHtmlToMjmlVars(html), "<p>{{injector.student.name}}</p>");
+});
+
+test("tiptapHtmlToMjmlVars converts variable token spans even when their label contains nested markup", () => {
+  const html =
+    '<p><span data-variable-token="injector.workspace_profile.workspace_code" data-category="injector" title="workspace_profile.workspace_code"><span class="truncate">workspace_profile.workspace_code</span></span></p>';
+
+  assert.equal(
+    tiptapHtmlToMjmlVars(html),
+    "<p>{{injector.workspace_profile.workspace_code}}</p>",
+  );
+});

--- a/web/src/components/templates/template-variable-html.ts
+++ b/web/src/components/templates/template-variable-html.ts
@@ -1,0 +1,69 @@
+import { guessSegmentCategory, normalizeVariableToken } from "./template-token-segments.ts";
+
+function findMatchingSpanCloseIndex(html: string, searchFrom: number) {
+  const spanTagPattern = /<\/?span\b[^>]*>/gi;
+  spanTagPattern.lastIndex = searchFrom;
+  let depth = 1;
+
+  for (;;) {
+    const tagMatch = spanTagPattern.exec(html);
+    if (!tagMatch) {
+      return -1;
+    }
+
+    const tag = tagMatch[0].toLowerCase();
+    if (tag.startsWith("</span")) {
+      depth -= 1;
+      if (depth === 0) {
+        return tagMatch.index + tagMatch[0].length;
+      }
+      continue;
+    }
+
+    depth += 1;
+  }
+}
+
+export function mjmlVarsToTiptapHtml(html: string): string {
+  return html.replace(/\{\{([^}]+)\}\}/g, (_match, rawToken: string) => {
+    const token = normalizeVariableToken(rawToken.trim());
+    const category = guessSegmentCategory(token);
+    const label = token;
+    return `<span data-variable-token="${token}" data-category="${category}">${label}</span>`;
+  });
+}
+
+export function tiptapHtmlToMjmlVars(html: string): string {
+  if (!html || !html.includes("data-variable-token")) {
+    return html;
+  }
+
+  const tokenSpanPattern = /<span\b[^>]*data-variable-token="([^"]*)"[^>]*>/gi;
+  let result = "";
+  let cursor = 0;
+
+  for (;;) {
+    tokenSpanPattern.lastIndex = cursor;
+    const match = tokenSpanPattern.exec(html);
+    if (!match) {
+      result += html.slice(cursor);
+      break;
+    }
+
+    const [openTag, token] = match;
+    const matchStart = match.index;
+    const openTagEnd = matchStart + openTag.length;
+    const closeTagEnd = findMatchingSpanCloseIndex(html, openTagEnd);
+
+    if (closeTagEnd === -1) {
+      result += html.slice(cursor);
+      break;
+    }
+
+    result += html.slice(cursor, matchStart);
+    result += `{{${token}}}`;
+    cursor = closeTagEnd;
+  }
+
+  return result;
+}

--- a/web/src/components/templates/test-send-modal-catalog.test.ts
+++ b/web/src/components/templates/test-send-modal-catalog.test.ts
@@ -36,10 +36,12 @@ test("keeps inherited injectors visible when the template references them", () =
           {
             field_name: "name",
             position: 0,
+            allow_overwrite: true,
           },
           {
             field_name: "ignored",
             position: 1,
+            allow_overwrite: false,
           },
         ],
       },
@@ -57,6 +59,7 @@ test("keeps inherited injectors visible when the template references them", () =
         {
           field_name: "name",
           position: 0,
+          allow_overwrite: true,
         },
       ],
     },

--- a/web/src/components/templates/test-send-modal-catalog.ts
+++ b/web/src/components/templates/test-send-modal-catalog.ts
@@ -32,7 +32,7 @@ export function resolveVisibleTestSendInjectors(
     }
 
     const filteredFields = (injector.fields ?? []).filter((field) =>
-      allowedFields.includes(field.field_name),
+      allowedFields.includes(field.field_name) && field.allow_overwrite,
     );
     if (!filteredFields.length) {
       return acc;

--- a/web/src/components/templates/test-send-modal-copy.test.ts
+++ b/web/src/components/templates/test-send-modal-copy.test.ts
@@ -1,0 +1,11 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { TEST_SEND_INJECTOR_HELPER_TEXT } = await import(
+  new URL("./test-send-modal-copy.ts", import.meta.url).href
+);
+
+test("test send helper text explains that only overwriteable fields are shown", () => {
+  assert.match(TEST_SEND_INJECTOR_HELPER_TEXT, /Only overwritable fields are shown/i);
+  assert.match(TEST_SEND_INJECTOR_HELPER_TEXT, /static\/locked values resolve automatically/i);
+});

--- a/web/src/components/templates/test-send-modal-copy.ts
+++ b/web/src/components/templates/test-send-modal-copy.ts
@@ -1,0 +1,2 @@
+export const TEST_SEND_INJECTOR_HELPER_TEXT =
+  "Only overwritable fields are shown. Leave them untouched to keep the runtime fallback; static/locked values resolve automatically.";

--- a/web/src/components/templates/test-send-modal.tsx
+++ b/web/src/components/templates/test-send-modal.tsx
@@ -17,6 +17,7 @@ import { useInjectorList } from "@/hooks/use-injectors";
 import type { InjectorDefinition, InjectorField, InjectorFieldType } from "@/types/injectors";
 import { toast } from "sonner";
 import { getTestSendScrollableBodyClassName } from "./test-send-modal-layout";
+import { TEST_SEND_INJECTOR_HELPER_TEXT } from "./test-send-modal-copy";
 import {
   type TemplateInjectorUsage,
 } from "./test-send-injector-usage";
@@ -65,6 +66,13 @@ export function TestSendModal({
   });
   const injectorItems = useMemo(
     () => resolveVisibleTestSendInjectors(injectorList.data?.items ?? [], allowedInjectorUsage),
+    [allowedInjectorUsage, injectorList.data],
+  );
+  const hasCatalogInjectors = useMemo(
+    () =>
+      (injectorList.data?.items ?? []).some((injector) =>
+        Object.prototype.hasOwnProperty.call(allowedInjectorUsage, injector.name)
+      ),
     [allowedInjectorUsage, injectorList.data],
   );
   const activeInjectorState = injectorState ?? buildInitialInjectorState(injectorItems);
@@ -180,8 +188,7 @@ export function TestSendModal({
                 <div className="flex flex-col gap-1">
                   <Label>Injectors</Label>
                   <p className="text-xs text-muted-foreground">
-                    Leave overwriteable fields untouched to keep the runtime fallback. Locked fields
-                    always use their default value.
+                    {TEST_SEND_INJECTOR_HELPER_TEXT}
                   </p>
                 </div>
               </div>
@@ -273,7 +280,9 @@ export function TestSendModal({
                 </div>
               ) : (
                 <p className="text-sm text-muted-foreground">
-                  This template references injectors that are not available in this scope.
+                  {hasCatalogInjectors
+                    ? "This template only uses static injectors. The backend resolves them automatically for preview and test send."
+                    : "This template references injectors that are not available in this scope."}
                 </p>
               )}
             </div>

--- a/web/src/components/templates/text-block-editor.tsx
+++ b/web/src/components/templates/text-block-editor.tsx
@@ -485,7 +485,7 @@ export const TextBlockEditor = forwardRef<TextBlockEditorHandle, TextBlockEditor
       >
         <EditorContent
           editor={editor}
-          className="[&_.tiptap]:min-h-6 [&_.tiptap]:outline-none [&_.tiptap]:text-sm [&_.tiptap_p]:my-0 [&_.tiptap_.ProseMirror-trailingBreak]:block"
+          className="[&_.tiptap]:min-h-6 [&_.tiptap]:min-w-0 [&_.tiptap]:w-full [&_.tiptap]:outline-none [&_.tiptap]:text-sm [&_.tiptap]:whitespace-pre-wrap [&_.tiptap]:break-words [&_.tiptap]:[overflow-wrap:anywhere] [&_.tiptap_p]:my-0 [&_.tiptap_p]:min-w-0 [&_.tiptap_p]:max-w-full [&_.tiptap_span[data-variable-token]]:max-w-full [&_.tiptap_.ProseMirror-trailingBreak]:block"
         />
       </div>
     </div>

--- a/web/src/components/templates/text-block-mjml.test.ts
+++ b/web/src/components/templates/text-block-mjml.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { renderTextBlockToMjml } = await import(
+  new URL("./text-block-mjml.ts", import.meta.url).href
+);
+
+test("renderTextBlockToMjml uses block align when content has no paragraph-level alignment", () => {
+  const html = "<p>Hello</p>";
+
+  assert.equal(renderTextBlockToMjml(html, "center"), '<mj-text align="center"><p>Hello</p></mj-text>');
+});
+
+test("renderTextBlockToMjml preserves mixed paragraph alignment by omitting outer mj-text align", () => {
+  const html = [
+    '<p style="text-align: center;">Hello <span data-variable-token="injector.workspace_profile.workspace_code" data-category="injector">injector.workspace_profile.workspace_code</span></p>',
+    '<p style="text-align: center;"><span data-variable-token="injector.workspace_profile.environment_badge_html" data-category="injector">injector.workspace_profile.environment_badge_html</span></p>',
+    '<p><span data-variable-token="injector.student.name" data-category="injector">injector.student.name</span></p>',
+    '<p><span data-variable-token="injector.student.status" data-category="injector">injector.student.status</span></p>',
+  ].join("");
+
+  assert.equal(
+    renderTextBlockToMjml(html, "center"),
+    [
+      "<mj-text>",
+      "<p style=\"text-align: center;\">Hello {{injector.workspace_profile.workspace_code}}</p>",
+      "<p style=\"text-align: center;\">{{injector.workspace_profile.environment_badge_html}}</p>",
+      "<p>{{injector.student.name}}</p>",
+      "<p>{{injector.student.status}}</p>",
+      "</mj-text>",
+    ].join(""),
+  );
+});

--- a/web/src/components/templates/text-block-mjml.ts
+++ b/web/src/components/templates/text-block-mjml.ts
@@ -1,0 +1,14 @@
+import { tiptapHtmlToMjmlVars } from "./template-variable-html.ts";
+
+type TextBlockAlign = "left" | "center" | "right" | "justify";
+
+const EXPLICIT_TEXT_ALIGN_PATTERN = /text-align\s*:\s*(left|center|right|justify)/i;
+
+export function renderTextBlockToMjml(content: string, align: TextBlockAlign): string {
+  const inner = tiptapHtmlToMjmlVars(content).replace(/&quot;/g, "'").trim() || " ";
+  const hasExplicitTextAlignment = EXPLICIT_TEXT_ALIGN_PATTERN.test(content);
+  const alignAttr =
+    !hasExplicitTextAlignment && align !== "left" ? ` align="${align}"` : "";
+
+  return `<mj-text${alignAttr}>${inner}</mj-text>`;
+}

--- a/web/src/components/templates/tiptap-variable-token.test.ts
+++ b/web/src/components/templates/tiptap-variable-token.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { readVariableTokenAttrs } = await import(
+  new URL("./tiptap-variable-token.ts", import.meta.url).href
+);
+const {
+  getVariableTokenClassName,
+} = await import(new URL("./tiptap-variable-token.ts", import.meta.url).href);
+const DATA_CATEGORY = "data-category";
+const EVENT_USER_NAME = "event.user_name";
+
+test("readVariableTokenAttrs preserves token, label and category from stored spans", () => {
+  const element = {
+    getAttribute(name: string) {
+      switch (name) {
+        case "data-variable-token":
+          return "injector.student.name";
+        case "data-label":
+          return "student.name";
+        case DATA_CATEGORY:
+          return "injector";
+        default:
+          return null;
+      }
+    },
+    textContent: "student.name",
+  };
+
+  assert.deepEqual(readVariableTokenAttrs(element), {
+    token: "injector.student.name",
+    label: "student.name",
+    category: "injector",
+  });
+});
+
+test("readVariableTokenAttrs falls back to text content when explicit label is absent", () => {
+  const element = {
+    getAttribute(name: string) {
+      switch (name) {
+        case "data-variable-token":
+          return EVENT_USER_NAME;
+        case DATA_CATEGORY:
+          return "event";
+        default:
+          return null;
+      }
+    },
+    textContent: EVENT_USER_NAME,
+  };
+
+  assert.deepEqual(readVariableTokenAttrs(element), {
+    token: EVENT_USER_NAME,
+    label: EVENT_USER_NAME,
+    category: "event",
+  });
+});
+
+test("getVariableTokenClassName constrains long tokens inside the editor width", () => {
+  const injectorClasses = getVariableTokenClassName("injector");
+  assert.match(injectorClasses, /\binline-flex\b/);
+  assert.match(injectorClasses, /\bmax-w-full\b/);
+  assert.match(injectorClasses, /\bmin-w-0\b/);
+  assert.match(injectorClasses, /\boverflow-hidden\b/);
+  assert.match(injectorClasses, /\btext-ellipsis\b/);
+  assert.match(injectorClasses, /\bwhitespace-nowrap\b/);
+  assert.match(injectorClasses, /\bborder-violet-400\b/);
+});

--- a/web/src/components/templates/tiptap-variable-token.ts
+++ b/web/src/components/templates/tiptap-variable-token.ts
@@ -4,6 +4,36 @@ export interface VariableTokenOptions {
   HTMLAttributes: Record<string, unknown>;
 }
 
+type VariableTokenElement = {
+  getAttribute: (name: string) => string | null;
+  textContent?: string | null;
+};
+
+export function readVariableTokenAttrs(element: VariableTokenElement) {
+  const token = element.getAttribute("data-variable-token")?.trim() ?? "";
+  const label =
+    element.getAttribute("data-label")?.trim() ||
+    element.textContent?.trim() ||
+    token;
+  const category =
+    element.getAttribute("data-category") === "injector" ? "injector" : "event";
+
+  return {
+    token,
+    label,
+    category,
+  };
+}
+
+export function getVariableTokenClassName(category: "event" | "injector") {
+  return [
+    "inline-flex max-w-full min-w-0 items-center overflow-hidden text-ellipsis whitespace-nowrap rounded border border-dashed px-1.5 py-0.5 text-xs align-middle select-none",
+    category === "injector"
+      ? "border-violet-400 bg-violet-50 text-violet-700 dark:border-violet-600 dark:bg-violet-950 dark:text-violet-300"
+      : "border-input bg-muted text-foreground",
+  ].join(" ");
+}
+
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     variableToken: {
@@ -37,24 +67,27 @@ export const VariableToken = Node.create<VariableTokenOptions>({
   },
 
   parseHTML() {
-    return [{ tag: "span[data-variable-token]" }];
+    return [
+      {
+        tag: "span[data-variable-token]",
+        getAttrs: (element) => readVariableTokenAttrs(element as VariableTokenElement),
+      },
+    ];
   },
 
   renderHTML({ node, HTMLAttributes }) {
-    const cat = node.attrs.category as string;
+    const cat = (node.attrs.category === "injector" ? "injector" : "event") as "event" | "injector";
     const label = (node.attrs.label as string) || (node.attrs.token as string);
     return [
       "span",
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         "data-variable-token": node.attrs.token,
+        "data-label": label,
         "data-category": cat,
-        class: [
-          "inline-flex items-center rounded border border-dashed px-1.5 py-0.5 text-xs align-middle select-none",
-          cat === "injector"
-            ? "border-violet-400 bg-violet-50 text-violet-700 dark:border-violet-600 dark:bg-violet-950 dark:text-violet-300"
-            : "border-input bg-muted text-foreground",
-        ].join(" "),
+        class: getVariableTokenClassName(cat),
         contenteditable: "false",
+        title: label,
+        "aria-label": label,
       }),
       label,
     ];

--- a/web/src/lib/workspace-resource-policies.ts
+++ b/web/src/lib/workspace-resource-policies.ts
@@ -26,6 +26,8 @@ type InjectorResourceLike = {
   inherited_from_system?: boolean;
   workspace_id?: string;
   scope_level?: ScopeLevel;
+  source?: "database" | "code";
+  static?: boolean;
 };
 
 export type ResourceStateBadge =
@@ -34,7 +36,8 @@ export type ResourceStateBadge =
   | "forkedFromDefault"
   | "readOnly"
   | "workspace"
-  | "global";
+  | "global"
+  | "code";
 
 export type ResourceDisplayScope = ScopeLevel | "system";
 
@@ -276,6 +279,14 @@ export function getInjectorManagementState(
     };
   }
 
+  if (resource.source === "code" || resource.static) {
+    return {
+      ...appendReadOnlyBadge(base),
+      canEdit: false,
+      canDelete: false,
+    };
+  }
+
   const resolved = resolveWorkspacePolicies(policies);
   if (!isWorkspaceScope(scope) || isSystemWorkspaceScope(scope)) {
     return {
@@ -314,6 +325,7 @@ function getBaseResourceState(
     owner_scope?: OwnerScope;
     inherited_from_system?: boolean;
     is_fork?: boolean;
+    source?: "database" | "code";
   } | null,
 ): ResourceState {
   if (resource?.is_fork) {
@@ -348,6 +360,13 @@ function getBaseResourceState(
     return {
       badges: ["global"],
       readOnly: false,
+    };
+  }
+
+  if (resource?.source === "code") {
+    return {
+      badges: ["global", "code"],
+      readOnly: true,
     };
   }
 

--- a/web/src/types/injectors.ts
+++ b/web/src/types/injectors.ts
@@ -19,6 +19,8 @@ export interface InjectorDefinition {
   id: string;
   workspace_id?: string;
   name: string;
+  source?: "database" | "code";
+  static?: boolean;
   description?: string;
   fields: InjectorField[];
   owner_scope?: OwnerScope;


### PR DESCRIPTION
## Summary
- replace injector registration with descriptor-based metadata for dynamic and static code injectors
- expose static code injectors in injector list/detail and resolve static defaults in builder preview
- improve builder/template UX with richer injector metadata, tokenized metadata fields, preview badges, and responsive token chips
- add local demo injectors plus supporting tests and generated OpenAPI docs

## Verification
- `go test ./...`
- `go build ./...`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `bash scripts/run-github-gates.sh pr`
