### PR TITLE
fix(templates): builder media placeholders, cursor fixes, and injector routing

### DIFF
--- a/internal/adapter/mjml/video_thumbnail.go
+++ b/internal/adapter/mjml/video_thumbnail.go
@@ -51,6 +51,10 @@ func buildVideoThumbnailURL(src, baseURL string) string {
 		return src
 	}
 
+	if strings.HasPrefix(original, "data:") {
+		return original
+	}
+
 	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		return original

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -190,7 +190,8 @@ log "starting docker services (api, postgres, keycloak, mailpit)"
 "${COMPOSE[@]}" up --build &
 COMPOSE_PID=$!
 
-log "starting frontend dev server"
+rm -rf "$ROOT_DIR/web/.next"
+log "starting frontend dev server (cache cleared)"
 (
   cd "$ROOT_DIR"
   NEXT_PUBLIC_API_URL="${API_URL}" \

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -9,6 +9,7 @@ import "./globals.css";
 const sora = Sora({
   variable: "--font-sora",
   subsets: ["latin"],
+  preload: false,
 });
 
 const ibmPlexMono = IBM_Plex_Mono({

--- a/web/src/components/templates/empty-media-placeholder.test.ts
+++ b/web/src/components/templates/empty-media-placeholder.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { emptyMediaPlaceholder, resolveSrcForMjml } = await import(
+  new URL("./empty-media-placeholder.ts", import.meta.url).href
+);
+
+const DATA_URI_PREFIX = "data:image/svg+xml,";
+
+test("emptyMediaPlaceholder starts with data:image/svg+xml", () => {
+  const result = emptyMediaPlaceholder("image");
+  assert.ok(result.startsWith(DATA_URI_PREFIX), `Expected data URI, got: ${result.slice(0, 40)}`);
+});
+
+function decodePlaceholder(result: string): string {
+  return decodeURIComponent(result.replace(DATA_URI_PREFIX, ""));
+}
+
+test("emptyMediaPlaceholder image defaults to 600x200", () => {
+  const result = emptyMediaPlaceholder("image");
+  const decoded = decodePlaceholder(result);
+  assert.ok(decoded.includes('width="600"'), `Missing width 600`);
+  assert.ok(decoded.includes('height="200"'), `Missing height 200`);
+});
+
+test("emptyMediaPlaceholder video defaults to 600x340", () => {
+  const result = emptyMediaPlaceholder("video");
+  const decoded = decodePlaceholder(result);
+  assert.ok(decoded.includes('width="600"'), `Missing width 600`);
+  assert.ok(decoded.includes('height="340"'), `Missing height 340`);
+});
+
+test("emptyMediaPlaceholder respects explicit dimensions", () => {
+  const result = emptyMediaPlaceholder("image", { width: 400, height: 150 });
+  const decoded = decodePlaceholder(result);
+  assert.ok(decoded.includes('width="400"'), `Missing width 400`);
+  assert.ok(decoded.includes('height="150"'), `Missing height 150`);
+});
+
+test("emptyMediaPlaceholder is URL-encoded not base64", () => {
+  const result = emptyMediaPlaceholder("image");
+  assert.ok(!result.startsWith("data:image/svg+xml;base64"), "Must not be base64");
+  assert.ok(result.startsWith("data:image/svg+xml,"), "Must use URL encoding (comma separator)");
+});
+
+test("emptyMediaPlaceholder is a pure function (deterministic)", () => {
+  const a = emptyMediaPlaceholder("image", { width: 600, height: 200 });
+  const b = emptyMediaPlaceholder("image", { width: 600, height: 200 });
+  assert.equal(a, b, "Same inputs must produce same output");
+});
+
+// resolveSrcForMjml tests
+
+test("resolveSrcForMjml token passthrough: single token", () => {
+  const token = "{{ injector.user.avatar }}";
+  assert.equal(resolveSrcForMjml(token, "image"), token);
+});
+
+test("resolveSrcForMjml token passthrough: hybrid string (URL + token)", () => {
+  const hybrid = "https://cdn.example.com/{{ injector.user.id }}/photo.jpg";
+  assert.equal(resolveSrcForMjml(hybrid, "image"), hybrid);
+});
+
+test("resolveSrcForMjml empty string returns placeholder", () => {
+  const result = resolveSrcForMjml("", "image");
+  assert.ok(result.startsWith("data:image/svg+xml"), "Empty → placeholder");
+});
+
+test("resolveSrcForMjml whitespace-only returns placeholder", () => {
+  const result = resolveSrcForMjml("   ", "image");
+  assert.ok(result.startsWith("data:image/svg+xml"), "Whitespace → placeholder");
+});
+
+test("resolveSrcForMjml valid URL is returned directly", () => {
+  const url = "https://example.com/img.png";
+  assert.equal(resolveSrcForMjml(url, "image"), url);
+});
+
+test("resolveSrcForMjml never calls placeholder when token present", () => {
+  const token = "{{ injector.user.avatar }}";
+  const result = resolveSrcForMjml(token, "image");
+  assert.ok(!result.startsWith("data:image/svg+xml"), "Token → no placeholder");
+});

--- a/web/src/components/templates/empty-media-placeholder.ts
+++ b/web/src/components/templates/empty-media-placeholder.ts
@@ -1,0 +1,49 @@
+const DEFAULT_IMAGE_WIDTH = 600;
+const DEFAULT_IMAGE_HEIGHT = 200;
+const DEFAULT_VIDEO_WIDTH = 600;
+const DEFAULT_VIDEO_HEIGHT = 340;
+
+const TOKEN_PATTERN = /\{\{[^}]+\}\}/;
+
+export function emptyMediaPlaceholder(
+  kind: "image" | "video",
+  opts?: { width?: number; height?: number },
+): string {
+  const width =
+    opts?.width ??
+    (kind === "video" ? DEFAULT_VIDEO_WIDTH : DEFAULT_IMAGE_WIDTH);
+  const height =
+    opts?.height ??
+    (kind === "video" ? DEFAULT_VIDEO_HEIGHT : DEFAULT_IMAGE_HEIGHT);
+  const label = kind === "video" ? "No video" : "No image";
+
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
+    `<rect width="100%" height="100%" fill="#e5e7eb"/>` +
+    `<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#9ca3af">${label}</text>` +
+    `</svg>`;
+
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+/**
+ * Resolves the `src` attribute value for MJML serialization.
+ *
+ * Precedence:
+ * 1. If the raw value contains a `{{ ... }}` token → return as-is (token passthrough).
+ * 2. If the raw value is empty or whitespace-only → return placeholder data URI.
+ * 3. Otherwise → return the raw value directly (URL or other non-empty string).
+ */
+export function resolveSrcForMjml(
+  raw: string,
+  kind: "image" | "video",
+  dims?: { width?: number; height?: number },
+): string {
+  if (TOKEN_PATTERN.test(raw)) {
+    return raw;
+  }
+  if (!raw.trim()) {
+    return emptyMediaPlaceholder(kind, dims);
+  }
+  return raw;
+}

--- a/web/src/components/templates/empty-media-placeholder.ts
+++ b/web/src/components/templates/empty-media-placeholder.ts
@@ -5,25 +5,29 @@ const DEFAULT_VIDEO_HEIGHT = 340;
 
 const TOKEN_PATTERN = /\{\{[^}]+\}\}/;
 
-export function emptyMediaPlaceholder(
-  kind: "image" | "video",
-  opts?: { width?: number; height?: number },
-): string {
-  const width =
-    opts?.width ??
-    (kind === "video" ? DEFAULT_VIDEO_WIDTH : DEFAULT_IMAGE_WIDTH);
-  const height =
-    opts?.height ??
-    (kind === "video" ? DEFAULT_VIDEO_HEIGHT : DEFAULT_IMAGE_HEIGHT);
-  const label = kind === "video" ? "No video" : "No image";
+const DEFAULT_IMAGE_PLACEHOLDER = buildPlaceholderUri("No image", DEFAULT_IMAGE_WIDTH, DEFAULT_IMAGE_HEIGHT);
+const DEFAULT_VIDEO_PLACEHOLDER = buildPlaceholderUri("No video", DEFAULT_VIDEO_WIDTH, DEFAULT_VIDEO_HEIGHT);
 
+function buildPlaceholderUri(label: string, width: number, height: number): string {
   const svg =
     `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
     `<rect width="100%" height="100%" fill="#e5e7eb"/>` +
     `<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#9ca3af">${label}</text>` +
     `</svg>`;
-
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+export function emptyMediaPlaceholder(
+  kind: "image" | "video",
+  opts?: { width?: number; height?: number },
+): string {
+  if (!opts?.width && !opts?.height) {
+    return kind === "video" ? DEFAULT_VIDEO_PLACEHOLDER : DEFAULT_IMAGE_PLACEHOLDER;
+  }
+  const width = opts.width ?? (kind === "video" ? DEFAULT_VIDEO_WIDTH : DEFAULT_IMAGE_WIDTH);
+  const height = opts.height ?? (kind === "video" ? DEFAULT_VIDEO_HEIGHT : DEFAULT_IMAGE_HEIGHT);
+  const label = kind === "video" ? "No video" : "No image";
+  return buildPlaceholderUri(label, width, height);
 }
 
 /**
@@ -37,13 +41,14 @@ export function emptyMediaPlaceholder(
 export function resolveSrcForMjml(
   raw: string,
   kind: "image" | "video",
-  dims?: { width?: number; height?: number },
+  widthStr?: string,
 ): string {
   if (TOKEN_PATTERN.test(raw)) {
     return raw;
   }
   if (!raw.trim()) {
-    return emptyMediaPlaceholder(kind, dims);
+    const width = widthStr ? Number.parseInt(widthStr, 10) || undefined : undefined;
+    return emptyMediaPlaceholder(kind, width ? { width } : undefined);
   }
   return raw;
 }

--- a/web/src/components/templates/metadata-token-input.tsx
+++ b/web/src/components/templates/metadata-token-input.tsx
@@ -599,8 +599,10 @@ export const MetadataTokenInput = forwardRef<
         data-placeholder={placeholder}
         onFocus={() => onFocus?.()}
         onInput={(event) => {
-          const segments = parseSegmentsFromEditorNode(event.currentTarget);
-          applySegments(segments);
+          const editor = event.currentTarget;
+          const caret = getSelectionUnitRange(editor);
+          const segments = parseSegmentsFromEditorNode(editor);
+          applySegments(segments, caret.end);
         }}
         onClick={(event) => {
           const target = event.target as HTMLElement | null;

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -4471,21 +4471,27 @@ export function MjmlEditor({
                             {block.type === "image" ? (
                               <>
                                 <Label className="text-xs">Source</Label>
-                                <MetadataTokenInput
-                                  ref={(handle) => {
-                                    metadataFieldRefs.current.set(`${block.id}:image_src`, handle);
-                                  }}
-                                  value={block.src}
-                                  className="h-8 mt-1"
-                                  onChange={(value) =>
-                                    updateImageBlock(block.id, "src", value)
-                                  }
-                                  onFocus={() => focusMetadataField(`${block.id}:image_src`)}
-                                  disabled={isReadOnlyMode}
-                                  ariaLabel="Image source URL"
-                                  placeholder="https://example.com/image.png"
-                                  resolveTokenMeta={resolveMetadataTokenMeta}
-                                />
+                                {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+                                <div onClick={(e) => e.stopPropagation()}>
+                                  <MetadataTokenInput
+                                    ref={(handle) => {
+                                      metadataFieldRefs.current.set(`${block.id}:image_src`, handle);
+                                    }}
+                                    value={block.src}
+                                    className="h-8 mt-1"
+                                    onChange={(value) =>
+                                      updateImageBlock(block.id, "src", value)
+                                    }
+                                    onFocus={() => {
+                                      setSelectedMetadataField(`${block.id}:image_src`);
+                                      setSelectedBlockId(block.id);
+                                    }}
+                                    disabled={isReadOnlyMode}
+                                    ariaLabel="Image source URL"
+                                    placeholder="https://example.com/image.png"
+                                    resolveTokenMeta={resolveMetadataTokenMeta}
+                                  />
+                                </div>
                                 <Label className="text-xs mt-2">Alt</Label>
                                 <Input
                                   value={block.alt || ""}
@@ -4688,49 +4694,61 @@ export function MjmlEditor({
                               <div className="space-y-2">
                                 <div>
                                   <Label className="text-xs">Video URL</Label>
-                                  <MetadataTokenInput
-                                    ref={(handle) => {
-                                      metadataFieldRefs.current.set(`${block.id}:video_url`, handle);
-                                    }}
-                                    value={block.videoUrl}
-                                    className="h-8 mt-1"
-                                    placeholder="https://youtube.com/watch?v=..."
-                                    onChange={(url) => {
-                                      if (!builderDocument) return;
-                                      const thumb = extractVideoThumbnail(url);
-                                      updateBuilderDocument({
-                                        ...builderDocument,
-                                        blocks: builderDocument.blocks.map((b) => {
-                                          if (b.id !== block.id || b.type !== "video") return b;
-                                          return {
-                                            ...b,
-                                            videoUrl: url,
-                                            ...(thumb ? { thumbnailUrl: thumb } : {}),
-                                          };
-                                        }),
-                                      });
-                                    }}
-                                    onFocus={() => focusMetadataField(`${block.id}:video_url`)}
-                                    disabled={isReadOnlyMode}
-                                    ariaLabel="Video URL"
-                                    resolveTokenMeta={resolveMetadataTokenMeta}
-                                  />
+                                  {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+                                  <div onClick={(e) => e.stopPropagation()}>
+                                    <MetadataTokenInput
+                                      ref={(handle) => {
+                                        metadataFieldRefs.current.set(`${block.id}:video_url`, handle);
+                                      }}
+                                      value={block.videoUrl}
+                                      className="h-8 mt-1"
+                                      placeholder="https://youtube.com/watch?v=..."
+                                      onChange={(url) => {
+                                        if (!builderDocument) return;
+                                        const thumb = extractVideoThumbnail(url);
+                                        updateBuilderDocument({
+                                          ...builderDocument,
+                                          blocks: builderDocument.blocks.map((b) => {
+                                            if (b.id !== block.id || b.type !== "video") return b;
+                                            return {
+                                              ...b,
+                                              videoUrl: url,
+                                              ...(thumb ? { thumbnailUrl: thumb } : {}),
+                                            };
+                                          }),
+                                        });
+                                      }}
+                                      onFocus={() => {
+                                        setSelectedMetadataField(`${block.id}:video_url`);
+                                        setSelectedBlockId(block.id);
+                                      }}
+                                      disabled={isReadOnlyMode}
+                                      ariaLabel="Video URL"
+                                      resolveTokenMeta={resolveMetadataTokenMeta}
+                                    />
+                                  </div>
                                 </div>
                                 <div>
                                   <Label className="text-xs">Thumbnail URL</Label>
-                                  <MetadataTokenInput
-                                    ref={(handle) => {
-                                      metadataFieldRefs.current.set(`${block.id}:video_thumbnail`, handle);
-                                    }}
-                                    value={block.thumbnailUrl}
-                                    className="h-8 mt-1"
-                                    placeholder="https://img.youtube.com/vi/ID/maxresdefault.jpg"
-                                    onChange={(value) => updateVideoBlock(block.id, "thumbnailUrl", value)}
-                                    onFocus={() => focusMetadataField(`${block.id}:video_thumbnail`)}
-                                    disabled={isReadOnlyMode}
-                                    ariaLabel="Video thumbnail URL"
-                                    resolveTokenMeta={resolveMetadataTokenMeta}
-                                  />
+                                  {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+                                  <div onClick={(e) => e.stopPropagation()}>
+                                    <MetadataTokenInput
+                                      ref={(handle) => {
+                                        metadataFieldRefs.current.set(`${block.id}:video_thumbnail`, handle);
+                                      }}
+                                      value={block.thumbnailUrl}
+                                      className="h-8 mt-1"
+                                      placeholder="https://img.youtube.com/vi/ID/maxresdefault.jpg"
+                                      onChange={(value) => updateVideoBlock(block.id, "thumbnailUrl", value)}
+                                      onFocus={() => {
+                                        setSelectedMetadataField(`${block.id}:video_thumbnail`);
+                                        setSelectedBlockId(block.id);
+                                      }}
+                                      disabled={isReadOnlyMode}
+                                      ariaLabel="Video thumbnail URL"
+                                      resolveTokenMeta={resolveMetadataTokenMeta}
+                                    />
+                                  </div>
                                 </div>
                                 {block.thumbnailUrl && (
                                   <div className="mt-1 rounded border overflow-hidden relative">

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -1600,9 +1600,7 @@ function renderColumnBlockToMjml(block: BuilderBlock): string {
         block.segments
       ).trim() || "Button"}</mj-button>`;
     case "image": {
-      const imageSrc = resolveSrcForMjml(block.src, "image", {
-        width: block.width ? Number.parseInt(block.width, 10) || undefined : undefined,
-      });
+      const imageSrc = resolveSrcForMjml(block.src, "image", block.width);
       return `\n<mj-image src="${imageSrc}"${
         block.width ? ` width="${block.width}"` : ""
       }${block.alt ? ` alt="${block.alt}"` : ""} />`;
@@ -2104,15 +2102,7 @@ export function MjmlEditor({
         const controller = new AbortController();
         abortControllerRef.current = controller;
 
-        const signal =
-          typeof AbortSignal.any === "function"
-            ? AbortSignal.any([controller.signal, AbortSignal.timeout(10_000)])
-            : controller.signal;
-
-        const fallbackTimer =
-          typeof AbortSignal.any !== "function"
-            ? setTimeout(() => controller.abort(), 10_000)
-            : undefined;
+        const signal = AbortSignal.any([controller.signal, AbortSignal.timeout(10_000)]);
 
         try {
           const result = await previewMutation.mutateAsync({ bodyMjml: code, signal });
@@ -2121,9 +2111,7 @@ export function MjmlEditor({
           if (err instanceof Error && err.name === "AbortError") {
             return;
           }
-          // Mantiene el comportamiento anterior: preview anterior si falla.
         } finally {
-          clearTimeout(fallbackTimer);
           if (abortControllerRef.current === controller) {
             abortControllerRef.current = undefined;
           }
@@ -2132,6 +2120,13 @@ export function MjmlEditor({
     },
     [previewMutation]
   );
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(previewTimeoutRef.current);
+      abortControllerRef.current?.abort();
+    };
+  }, []);
 
   const serializedEditorData = useMemo(() => {
     if (!version?.editor_data) {
@@ -4471,14 +4466,13 @@ export function MjmlEditor({
                             {block.type === "image" ? (
                               <>
                                 <Label className="text-xs">Source</Label>
-                                {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
                                 <div onClick={(e) => e.stopPropagation()}>
                                   <MetadataTokenInput
                                     ref={(handle) => {
                                       metadataFieldRefs.current.set(`${block.id}:image_src`, handle);
                                     }}
                                     value={block.src}
-                                    className="h-8 mt-1"
+                                    className="min-h-8 mt-1"
                                     onChange={(value) =>
                                       updateImageBlock(block.id, "src", value)
                                     }
@@ -4694,14 +4688,13 @@ export function MjmlEditor({
                               <div className="space-y-2">
                                 <div>
                                   <Label className="text-xs">Video URL</Label>
-                                  {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
                                   <div onClick={(e) => e.stopPropagation()}>
                                     <MetadataTokenInput
                                       ref={(handle) => {
                                         metadataFieldRefs.current.set(`${block.id}:video_url`, handle);
                                       }}
                                       value={block.videoUrl}
-                                      className="h-8 mt-1"
+                                      className="min-h-8 mt-1"
                                       placeholder="https://youtube.com/watch?v=..."
                                       onChange={(url) => {
                                         if (!builderDocument) return;
@@ -4730,14 +4723,13 @@ export function MjmlEditor({
                                 </div>
                                 <div>
                                   <Label className="text-xs">Thumbnail URL</Label>
-                                  {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
                                   <div onClick={(e) => e.stopPropagation()}>
                                     <MetadataTokenInput
                                       ref={(handle) => {
                                         metadataFieldRefs.current.set(`${block.id}:video_thumbnail`, handle);
                                       }}
                                       value={block.thumbnailUrl}
-                                      className="h-8 mt-1"
+                                      className="min-h-8 mt-1"
                                       placeholder="https://img.youtube.com/vi/ID/maxresdefault.jpg"
                                       onChange={(value) => updateVideoBlock(block.id, "thumbnailUrl", value)}
                                       onFocus={() => {

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -2711,9 +2711,9 @@ export function MjmlEditor({
       newBlock = {
         id,
         type: "image",
-        src: "https://placehold.co/600x200",
-        alt: "image",
-        width: "100%",
+        src: "",
+        alt: "",
+        width: "",
         align: "left",
       };
     } else if (type === "divider") {

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -71,6 +71,7 @@ import {
   type BuilderInjectorVariablePresentation,
 } from "./injector-variable-presentation";
 import { mjmlVarsToTiptapHtml } from "./template-variable-html";
+import { resolveSrcForMjml } from "./empty-media-placeholder";
 import { renderTextBlockToMjml } from "./text-block-mjml";
 import {
   extractOriginalThumbnailUrl,
@@ -129,7 +130,9 @@ const metadataSchema = z.object({
 });
 
 type MetadataForm = z.infer<typeof metadataSchema>;
-type TokenizableMetadataFieldKey = "subject" | "from_name";
+type StaticMetadataFieldKey = "subject" | "from_name";
+type MediaFieldKey = `${string}:${"image_src" | "video_url" | "video_thumbnail"}`;
+type MetadataFieldRefKey = StaticMetadataFieldKey | MediaFieldKey;
 
 type BuilderBlockType = "text" | "button" | "image" | "divider" | "spacer" | "banner" | "video" | "list";
 
@@ -1596,10 +1599,14 @@ function renderColumnBlockToMjml(block: BuilderBlock): string {
       return `<mj-button href="${block.href || "#"}">${renderSegmentsToText(
         block.segments
       ).trim() || "Button"}</mj-button>`;
-    case "image":
-      return `\n<mj-image src="${block.src || ""}"${
+    case "image": {
+      const imageSrc = resolveSrcForMjml(block.src, "image", {
+        width: block.width ? Number.parseInt(block.width, 10) || undefined : undefined,
+      });
+      return `\n<mj-image src="${imageSrc}"${
         block.width ? ` width="${block.width}"` : ""
       }${block.alt ? ` alt="${block.alt}"` : ""} />`;
+    }
     case "divider":
       return "\n<mj-divider />";
     case "spacer":
@@ -1799,6 +1806,7 @@ export function MjmlEditor({
   const saveLocaleMutation = useSaveTemplateLocale(scopedPath, templateId, versionId);
   const deleteLocaleMutation = useDeleteTemplateLocale(scopedPath, templateId, versionId);
   const previewTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const abortControllerRef = useRef<AbortController | undefined>(undefined);
   const resizeRef = useRef<{ startX: number; startWidth: number } | null>(
     null
   );
@@ -1808,7 +1816,7 @@ export function MjmlEditor({
   const [codeOverride, setCodeOverride] = useState("");
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
   const [selectedMetadataField, setSelectedMetadataField] =
-    useState<TokenizableMetadataFieldKey | null>(null);
+    useState<MetadataFieldRefKey | null>(null);
   const [collapsedBlocks, setCollapsedBlocks] = useState<Record<string, boolean>>({});
   const [previewSplitMode, setPreviewSplitMode] =
     useState<PreviewSplitMode>("ratio");
@@ -1825,9 +1833,9 @@ export function MjmlEditor({
   const previewPanelWrapRef = useRef<HTMLDivElement | null>(null);
   const blockEditorRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const textBlockEditorRefs = useRef<Record<string, TextBlockEditorHandle | null>>({});
-  const metadataFieldRefs = useRef<
-    Partial<Record<TokenizableMetadataFieldKey, MetadataTokenInputHandle | null>>
-  >({});
+  const metadataFieldRefs = useRef<Map<MetadataFieldRefKey, MetadataTokenInputHandle | null>>(
+    new Map()
+  );
   const metadataPanelId = useId();
   const previewStageRef = useRef<HTMLDivElement | null>(null);
   const previewStageObserverRef = useRef<ResizeObserver | null>(null);
@@ -2085,18 +2093,40 @@ export function MjmlEditor({
 
   const triggerPreview = useCallback(
     (code: string) => {
-      if (previewTimeoutRef.current) {
-        clearTimeout(previewTimeoutRef.current);
-      }
+      clearTimeout(previewTimeoutRef.current);
+      abortControllerRef.current?.abort();
+
       previewTimeoutRef.current = setTimeout(async () => {
         if (!code.trim()) {
           return;
         }
+
+        const controller = new AbortController();
+        abortControllerRef.current = controller;
+
+        const signal =
+          typeof AbortSignal.any === "function"
+            ? AbortSignal.any([controller.signal, AbortSignal.timeout(10_000)])
+            : controller.signal;
+
+        const fallbackTimer =
+          typeof AbortSignal.any !== "function"
+            ? setTimeout(() => controller.abort(), 10_000)
+            : undefined;
+
         try {
-          const result = await previewMutation.mutateAsync(code);
+          const result = await previewMutation.mutateAsync({ bodyMjml: code, signal });
           setPreviewHtml(sanitizePreviewHtml(result.html));
-        } catch {
+        } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") {
+            return;
+          }
           // Mantiene el comportamiento anterior: preview anterior si falla.
+        } finally {
+          clearTimeout(fallbackTimer);
+          if (abortControllerRef.current === controller) {
+            abortControllerRef.current = undefined;
+          }
         }
       }, 800);
     },
@@ -2591,7 +2621,7 @@ export function MjmlEditor({
     autoSave.scheduleSave();
   }
 
-  function focusMetadataField(field: TokenizableMetadataFieldKey) {
+  function focusMetadataField(field: MetadataFieldRefKey) {
     setSelectedMetadataField(field);
     setSelectedBlockId(null);
   }
@@ -2744,6 +2774,13 @@ export function MjmlEditor({
 
   function removeBlock(blockId: string) {
     if (!builderDocument || !canEditDraft) return;
+
+    metadataFieldRefs.current.delete(`${blockId}:image_src`);
+    metadataFieldRefs.current.delete(`${blockId}:video_url`);
+    metadataFieldRefs.current.delete(`${blockId}:video_thumbnail`);
+    if (selectedMetadataField?.startsWith(`${blockId}:`)) {
+      setSelectedMetadataField(null);
+    }
 
     const remaining = builderDocument.blocks.filter((block) => block.id !== blockId);
     if (!remaining.length) {
@@ -2943,7 +2980,7 @@ export function MjmlEditor({
   }
 
   function appendTemplateVariableToMetadataField(
-    field: TokenizableMetadataFieldKey,
+    field: MetadataFieldRefKey,
     variable: TemplateVariable,
   ) {
     if (!canEditDraft) return;
@@ -2953,7 +2990,7 @@ export function MjmlEditor({
     const token = normalizeVariableToken(variable.token);
     if (!token) return;
 
-    const editor = metadataFieldRefs.current[field];
+    const editor = metadataFieldRefs.current.get(field);
     if (editor) {
       editor.insertVariable({
         token,
@@ -2963,12 +3000,16 @@ export function MjmlEditor({
       return;
     }
 
-    const currentValue = getValues(field) ?? "";
-    const prefix = currentValue && !/\s$/.test(currentValue) ? " " : "";
-    handleMetadataFieldChange(
-      field,
-      `${currentValue}${prefix}${variableToPlaceholder(token)}`,
-    );
+    // Fallback: only applies to static form fields (subject, from_name)
+    const staticField = field as keyof MetadataForm;
+    if (staticField === "subject" || staticField === "from_name") {
+      const currentValue = getValues(staticField) ?? "";
+      const prefix = currentValue && !/\s$/.test(currentValue) ? " " : "";
+      handleMetadataFieldChange(
+        staticField,
+        `${currentValue}${prefix}${variableToPlaceholder(token)}`,
+      );
+    }
   }
 
   function appendTemplateVariable(variable: TemplateVariable) {
@@ -4416,13 +4457,20 @@ export function MjmlEditor({
                             {block.type === "image" ? (
                               <>
                                 <Label className="text-xs">Source</Label>
-                                <Input
+                                <MetadataTokenInput
+                                  ref={(handle) => {
+                                    metadataFieldRefs.current.set(`${block.id}:image_src`, handle);
+                                  }}
                                   value={block.src}
                                   className="h-8 mt-1"
-                                  onChange={(ev) =>
-                                    updateImageBlock(block.id, "src", ev.target.value)
+                                  onChange={(value) =>
+                                    updateImageBlock(block.id, "src", value)
                                   }
-                                  readOnly={isReadOnlyMode}
+                                  onFocus={() => focusMetadataField(`${block.id}:image_src`)}
+                                  disabled={isReadOnlyMode}
+                                  ariaLabel="Image source URL"
+                                  placeholder="https://example.com/image.png"
+                                  resolveTokenMeta={resolveMetadataTokenMeta}
                                 />
                                 <Label className="text-xs mt-2">Alt</Label>
                                 <Input
@@ -4626,13 +4674,15 @@ export function MjmlEditor({
                               <div className="space-y-2">
                                 <div>
                                   <Label className="text-xs">Video URL</Label>
-                                  <Input
+                                  <MetadataTokenInput
+                                    ref={(handle) => {
+                                      metadataFieldRefs.current.set(`${block.id}:video_url`, handle);
+                                    }}
                                     value={block.videoUrl}
                                     className="h-8 mt-1"
                                     placeholder="https://youtube.com/watch?v=..."
-                                    onChange={(ev) => {
+                                    onChange={(url) => {
                                       if (!builderDocument) return;
-                                      const url = ev.target.value;
                                       const thumb = extractVideoThumbnail(url);
                                       updateBuilderDocument({
                                         ...builderDocument,
@@ -4646,17 +4696,26 @@ export function MjmlEditor({
                                         }),
                                       });
                                     }}
-                                    readOnly={isReadOnlyMode}
+                                    onFocus={() => focusMetadataField(`${block.id}:video_url`)}
+                                    disabled={isReadOnlyMode}
+                                    ariaLabel="Video URL"
+                                    resolveTokenMeta={resolveMetadataTokenMeta}
                                   />
                                 </div>
                                 <div>
                                   <Label className="text-xs">Thumbnail URL</Label>
-                                  <Input
+                                  <MetadataTokenInput
+                                    ref={(handle) => {
+                                      metadataFieldRefs.current.set(`${block.id}:video_thumbnail`, handle);
+                                    }}
                                     value={block.thumbnailUrl}
                                     className="h-8 mt-1"
                                     placeholder="https://img.youtube.com/vi/ID/maxresdefault.jpg"
-                                    onChange={(ev) => updateVideoBlock(block.id, "thumbnailUrl", ev.target.value)}
-                                    readOnly={isReadOnlyMode}
+                                    onChange={(value) => updateVideoBlock(block.id, "thumbnailUrl", value)}
+                                    onFocus={() => focusMetadataField(`${block.id}:video_thumbnail`)}
+                                    disabled={isReadOnlyMode}
+                                    ariaLabel="Video thumbnail URL"
+                                    resolveTokenMeta={resolveMetadataTokenMeta}
                                   />
                                 </div>
                                 {block.thumbnailUrl && (
@@ -4920,7 +4979,7 @@ export function MjmlEditor({
                 <Label className="text-xs font-medium">Subject</Label>
                 <MetadataTokenInput
                   ref={(handle) => {
-                    metadataFieldRefs.current.subject = handle;
+                    metadataFieldRefs.current.set("subject", handle);
                   }}
                   value={watchedSubject}
                   onChange={(value) => handleMetadataFieldChange("subject", value)}
@@ -4962,7 +5021,7 @@ export function MjmlEditor({
                 <Label className="text-xs font-medium">From Name</Label>
                 <MetadataTokenInput
                   ref={(handle) => {
-                    metadataFieldRefs.current.from_name = handle;
+                    metadataFieldRefs.current.set("from_name", handle);
                   }}
                   value={watchedFromName}
                   onChange={(value) => handleMetadataFieldChange("from_name", value)}

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -2240,7 +2240,9 @@ export function MjmlEditor({
       );
     };
 
-    clampToContainer(container.clientWidth);
+    requestAnimationFrame(() => {
+      clampToContainer(container.clientWidth);
+    });
 
     const observer = new ResizeObserver((entries) => {
       const rect = entries[0]?.contentRect;

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -2742,7 +2742,7 @@ export function MjmlEditor({
         id,
         type: "video",
         videoUrl: "",
-        thumbnailUrl: "https://placehold.co/600x340",
+        thumbnailUrl: "",
         alt: "Video thumbnail",
         width: "100%",
         align: "center",
@@ -2954,6 +2954,18 @@ export function MjmlEditor({
           category: variable.category,
         });
       }
+      return;
+    }
+
+    // Image blocks: route to the image_src metadata field
+    if (targetBlock.type === "image") {
+      appendTemplateVariableToMetadataField(`${targetId}:image_src`, variable);
+      return;
+    }
+
+    // Video blocks: route to the video_url metadata field
+    if (targetBlock.type === "video") {
+      appendTemplateVariableToMetadataField(`${targetId}:video_url`, variable);
       return;
     }
 
@@ -4162,12 +4174,12 @@ export function MjmlEditor({
                                           <div className="space-y-1">
                                             <p className="font-mono font-semibold text-[11px]">{tooltip.name}</p>
                                             {tooltip.description ? (
-                                              <p className="text-[10px] leading-snug text-white/90">
+                                              <p className="text-[10px] leading-snug text-background/90">
                                                 {tooltip.description}
                                               </p>
                                             ) : null}
                                             {tooltip.injectorDescription ? (
-                                              <p className="text-[10px] leading-snug text-white/75">
+                                              <p className="text-[10px] leading-snug text-background/75">
                                                 {tooltip.injectorDescription}
                                               </p>
                                             ) : null}
@@ -4178,8 +4190,8 @@ export function MjmlEditor({
                                                 key={`${item.id}-${detail.label}`}
                                                 className="contents"
                                               >
-                                                <span className="text-white/65">{detail.label}</span>
-                                                <span className="font-medium text-white">{detail.value}</span>
+                                                <span className="text-background/65">{detail.label}</span>
+                                                <span className="font-medium text-background">{detail.value}</span>
                                               </div>
                                             ))}
                                           </div>

--- a/web/src/components/templates/text-block-editor.tsx
+++ b/web/src/components/templates/text-block-editor.tsx
@@ -485,7 +485,7 @@ export const TextBlockEditor = forwardRef<TextBlockEditorHandle, TextBlockEditor
       >
         <EditorContent
           editor={editor}
-          className="[&_.tiptap]:min-h-6 [&_.tiptap]:min-w-0 [&_.tiptap]:w-full [&_.tiptap]:outline-none [&_.tiptap]:text-sm [&_.tiptap]:whitespace-pre-wrap [&_.tiptap]:break-words [&_.tiptap]:[overflow-wrap:anywhere] [&_.tiptap_p]:my-0 [&_.tiptap_p]:min-w-0 [&_.tiptap_p]:max-w-full [&_.tiptap_span[data-variable-token]]:max-w-full [&_.tiptap_.ProseMirror-trailingBreak]:block"
+          className="[&_.tiptap]:min-h-6 [&_.tiptap]:min-w-0 [&_.tiptap]:w-full [&_.tiptap]:outline-none [&_.tiptap]:text-sm [&_.tiptap]:whitespace-pre-wrap [&_.tiptap]:break-words [&_.tiptap]:[overflow-wrap:anywhere] [&_.tiptap_p]:my-0 [&_.tiptap_p]:min-h-[1.25em] [&_.tiptap_p]:min-w-0 [&_.tiptap_p]:max-w-full [&_.tiptap_span[data-variable-token]]:max-w-full [&_.tiptap_.ProseMirror-trailingBreak]:block"
         />
       </div>
     </div>

--- a/web/src/components/templates/text-block-editor.tsx
+++ b/web/src/components/templates/text-block-editor.tsx
@@ -151,7 +151,7 @@ export const TextBlockEditor = forwardRef<TextBlockEditorHandle, TextBlockEditor
     onFocus: () => onFocus?.(),
     editorProps: {
       attributes: {
-        class: "min-h-6 w-full outline-none text-sm",
+        class: "min-h-6 w-full outline-none text-sm leading-normal",
         "data-placeholder": effectivePlaceholder,
       },
       handleDrop: (view, event) => {
@@ -479,13 +479,13 @@ export const TextBlockEditor = forwardRef<TextBlockEditorHandle, TextBlockEditor
       {/* Editor */}
       <div
         className={cn(
-          "rounded-md border border-input bg-background px-2 py-1.5 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+          "rounded-md border border-input bg-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
           disabled && "opacity-60",
         )}
       >
         <EditorContent
           editor={editor}
-          className="[&_.tiptap]:min-h-6 [&_.tiptap]:leading-normal [&_.tiptap]:min-w-0 [&_.tiptap]:w-full [&_.tiptap]:outline-none [&_.tiptap]:text-sm [&_.tiptap]:whitespace-pre-wrap [&_.tiptap]:break-words [&_.tiptap]:[overflow-wrap:anywhere] [&_.tiptap_p]:my-0 [&_.tiptap_p]:min-h-[1.25em] [&_.tiptap_p]:leading-normal [&_.tiptap_p]:min-w-0 [&_.tiptap_p]:max-w-full [&_.tiptap_span[data-variable-token]]:max-w-full [&_.tiptap_.ProseMirror-trailingBreak]:block"
+          className="[&_.tiptap]:min-h-6 [&_.tiptap]:px-2 [&_.tiptap]:py-1.5 [&_.tiptap]:leading-normal [&_.tiptap]:min-w-0 [&_.tiptap]:w-full [&_.tiptap]:outline-none [&_.tiptap]:text-sm [&_.tiptap]:whitespace-pre-wrap [&_.tiptap]:break-words [&_.tiptap]:[overflow-wrap:anywhere] [&_.tiptap_p]:my-0 [&_.tiptap_p]:min-h-[1.25em] [&_.tiptap_p]:leading-normal [&_.tiptap_p]:min-w-0 [&_.tiptap_p]:max-w-full [&_.tiptap_span[data-variable-token]]:max-w-full [&_.tiptap_.ProseMirror-trailingBreak]:block"
         />
       </div>
     </div>

--- a/web/src/components/templates/text-block-editor.tsx
+++ b/web/src/components/templates/text-block-editor.tsx
@@ -151,7 +151,6 @@ export const TextBlockEditor = forwardRef<TextBlockEditorHandle, TextBlockEditor
     onFocus: () => onFocus?.(),
     editorProps: {
       attributes: {
-        class: "min-h-6 w-full outline-none text-sm leading-normal",
         "data-placeholder": effectivePlaceholder,
       },
       handleDrop: (view, event) => {
@@ -485,7 +484,7 @@ export const TextBlockEditor = forwardRef<TextBlockEditorHandle, TextBlockEditor
       >
         <EditorContent
           editor={editor}
-          className="[&_.tiptap]:min-h-6 [&_.tiptap]:px-2 [&_.tiptap]:py-1.5 [&_.tiptap]:leading-normal [&_.tiptap]:min-w-0 [&_.tiptap]:w-full [&_.tiptap]:outline-none [&_.tiptap]:text-sm [&_.tiptap]:whitespace-pre-wrap [&_.tiptap]:break-words [&_.tiptap]:[overflow-wrap:anywhere] [&_.tiptap_p]:my-0 [&_.tiptap_p]:min-h-[1.25em] [&_.tiptap_p]:leading-normal [&_.tiptap_p]:min-w-0 [&_.tiptap_p]:max-w-full [&_.tiptap_span[data-variable-token]]:max-w-full [&_.tiptap_.ProseMirror-trailingBreak]:block"
+          className="[&_.tiptap]:min-h-6 [&_.tiptap]:px-2 [&_.tiptap]:py-1.5 [&_.tiptap]:leading-normal [&_.tiptap]:min-w-0 [&_.tiptap]:w-full [&_.tiptap]:outline-none [&_.tiptap]:text-sm [&_.tiptap]:whitespace-pre-wrap [&_.tiptap]:break-words [&_.tiptap]:[overflow-wrap:anywhere] [&_.tiptap_p]:my-0 [&_.tiptap_p]:min-h-[1lh] [&_.tiptap_p]:leading-normal [&_.tiptap_p]:min-w-0 [&_.tiptap_p]:max-w-full [&_.tiptap_span[data-variable-token]]:max-w-full [&_.tiptap_.ProseMirror-trailingBreak]:block"
         />
       </div>
     </div>

--- a/web/src/components/templates/text-block-editor.tsx
+++ b/web/src/components/templates/text-block-editor.tsx
@@ -485,7 +485,7 @@ export const TextBlockEditor = forwardRef<TextBlockEditorHandle, TextBlockEditor
       >
         <EditorContent
           editor={editor}
-          className="[&_.tiptap]:min-h-6 [&_.tiptap]:min-w-0 [&_.tiptap]:w-full [&_.tiptap]:outline-none [&_.tiptap]:text-sm [&_.tiptap]:whitespace-pre-wrap [&_.tiptap]:break-words [&_.tiptap]:[overflow-wrap:anywhere] [&_.tiptap_p]:my-0 [&_.tiptap_p]:min-h-[1.25em] [&_.tiptap_p]:min-w-0 [&_.tiptap_p]:max-w-full [&_.tiptap_span[data-variable-token]]:max-w-full [&_.tiptap_.ProseMirror-trailingBreak]:block"
+          className="[&_.tiptap]:min-h-6 [&_.tiptap]:leading-normal [&_.tiptap]:min-w-0 [&_.tiptap]:w-full [&_.tiptap]:outline-none [&_.tiptap]:text-sm [&_.tiptap]:whitespace-pre-wrap [&_.tiptap]:break-words [&_.tiptap]:[overflow-wrap:anywhere] [&_.tiptap_p]:my-0 [&_.tiptap_p]:min-h-[1.25em] [&_.tiptap_p]:leading-normal [&_.tiptap_p]:min-w-0 [&_.tiptap_p]:max-w-full [&_.tiptap_span[data-variable-token]]:max-w-full [&_.tiptap_.ProseMirror-trailingBreak]:block"
         />
       </div>
     </div>

--- a/web/src/components/templates/video-block.ts
+++ b/web/src/components/templates/video-block.ts
@@ -1,3 +1,5 @@
+import { resolveSrcForMjml } from "./empty-media-placeholder.ts";
+
 export type VideoBlockLike = {
   videoUrl: string;
   thumbnailUrl: string;
@@ -47,5 +49,8 @@ export function renderVideoBlockToMjml(block: VideoBlockLike): string {
   const href = block.videoUrl ? ` href="${block.videoUrl}"` : "";
   const width = block.width ? ` width="${block.width}"` : "";
   const alt = block.alt ? ` alt="${block.alt}"` : "";
-  return `\n<mj-image src="${block.thumbnailUrl || ""}"${href}${width}${alt} align="${block.align}" css-class="senda-video" />`;
+  const thumbnailSrc = resolveSrcForMjml(block.thumbnailUrl, "video", {
+    width: block.width ? Number.parseInt(block.width, 10) || undefined : undefined,
+  });
+  return `\n<mj-image src="${thumbnailSrc}"${href}${width}${alt} align="${block.align}" css-class="senda-video" />`;
 }

--- a/web/src/components/templates/video-block.ts
+++ b/web/src/components/templates/video-block.ts
@@ -49,8 +49,6 @@ export function renderVideoBlockToMjml(block: VideoBlockLike): string {
   const href = block.videoUrl ? ` href="${block.videoUrl}"` : "";
   const width = block.width ? ` width="${block.width}"` : "";
   const alt = block.alt ? ` alt="${block.alt}"` : "";
-  const thumbnailSrc = resolveSrcForMjml(block.thumbnailUrl, "video", {
-    width: block.width ? Number.parseInt(block.width, 10) || undefined : undefined,
-  });
+  const thumbnailSrc = resolveSrcForMjml(block.thumbnailUrl, "video", block.width);
   return `\n<mj-image src="${thumbnailSrc}"${href}${width}${alt} align="${block.align}" css-class="senda-video" />`;
 }

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -60,6 +60,7 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
+        aria-describedby={undefined}
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
           className

--- a/web/src/hooks/use-template-version.ts
+++ b/web/src/hooks/use-template-version.ts
@@ -141,10 +141,17 @@ export function usePreviewMjml(scopedPath: string, templateId: string) {
   const api = useApi();
 
   return useMutation({
-    mutationFn: (bodyMjml: string) =>
+    mutationFn: ({
+      bodyMjml,
+      signal,
+    }: {
+      bodyMjml: string;
+      signal?: AbortSignal;
+    }) =>
       api
         .post(`${scopedPath}/templates/${templateId}/preview-mjml`, {
           json: { mjml: bodyMjml },
+          signal,
         })
         .json<MjmlPreviewResponse>(),
   });


### PR DESCRIPTION
## Summary

- **Empty media URLs no longer hang the preview** — generates inline SVG placeholders for image/video blocks with empty `src`/`thumbnailUrl`
- **Tiptap text editor cursor alignment fixed** — empty paragraphs use `min-h-[1lh]` matching line-height so the caret renders within bounds
- **Injector tokens route to the correct field** — clicking an injector variable while an image/video block is selected inserts the token in the media field, not the text block
- **MetadataTokenInput caret no longer jumps** — `onInput` preserves caret position through React re-renders
- **Long injector tokens don't overflow** — `max-w-full truncate` on token chips
- **Preview requests are cancellable** — AbortController with 10s timeout, cleanup on unmount
- **Dark mode tooltip colors** — `text-white` → `text-background` for theme awareness

## Test plan

- [ ] Open template builder → add Video block with empty URL → preview shows "No video" placeholder (no spinner hang)
- [ ] Add Image block → preview shows "No image" placeholder
- [ ] Click in empty text block → cursor `|` aligned within input bounds
- [ ] Type text → press Enter 3x → cursor stays within each empty line
- [ ] Select image block → click injector variable → token appears in Image Source field (not text block)
- [ ] Select video block → click injector variable → token appears in Video URL field
- [ ] In Video URL with token, type text after token → text appears in correct order (no cursor jump)
- [ ] Type a long URL in Image Source → text wraps, input grows (no overflow)