### PR TITLE
feat(sdk): add WorkspaceFilter to ExternalWorkspaceResolver

### DIFF
--- a/cmd/senda-e2e/main.go
+++ b/cmd/senda-e2e/main.go
@@ -113,7 +113,7 @@ func (e2eExternalWorkspaceResolver) Description() string {
 	return "E2E resolver that can force workspace fallback via query params"
 }
 
-func (e2eExternalWorkspaceResolver) ResolveWorkspace(_ context.Context, req *sdk.ExternalIntegrationRequest, _ *sdk.ExternalAuthResult) (*sdk.ExternalWorkspaceResolution, error) {
+func (e2eExternalWorkspaceResolver) ResolveWorkspace(_ context.Context, req *sdk.ExternalIntegrationRequest, _ *sdk.ExternalAuthResult, _ sdk.WorkspaceFilter) (*sdk.ExternalWorkspaceResolution, error) {
 	if req == nil {
 		return nil, errors.New("missing external integration request")
 	}

--- a/internal/adapter/mjml/video_thumbnail.go
+++ b/internal/adapter/mjml/video_thumbnail.go
@@ -51,6 +51,10 @@ func buildVideoThumbnailURL(src, baseURL string) string {
 		return src
 	}
 
+	if strings.HasPrefix(original, "data:") {
+		return original
+	}
+
 	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		return original

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -150,6 +150,8 @@ func newServerOptions(shared serverSharedDeps, handlers serverHandlerBundle) []s
 	var wsExistenceStore port.WorkspaceExistenceStore
 	if ws, ok := shared.workspaceStore.(port.WorkspaceExistenceStore); ok {
 		wsExistenceStore = ws
+	} else {
+		slog.Warn("workspace store does not implement WorkspaceExistenceStore; external workspace filter will be unavailable")
 	}
 	opts = append(opts, externalIntegrationSurfaceOptions(externalIntegrationSurfaceHandlers{
 		externalIntegration:     handlers.externalIntegrationHandler,

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -147,12 +147,17 @@ func newServerOptions(shared serverSharedDeps, handlers serverHandlerBundle) []s
 		sesWebhook:     handlers.sesWebhookHandler,
 		onboarding:     handlers.onboardingHandler,
 	})...)
+	var wsExistenceStore port.WorkspaceExistenceStore
+	if ws, ok := shared.workspaceStore.(port.WorkspaceExistenceStore); ok {
+		wsExistenceStore = ws
+	}
 	opts = append(opts, externalIntegrationSurfaceOptions(externalIntegrationSurfaceHandlers{
-		externalIntegration: handlers.externalIntegrationHandler,
-		injector:            handlers.injectorHandler,
-		workspacePolicy:     handlers.workspacePolicyHandler,
-		templateType:        handlers.templateTypeHandler,
-		template:            handlers.templateHandler,
+		externalIntegration:     handlers.externalIntegrationHandler,
+		injector:                handlers.injectorHandler,
+		workspacePolicy:         handlers.workspacePolicyHandler,
+		templateType:            handlers.templateTypeHandler,
+		template:                handlers.templateHandler,
+		workspaceExistenceStore: wsExistenceStore,
 	})...)
 	opts = append(opts, publicSurfaceOptions(publicSurfaceHandlers{
 		tracking: handlers.trackingHandler,

--- a/internal/app/http_surfaces.go
+++ b/internal/app/http_surfaces.go
@@ -3,6 +3,7 @@ package app
 import (
 	sendahttp "github.com/rendis/senda/internal/http"
 	"github.com/rendis/senda/internal/http/handler"
+	"github.com/rendis/senda/internal/port"
 )
 
 type managementSurfaceHandlers struct {
@@ -64,11 +65,12 @@ func dataPlaneSurfaceOptions(h dataPlaneSurfaceHandlers) []sendahttp.ServerOptio
 }
 
 type externalIntegrationSurfaceHandlers struct {
-	externalIntegration *handler.ExternalIntegrationHandler
-	injector            *handler.InjectorHandler
-	workspacePolicy     *handler.WorkspacePolicyHandler
-	templateType        *handler.TemplateTypeHandler
-	template            *handler.TemplateHandler
+	externalIntegration     *handler.ExternalIntegrationHandler
+	injector                *handler.InjectorHandler
+	workspacePolicy         *handler.WorkspacePolicyHandler
+	templateType            *handler.TemplateTypeHandler
+	template                *handler.TemplateHandler
+	workspaceExistenceStore port.WorkspaceExistenceStore
 }
 
 func externalIntegrationSurfaceOptions(h externalIntegrationSurfaceHandlers) []sendahttp.ServerOption {
@@ -78,6 +80,7 @@ func externalIntegrationSurfaceOptions(h externalIntegrationSurfaceHandlers) []s
 		sendahttp.WithWorkspacePolicyHandler(h.workspacePolicy),
 		sendahttp.WithTemplateTypeHandler(h.templateType),
 		sendahttp.WithTemplateHandler(h.template),
+		sendahttp.WithWorkspaceExistenceStore(h.workspaceExistenceStore),
 	}
 }
 

--- a/internal/http/handler/external_integration_test.go
+++ b/internal/http/handler/external_integration_test.go
@@ -33,7 +33,7 @@ type testExternalResolver struct {
 
 func (t *testExternalResolver) Name() string        { return t.name }
 func (t *testExternalResolver) Description() string { return t.description }
-func (t *testExternalResolver) ResolveWorkspace(context.Context, *port.ExternalIntegrationRequest, *port.ExternalAuthResult) (*port.ExternalWorkspaceResolution, error) {
+func (t *testExternalResolver) ResolveWorkspace(context.Context, *port.ExternalIntegrationRequest, *port.ExternalAuthResult, port.WorkspaceFilter) (*port.ExternalWorkspaceResolution, error) {
 	return &port.ExternalWorkspaceResolution{WorkspaceCode: "_system", ReadOnly: true}, nil
 }
 

--- a/internal/http/middleware/export_test.go
+++ b/internal/http/middleware/export_test.go
@@ -6,6 +6,6 @@ import (
 )
 
 // NewWorkspaceFilterForTest exposes newWorkspaceFilter for external test packages.
-func NewWorkspaceFilterForTest(store port.WorkspaceExistenceStore, tenantCode string, environment domain.Environment) *workspaceFilter {
+func NewWorkspaceFilterForTest(store port.WorkspaceExistenceStore, tenantCode string, environment domain.Environment) port.WorkspaceFilter {
 	return newWorkspaceFilter(store, tenantCode, environment)
 }

--- a/internal/http/middleware/export_test.go
+++ b/internal/http/middleware/export_test.go
@@ -1,0 +1,11 @@
+package middleware
+
+import (
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/port"
+)
+
+// NewWorkspaceFilterForTest exposes newWorkspaceFilter for external test packages.
+func NewWorkspaceFilterForTest(store port.WorkspaceExistenceStore, tenantCode string, environment domain.Environment) *workspaceFilter {
+	return newWorkspaceFilter(store, tenantCode, environment)
+}

--- a/internal/http/middleware/external_integration.go
+++ b/internal/http/middleware/external_integration.go
@@ -66,7 +66,10 @@ type ExternalIntegrationResolverStore interface {
 
 // ExternalIntegration resolves the external profile, auth method and workspace
 // resolver for a request, and stores the resulting state in the echo context.
-func ExternalIntegration(h ExternalIntegrationResolverStore) echo.MiddlewareFunc {
+// store is used to construct a per-request WorkspaceFilter bound to the current
+// tenant and environment; it may be nil for deployments that do not require
+// workspace existence checks.
+func ExternalIntegration(h ExternalIntegrationResolverStore, store port.WorkspaceExistenceStore) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			profile, err := loadExternalProfileForRequest(c, h)
@@ -94,7 +97,7 @@ func ExternalIntegration(h ExternalIntegrationResolverStore) echo.MiddlewareFunc
 				return err
 			}
 
-			resolution, effectiveWorkspaceCode, readOnly, err := resolveExternalWorkspace(c, resolver, reqCtx, authResult)
+			resolution, effectiveWorkspaceCode, readOnly, err := resolveExternalWorkspace(c, resolver, reqCtx, authResult, buildWorkspaceFilter(store, reqCtx))
 			if err != nil || responseCommitted(c) {
 				return err
 			}
@@ -189,8 +192,8 @@ func authenticateExternalRequest(c *echo.Context, authMethod port.ExternalAuthMe
 	return authResult, nil
 }
 
-func resolveExternalWorkspace(c *echo.Context, resolver port.ExternalWorkspaceResolver, reqCtx *port.ExternalIntegrationRequest, authResult *port.ExternalAuthResult) (*port.ExternalWorkspaceResolution, string, bool, error) {
-	resolution, err := resolver.ResolveWorkspace(c.Request().Context(), reqCtx, authResult)
+func resolveExternalWorkspace(c *echo.Context, resolver port.ExternalWorkspaceResolver, reqCtx *port.ExternalIntegrationRequest, authResult *port.ExternalAuthResult, filter port.WorkspaceFilter) (*port.ExternalWorkspaceResolution, string, bool, error) {
+	resolution, err := resolver.ResolveWorkspace(c.Request().Context(), reqCtx, authResult, filter)
 	if err != nil || resolution == nil {
 		return nil, "", false, response.WriteError(c, http.StatusInternalServerError, "INTERNAL_ERROR", "external workspace resolution failed")
 	}
@@ -496,6 +499,16 @@ func patchExternalWorkspaceParam(c *echo.Context, workspaceCode string) {
 		updated = append(updated, pv)
 	}
 	c.SetPathValues(updated)
+}
+
+// buildWorkspaceFilter constructs a per-request WorkspaceFilter bound to the
+// tenant and environment from reqCtx. Returns nil when store is nil so that
+// the resolved filter propagates as a nil port.WorkspaceFilter to the resolver.
+func buildWorkspaceFilter(store port.WorkspaceExistenceStore, reqCtx *port.ExternalIntegrationRequest) port.WorkspaceFilter {
+	if store == nil {
+		return nil
+	}
+	return newWorkspaceFilter(store, reqCtx.TenantCode, reqCtx.Environment)
 }
 
 // ExternalAuthDenied returns a sentinel error that external auth methods can

--- a/internal/http/middleware/workspace_filter.go
+++ b/internal/http/middleware/workspace_filter.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/port"
+)
+
+// workspaceFilter is a per-request implementation of port.WorkspaceFilter that
+// binds a tenant code and environment to the underlying existence store.
+// It is constructed fresh for each request to prevent tenant/environment leakage
+// between concurrent requests.
+type workspaceFilter struct {
+	store       port.WorkspaceExistenceStore
+	tenantCode  string
+	environment domain.Environment
+}
+
+func newWorkspaceFilter(store port.WorkspaceExistenceStore, tenantCode string, environment domain.Environment) *workspaceFilter {
+	return &workspaceFilter{
+		store:       store,
+		tenantCode:  tenantCode,
+		environment: environment,
+	}
+}
+
+// Exists returns a dense map where each requested code is a key. Codes that
+// are active for the tenant are mapped to true; unknown or deleted codes map to
+// false. An empty/nil codes slice returns an empty map without contacting the
+// store (REQ-B4).
+func (f *workspaceFilter) Exists(ctx context.Context, codes []string) (map[string]bool, error) {
+	if len(codes) == 0 {
+		return map[string]bool{}, nil
+	}
+	return f.store.ExistsActiveByTenantCode(ctx, f.tenantCode, codes, f.environment)
+}

--- a/internal/http/middleware/workspace_filter_integration_test.go
+++ b/internal/http/middleware/workspace_filter_integration_test.go
@@ -1,0 +1,163 @@
+//go:build integration
+
+package middleware_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	pgadapter "github.com/rendis/senda/internal/adapter/postgres"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/http/middleware"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// projectRoot returns the absolute path to the project root directory.
+func projectRoot() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..", "..")
+}
+
+func migrationsPath() string {
+	return filepath.Join(projectRoot(), "migrations")
+}
+
+// setupFilterIntegrationDB starts (or reuses) a postgres container and applies migrations.
+func setupFilterIntegrationDB(ctx context.Context, t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	connStr := os.Getenv("SENDA_INTEGRATION_DATABASE_URL")
+	if connStr == "" {
+		dockerfilePath := filepath.Join(projectRoot(), "docker", "postgres")
+		const (
+			dbName = "senda_test"
+			dbUser = "senda"
+			dbPass = "senda"
+		)
+		req := testcontainers.ContainerRequest{
+			FromDockerfile: testcontainers.FromDockerfile{
+				Context:    dockerfilePath,
+				Dockerfile: "Dockerfile",
+			},
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       dbName,
+				"POSTGRES_USER":     dbUser,
+				"POSTGRES_PASSWORD": dbPass,
+			},
+			Cmd: []string{
+				"postgres",
+				"-c", "shared_preload_libraries=pg_cron",
+				"-c", "cron.database_name=" + dbName,
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60 * time.Second),
+		}
+		ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+		if err != nil {
+			t.Fatalf("starting postgres container: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := testcontainers.TerminateContainer(ctr); err != nil {
+				fmt.Fprintf(os.Stderr, "terminating postgres: %v\n", err)
+			}
+		})
+		host, _ := ctr.Host(ctx)
+		port, _ := ctr.MappedPort(ctx, "5432")
+		connStr = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", dbUser, dbPass, host, port.Port(), dbName)
+	}
+
+	if err := pgadapter.RunMigrationsDown(connStr, migrationsPath()); err != nil {
+		t.Fatalf("migrations down: %v", err)
+	}
+	if err := pgadapter.RunMigrations(connStr, migrationsPath()); err != nil {
+		t.Fatalf("migrations up: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Fatalf("creating pool: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	return pool
+}
+
+// TestWorkspaceFilter_EnvironmentHonouredByStore verifies that the workspaceFilter
+// constructed from an X-Senda-Environment header value correctly scopes workspace
+// existence checks to the specified environment. A workspace that exists in prod
+// must not appear as existing when the filter is built for the test environment,
+// and vice-versa.
+func TestWorkspaceFilter_EnvironmentHonouredByStore(t *testing.T) {
+	ctx := context.Background()
+	pool := setupFilterIntegrationDB(ctx, t)
+
+	tenantRepo := pgadapter.NewTenantRepo(pool)
+	workspaceRepo := pgadapter.NewWorkspaceRepo(pool)
+
+	// Create a tenant for this test.
+	tenant := &domain.Tenant{
+		ID:   uuid.New(),
+		Code: "t-" + uuid.New().String()[:8],
+		Name: "Filter Integration Tenant",
+	}
+	if err := tenantRepo.Create(ctx, tenant); err != nil {
+		t.Fatalf("creating tenant: %v", err)
+	}
+
+	// Create a prod workspace and a test workspace with different codes.
+	prodWS := &domain.Workspace{
+		ID:          uuid.New(),
+		TenantID:    tenant.ID,
+		Code:        "marketing",
+		Name:        "Marketing",
+		Environment: domain.EnvironmentProd,
+	}
+	testWS := &domain.Workspace{
+		ID:          uuid.New(),
+		TenantID:    tenant.ID,
+		Code:        "marketing",
+		Name:        "Marketing (test)",
+		Environment: domain.EnvironmentTest,
+	}
+	if err := workspaceRepo.Create(ctx, prodWS); err != nil {
+		t.Fatalf("creating prod workspace: %v", err)
+	}
+	if err := workspaceRepo.Create(ctx, testWS); err != nil {
+		t.Fatalf("creating test workspace: %v", err)
+	}
+
+	// Build a filter for prod — "marketing" must be found.
+	prodFilter := middleware.NewWorkspaceFilterForTest(workspaceRepo, tenant.Code, domain.EnvironmentProd)
+	prodResult, err := prodFilter.Exists(ctx, []string{"marketing", "missing"})
+	if err != nil {
+		t.Fatalf("prod filter Exists() error: %v", err)
+	}
+	if !prodResult["marketing"] {
+		t.Errorf("prod filter: expected marketing=true, got %v", prodResult)
+	}
+	if prodResult["missing"] {
+		t.Errorf("prod filter: expected missing=false, got %v", prodResult)
+	}
+
+	// Build a filter for test — same code must also be found under the test environment.
+	testFilter := middleware.NewWorkspaceFilterForTest(workspaceRepo, tenant.Code, domain.EnvironmentTest)
+	testResult, err := testFilter.Exists(ctx, []string{"marketing"})
+	if err != nil {
+		t.Fatalf("test filter Exists() error: %v", err)
+	}
+	if !testResult["marketing"] {
+		t.Errorf("test filter: expected marketing=true under test env, got %v", testResult)
+	}
+}

--- a/internal/http/middleware/workspace_filter_test.go
+++ b/internal/http/middleware/workspace_filter_test.go
@@ -1,0 +1,97 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rendis/senda/internal/domain"
+)
+
+// fakeWorkspaceExistenceStore is a manual fake for port.WorkspaceExistenceStore.
+type fakeWorkspaceExistenceStore struct {
+	calledWith struct {
+		tenantCode     string
+		workspaceCodes []string
+		environment    domain.Environment
+	}
+	returnResult map[string]bool
+	returnErr    error
+}
+
+func (f *fakeWorkspaceExistenceStore) ExistsActiveByTenantCode(
+	_ context.Context,
+	tenantCode string,
+	workspaceCodes []string,
+	environment domain.Environment,
+) (map[string]bool, error) {
+	f.calledWith.tenantCode = tenantCode
+	f.calledWith.workspaceCodes = workspaceCodes
+	f.calledWith.environment = environment
+	return f.returnResult, f.returnErr
+}
+
+func TestWorkspaceFilter_Exists_ForwardsTenantAndEnvironment(t *testing.T) {
+	store := &fakeWorkspaceExistenceStore{
+		returnResult: map[string]bool{"ws-a": true, "ws-b": false},
+	}
+	filter := newWorkspaceFilter(store, "acme", domain.EnvironmentProd)
+
+	result, err := filter.Exists(context.Background(), []string{"ws-a", "ws-b"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if store.calledWith.tenantCode != "acme" {
+		t.Errorf("tenantCode = %q, want %q", store.calledWith.tenantCode, "acme")
+	}
+	if store.calledWith.environment != domain.EnvironmentProd {
+		t.Errorf("environment = %q, want %q", store.calledWith.environment, domain.EnvironmentProd)
+	}
+	if result["ws-a"] != true || result["ws-b"] != false {
+		t.Errorf("result = %v, want {ws-a:true, ws-b:false}", result)
+	}
+}
+
+func TestWorkspaceFilter_Exists_NilCodesReturnsEmptyWithoutCallingStore(t *testing.T) {
+	store := &fakeWorkspaceExistenceStore{}
+	filter := newWorkspaceFilter(store, "acme", domain.EnvironmentProd)
+
+	result, err := filter.Exists(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty map, got %v", result)
+	}
+	if store.calledWith.tenantCode != "" {
+		t.Error("store should not have been called for nil codes")
+	}
+}
+
+func TestWorkspaceFilter_Exists_EmptyCodesReturnsEmptyWithoutCallingStore(t *testing.T) {
+	store := &fakeWorkspaceExistenceStore{}
+	filter := newWorkspaceFilter(store, "acme", domain.EnvironmentProd)
+
+	result, err := filter.Exists(context.Background(), []string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty map, got %v", result)
+	}
+	if store.calledWith.tenantCode != "" {
+		t.Error("store should not have been called for empty codes")
+	}
+}
+
+func TestWorkspaceFilter_Exists_StoreErrorPropagates(t *testing.T) {
+	storeErr := errors.New("db connection lost")
+	store := &fakeWorkspaceExistenceStore{returnErr: storeErr}
+	filter := newWorkspaceFilter(store, "acme", domain.EnvironmentProd)
+
+	_, err := filter.Exists(context.Background(), []string{"ws-a"})
+	if !errors.Is(err, storeErr) {
+		t.Fatalf("expected storeErr, got %v", err)
+	}
+}

--- a/internal/http/routes_external.go
+++ b/internal/http/routes_external.go
@@ -14,7 +14,7 @@ func (s *Server) registerExternalRoutes() {
 	external.GET("/environments/:environment/bootstrap", s.externalIntegrationHandler.Bootstrap)
 
 	externalScoped := external.Group("/tenants/:tenant_code/workspaces/:workspace_code")
-	externalScoped.Use(middleware.ExternalIntegration(s.externalIntegrationHandler))
+	externalScoped.Use(middleware.ExternalIntegration(s.externalIntegrationHandler, s.workspaceExistenceStore))
 	externalScoped.GET("/session", s.externalIntegrationHandler.Session, middleware.RequireExternalCapability(middleware.ExternalActionBuilderAccess))
 
 	if s.templateTypeHandler == nil && s.templateHandler == nil && s.injectorHandler == nil && s.workspacePolicyHandler == nil {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -35,6 +35,10 @@ type Server struct {
 	wsStore     port.WorkspaceStore
 	configStore port.GlobalConfigStore
 
+	// workspaceExistenceStore is used by the external integration middleware to
+	// construct a per-request workspace filter for resolver extensions.
+	workspaceExistenceStore port.WorkspaceExistenceStore
+
 	// Handlers.
 	tenantHandler          *handler.TenantHandler
 	workspaceHandler       *handler.WorkspaceHandler
@@ -127,6 +131,14 @@ func WithWorkspaceStore(ws port.WorkspaceStore) ServerOption {
 func WithConfigStore(cs port.GlobalConfigStore) ServerOption {
 	return func(s *Server) {
 		s.configStore = cs
+	}
+}
+
+// WithWorkspaceExistenceStore sets the WorkspaceExistenceStore used by the
+// external integration middleware to build a per-request workspace filter.
+func WithWorkspaceExistenceStore(ws port.WorkspaceExistenceStore) ServerOption {
+	return func(s *Server) {
+		s.workspaceExistenceStore = ws
 	}
 }
 

--- a/internal/http/server_external_test.go
+++ b/internal/http/server_external_test.go
@@ -56,7 +56,7 @@ type externalResolver struct {
 
 func (r *externalResolver) Name() string        { return r.name }
 func (r *externalResolver) Description() string { return r.description }
-func (r *externalResolver) ResolveWorkspace(context.Context, *port.ExternalIntegrationRequest, *port.ExternalAuthResult) (*port.ExternalWorkspaceResolution, error) {
+func (r *externalResolver) ResolveWorkspace(context.Context, *port.ExternalIntegrationRequest, *port.ExternalAuthResult, port.WorkspaceFilter) (*port.ExternalWorkspaceResolution, error) {
 	if r.result == nil && r.err == nil {
 		return &port.ExternalWorkspaceResolution{WorkspaceCode: "main"}, nil
 	}
@@ -105,7 +105,7 @@ func setupExternalRouteServer(cfg *domain.GlobalConfig, auth *externalAuthMethod
 	e.Use(middleware.ExternalIntegrationCORS(h))
 
 	group := e.Group("/api/v1/external/:profile_slug/tenants/:tenant_code/workspaces/:workspace_code")
-	group.Use(middleware.ExternalIntegration(h))
+	group.Use(middleware.ExternalIntegration(h, nil))
 
 	group.GET("/template-types", func(c *echo.Context) error {
 		state := map[string]any{

--- a/internal/port/external_integration.go
+++ b/internal/port/external_integration.go
@@ -57,10 +57,22 @@ type ExternalAuthMethod interface {
 	Authenticate(ctx context.Context, req *ExternalIntegrationRequest) (*ExternalAuthResult, error)
 }
 
+// WorkspaceFilter provides a read-only view of which workspace codes are active
+// for the current tenant and environment. It is constructed per-request by the
+// middleware and injected into ExternalWorkspaceResolver.
+type WorkspaceFilter interface {
+	// Exists returns a dense map where every requested code is present as a key.
+	// A code maps to true only when the workspace is active for the tenant in the
+	// current environment. An empty or nil codes slice returns an empty map
+	// without contacting the store.
+	Exists(ctx context.Context, codes []string) (map[string]bool, error)
+}
+
 // ExternalWorkspaceResolver maps the authenticated request to a workspace
-// code or a read-only fallback.
+// code or a read-only fallback. filter provides an existence check for
+// workspace codes scoped to the current tenant and environment.
 type ExternalWorkspaceResolver interface {
 	Name() string
 	Description() string
-	ResolveWorkspace(ctx context.Context, req *ExternalIntegrationRequest, auth *ExternalAuthResult) (*ExternalWorkspaceResolution, error)
+	ResolveWorkspace(ctx context.Context, req *ExternalIntegrationRequest, auth *ExternalAuthResult, filter WorkspaceFilter) (*ExternalWorkspaceResolution, error)
 }

--- a/sdk/external_extensions_test.go
+++ b/sdk/external_extensions_test.go
@@ -23,7 +23,7 @@ type testExternalWorkspaceResolver struct {
 
 func (t *testExternalWorkspaceResolver) Name() string        { return t.name }
 func (t *testExternalWorkspaceResolver) Description() string { return t.description }
-func (t *testExternalWorkspaceResolver) ResolveWorkspace(context.Context, *ExternalIntegrationRequest, *ExternalAuthResult) (*ExternalWorkspaceResolution, error) {
+func (t *testExternalWorkspaceResolver) ResolveWorkspace(context.Context, *ExternalIntegrationRequest, *ExternalAuthResult, WorkspaceFilter) (*ExternalWorkspaceResolution, error) {
 	return &ExternalWorkspaceResolution{}, nil
 }
 

--- a/sdk/interfaces.go
+++ b/sdk/interfaces.go
@@ -55,12 +55,24 @@ type ExternalAuthMethod interface {
 	Authenticate(ctx context.Context, req *ExternalIntegrationRequest) (*ExternalAuthResult, error)
 }
 
+// WorkspaceFilter provides callers with a read-only view of which workspace
+// codes are active for the current tenant and environment. It is constructed
+// per-request by the middleware and injected into ExternalWorkspaceResolver.
+type WorkspaceFilter interface {
+	// Exists returns a dense map where every requested code is present as a key.
+	// A code maps to true only when the workspace is active for the tenant in the
+	// current environment. An empty or nil codes slice returns an empty map
+	// without contacting the store.
+	Exists(ctx context.Context, codes []string) (map[string]bool, error)
+}
+
 // ExternalWorkspaceResolver maps a validated request to a workspace code or a
-// read-only fallback.
+// read-only fallback. filter provides an existence check for workspace codes
+// scoped to the current tenant and environment.
 type ExternalWorkspaceResolver interface {
 	Name() string
 	Description() string
-	ResolveWorkspace(ctx context.Context, req *ExternalIntegrationRequest, auth *ExternalAuthResult) (*ExternalWorkspaceResolution, error)
+	ResolveWorkspace(ctx context.Context, req *ExternalIntegrationRequest, auth *ExternalAuthResult, filter WorkspaceFilter) (*ExternalWorkspaceResolution, error)
 }
 
 // ExternalIntegrationRequest is the request context passed to auth and

--- a/sdk/internal_adapters.go
+++ b/sdk/internal_adapters.go
@@ -133,7 +133,7 @@ type externalWorkspaceResolverAdapter struct {
 
 func (a externalWorkspaceResolverAdapter) Name() string        { return a.resolver.Name() }
 func (a externalWorkspaceResolverAdapter) Description() string { return a.resolver.Description() }
-func (a externalWorkspaceResolverAdapter) ResolveWorkspace(ctx context.Context, req *port.ExternalIntegrationRequest, auth *port.ExternalAuthResult) (*port.ExternalWorkspaceResolution, error) {
+func (a externalWorkspaceResolverAdapter) ResolveWorkspace(ctx context.Context, req *port.ExternalIntegrationRequest, auth *port.ExternalAuthResult, filter port.WorkspaceFilter) (*port.ExternalWorkspaceResolution, error) {
 	result, err := a.resolver.ResolveWorkspace(ctx, adaptExternalRequest(req), &ExternalAuthResult{
 		Permissions: ExternalPermissions{
 			ListTemplates:   auth.Permissions.ListTemplates,
@@ -146,9 +146,25 @@ func (a externalWorkspaceResolverAdapter) ResolveWorkspace(ctx context.Context, 
 			LocaleAccess:    auth.Permissions.LocaleAccess,
 		},
 		Context: auth.Context,
-	})
+	}, adaptWorkspaceFilter(filter))
 	if err != nil {
 		return nil, err
 	}
 	return adaptExternalWorkspaceResolution(result), nil
+}
+
+type sdkWorkspaceFilterAdapter struct {
+	filter port.WorkspaceFilter
+}
+
+func (a sdkWorkspaceFilterAdapter) Exists(ctx context.Context, codes []string) (map[string]bool, error) {
+	return a.filter.Exists(ctx, codes)
+}
+
+// Returns nil when f is nil so SDK resolvers can detect an absent filter.
+func adaptWorkspaceFilter(f port.WorkspaceFilter) WorkspaceFilter {
+	if f == nil {
+		return nil
+	}
+	return sdkWorkspaceFilterAdapter{filter: f}
 }

--- a/sdk/public_contract_test.go
+++ b/sdk/public_contract_test.go
@@ -147,7 +147,7 @@ func TestBuildExtensions_AdaptsExternalContractsToInternalContracts(t *testing.T
 	resolution, err := ext.ExternalWorkspaceResolvers[0].ResolveWorkspace(context.Background(), &port.ExternalIntegrationRequest{
 		ProfileSlug: "partner",
 		TenantCode:  "acme",
-	}, authResult)
+	}, authResult, nil)
 	if err != nil {
 		t.Fatalf("resolver returned error: %v", err)
 	}
@@ -173,6 +173,6 @@ type publicExternalWorkspaceResolver struct{}
 
 func (publicExternalWorkspaceResolver) Name() string        { return "tenant-workspace" }
 func (publicExternalWorkspaceResolver) Description() string { return "Tenant workspace resolver" }
-func (publicExternalWorkspaceResolver) ResolveWorkspace(_ context.Context, _ *ExternalIntegrationRequest, _ *ExternalAuthResult) (*ExternalWorkspaceResolution, error) {
+func (publicExternalWorkspaceResolver) ResolveWorkspace(_ context.Context, _ *ExternalIntegrationRequest, _ *ExternalAuthResult, _ WorkspaceFilter) (*ExternalWorkspaceResolution, error) {
 	return &ExternalWorkspaceResolution{WorkspaceCode: "main", ReadOnly: true}, nil
 }

--- a/sdk/workspace_filter_bridge_test.go
+++ b/sdk/workspace_filter_bridge_test.go
@@ -1,0 +1,67 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rendis/senda/internal/port"
+)
+
+// fakePortWorkspaceFilter is a manual fake for port.WorkspaceFilter that records calls.
+type fakePortWorkspaceFilter struct {
+	calledWithCodes []string
+	returnResult    map[string]bool
+	returnErr       error
+}
+
+func (f *fakePortWorkspaceFilter) Exists(_ context.Context, codes []string) (map[string]bool, error) {
+	f.calledWithCodes = codes
+	return f.returnResult, f.returnErr
+}
+
+// recordingWorkspaceResolver is an SDK resolver that records the WorkspaceFilter it receives.
+type recordingWorkspaceResolver struct {
+	receivedFilter WorkspaceFilter
+}
+
+func (r *recordingWorkspaceResolver) Name() string        { return "recording" }
+func (r *recordingWorkspaceResolver) Description() string { return "records filter" }
+func (r *recordingWorkspaceResolver) ResolveWorkspace(_ context.Context, _ *ExternalIntegrationRequest, _ *ExternalAuthResult, filter WorkspaceFilter) (*ExternalWorkspaceResolution, error) {
+	r.receivedFilter = filter
+	return &ExternalWorkspaceResolution{WorkspaceCode: "main"}, nil
+}
+
+// TestWorkspaceFilterBridge_AdapterPassesFilterToSDKResolver verifies that the
+// externalWorkspaceResolverAdapter wraps the port.WorkspaceFilter and passes it
+// to the SDK resolver as an sdk.WorkspaceFilter.
+func TestWorkspaceFilterBridge_AdapterPassesFilterToSDKResolver(t *testing.T) {
+	recorder := &recordingWorkspaceResolver{}
+	adapter := externalWorkspaceResolverAdapter{resolver: recorder}
+
+	portFilter := &fakePortWorkspaceFilter{
+		returnResult: map[string]bool{"ws-a": true},
+	}
+
+	_, err := adapter.ResolveWorkspace(context.Background(), &port.ExternalIntegrationRequest{
+		TenantCode: "acme",
+	}, &port.ExternalAuthResult{}, portFilter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if recorder.receivedFilter == nil {
+		t.Fatal("expected adapter to pass a WorkspaceFilter to the SDK resolver")
+	}
+
+	// Verify the wrapped filter delegates Exists to the port filter.
+	result, err := recorder.receivedFilter.Exists(context.Background(), []string{"ws-a"})
+	if err != nil {
+		t.Fatalf("unexpected error from wrapped filter: %v", err)
+	}
+	if !result["ws-a"] {
+		t.Errorf("expected ws-a=true, got %v", result)
+	}
+	if len(portFilter.calledWithCodes) != 1 || portFilter.calledWithCodes[0] != "ws-a" {
+		t.Errorf("port filter not called with expected codes, got %v", portFilter.calledWithCodes)
+	}
+}

--- a/test/e2e/security_perimeter_hardening_test.go
+++ b/test/e2e/security_perimeter_hardening_test.go
@@ -162,7 +162,7 @@ type hardeningExternalResolver struct{}
 
 func (hardeningExternalResolver) Name() string        { return "tenant-workspace-resolver" }
 func (hardeningExternalResolver) Description() string { return "test resolver" }
-func (hardeningExternalResolver) ResolveWorkspace(context.Context, *port.ExternalIntegrationRequest, *port.ExternalAuthResult) (*port.ExternalWorkspaceResolution, error) {
+func (hardeningExternalResolver) ResolveWorkspace(context.Context, *port.ExternalIntegrationRequest, *port.ExternalAuthResult, port.WorkspaceFilter) (*port.ExternalWorkspaceResolution, error) {
 	return &port.ExternalWorkspaceResolution{WorkspaceCode: "marketing", ReadOnly: false}, nil
 }
 


### PR DESCRIPTION
## Summary

- **Breaking change**: `ExternalWorkspaceResolver.ResolveWorkspace` now takes a 4th parameter `WorkspaceFilter` (both `port` and `sdk` surfaces)
- SDK consumers implementing custom workspace resolvers can now check workspace existence scoped to the current tenant and environment without redundant round-trips
- `WorkspaceFilter.Exists(ctx, codes)` returns a dense `map[string]bool` — batch operation, no N+1
- Filter is constructed per-request by the middleware, bound to tenant+environment from the request context
- Nil-safe: when `WorkspaceExistenceStore` is not available, filter propagates as nil with a log warning
- Also removes deprecated `nat.Port()` wrapper from teststack (testcontainers-go accepts string directly)

## Test plan

- [x] Unit tests: `workspace_filter_test.go` — forwards tenant/env, empty/nil codes, error propagation
- [x] Unit tests: `workspace_filter_bridge_test.go` — adapter passes filter from port→SDK correctly
- [x] Integration test: `workspace_filter_integration_test.go` — real PG with prod/test environment scoping
- [x] All existing external integration tests updated to new signature
- [x] `make lint` — 0 issues
- [x] `make vet` — clean
- [x] `make test` — all pass