### PR TITLE
fix(web): prevent unauthenticated dashboard shell flash

### DIFF
--- a/web/src/app/(dashboard)/layout.tsx
+++ b/web/src/app/(dashboard)/layout.tsx
@@ -15,15 +15,15 @@ export default async function DashboardLayout({
   // - SessionProvider refetchInterval (every 3min) via /api/auth/session
   const session = await authWithoutRefresh();
 
-  if (!session) {
+  if (!session?.idToken) {
     redirect("/login");
   }
 
   // Membership and onboarding checks are done client-side in MembershipGate
   // because they need a fresh idToken (from SessionProvider, which CAN update cookies).
   return (
-    <DashboardShell>
-      <MembershipGate>{children}</MembershipGate>
-    </DashboardShell>
+    <MembershipGate>
+      <DashboardShell>{children}</DashboardShell>
+    </MembershipGate>
   );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,5 +1,8 @@
 import { redirect } from "next/navigation";
+import { authWithoutRefresh } from "@/auth";
+import { decideRootRedirectPath } from "@/app/root-page-redirect";
 
-export default function RootPage() {
-  redirect("/global");
+export default async function RootPage() {
+  const session = await authWithoutRefresh();
+  redirect(decideRootRedirectPath(session));
 }

--- a/web/src/app/root-page-redirect.test.ts
+++ b/web/src/app/root-page-redirect.test.ts
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { decideRootRedirectPath } = await import(
+  new URL("./root-page-redirect.ts", import.meta.url).href,
+);
+
+test("redirects unauthenticated visitors to login", () => {
+  assert.equal(decideRootRedirectPath(null), "/login");
+  assert.equal(decideRootRedirectPath(undefined), "/login");
+  assert.equal(decideRootRedirectPath({}), "/login");
+});
+
+test("redirects authenticated visitors to the global dashboard", () => {
+  assert.equal(decideRootRedirectPath({ idToken: "token" }), "/global");
+});

--- a/web/src/app/root-page-redirect.ts
+++ b/web/src/app/root-page-redirect.ts
@@ -1,0 +1,5 @@
+export function decideRootRedirectPath(
+  session: { idToken?: string | null } | null | undefined,
+): "/login" | "/global" {
+  return session?.idToken ? "/global" : "/login";
+}

--- a/web/src/providers/membership-gate.tsx
+++ b/web/src/providers/membership-gate.tsx
@@ -120,10 +120,10 @@ export function MembershipGate({ children }: { children: React.ReactNode }) {
     };
   }, [gateKey, pathname, router, session?.idToken]);
 
-  if (!gateKey || checkedKey !== gateKey) {
+  if (status === "loading" || status === "unauthenticated" || !gateKey || checkedKey !== gateKey) {
     return (
-      <div className="flex h-[50vh] items-center justify-center">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      <div className="flex min-h-screen items-center justify-center bg-page">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" aria-label="Loading access state" />
       </div>
     );
   }

--- a/web/src/providers/session-guard-policy.test.ts
+++ b/web/src/providers/session-guard-policy.test.ts
@@ -1,13 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-const { isExternalEmbedPath, shouldRedirectUnauthenticatedToLogin, shouldTriggerFederatedLogout } = await import(
+const { isExternalEmbedPath, isPublicAppPath, shouldRedirectUnauthenticatedToLogin, shouldTriggerFederatedLogout } = await import(
   new URL("./session-guard-policy.ts", import.meta.url).href,
 );
+const UNAUTHENTICATED_STATUS = "unauthenticated" as const;
+const EMBED_PATH =
+  "/embed/partner-portal/t/acme/w/main/templates/newsletter/edit";
 
 test("detects embed routes for external session mode", () => {
   assert.equal(
-    isExternalEmbedPath("/embed/partner-portal/t/acme/w/main/templates/newsletter/edit"),
+    isExternalEmbedPath(EMBED_PATH),
     true,
   );
   assert.equal(isExternalEmbedPath("/global"), false);
@@ -52,7 +55,7 @@ test("does not trigger federated logout on /login", () => {
 test("does not trigger federated logout on embed routes", () => {
   assert.equal(
     shouldTriggerFederatedLogout({
-      pathname: "/embed/partner-portal/t/acme/w/main/templates/newsletter/edit",
+      pathname: EMBED_PATH,
       status: "authenticated",
       sessionError: "RefreshTokenError",
       alreadyTriggered: false,
@@ -65,7 +68,34 @@ test("redirects unauthenticated users on app routes", () => {
   assert.equal(
     shouldRedirectUnauthenticatedToLogin({
       pathname: "/global",
-      status: "unauthenticated",
+      status: UNAUTHENTICATED_STATUS,
+      alreadyTriggered: false,
+    }),
+    true,
+  );
+
+  assert.equal(
+    shouldRedirectUnauthenticatedToLogin({
+      pathname: "/t/acme/w/main",
+      status: UNAUTHENTICATED_STATUS,
+      alreadyTriggered: false,
+    }),
+    true,
+  );
+
+  assert.equal(
+    shouldRedirectUnauthenticatedToLogin({
+      pathname: "/onboarding",
+      status: UNAUTHENTICATED_STATUS,
+      alreadyTriggered: false,
+    }),
+    true,
+  );
+
+  assert.equal(
+    shouldRedirectUnauthenticatedToLogin({
+      pathname: "/",
+      status: UNAUTHENTICATED_STATUS,
       alreadyTriggered: false,
     }),
     true,
@@ -75,10 +105,35 @@ test("redirects unauthenticated users on app routes", () => {
 test("does not redirect unauthenticated users on embed routes", () => {
   assert.equal(
     shouldRedirectUnauthenticatedToLogin({
-      pathname: "/embed/partner-portal/t/acme/w/main/templates/newsletter/edit",
-      status: "unauthenticated",
+      pathname: EMBED_PATH,
+      status: UNAUTHENTICATED_STATUS,
       alreadyTriggered: false,
     }),
     false,
   );
+});
+
+test("does not redirect unauthenticated users on public routes", () => {
+  const publicRoutes = ["/login", "/logout", "/access-denied"];
+
+  for (const pathname of publicRoutes) {
+    assert.equal(
+      shouldRedirectUnauthenticatedToLogin({
+        pathname,
+        status: UNAUTHENTICATED_STATUS,
+        alreadyTriggered: false,
+      }),
+      false,
+      `expected ${pathname} to stay public`,
+    );
+  }
+});
+
+test("identifies explicitly public app routes", () => {
+  assert.equal(isPublicAppPath("/login"), true);
+  assert.equal(isPublicAppPath("/logout"), true);
+  assert.equal(isPublicAppPath("/access-denied"), true);
+  assert.equal(isPublicAppPath(EMBED_PATH), true);
+  assert.equal(isPublicAppPath("/onboarding"), false);
+  assert.equal(isPublicAppPath("/global"), false);
 });

--- a/web/src/providers/session-guard-policy.ts
+++ b/web/src/providers/session-guard-policy.ts
@@ -2,6 +2,16 @@ export function isExternalEmbedPath(pathname: string): boolean {
   return pathname.startsWith("/embed/");
 }
 
+export function isPublicAppPath(pathname: string): boolean {
+  if (isExternalEmbedPath(pathname)) return true;
+
+  return (
+    pathname === "/login" ||
+    pathname === "/logout" ||
+    pathname === "/access-denied"
+  );
+}
+
 export function shouldTriggerFederatedLogout(params: {
   pathname: string;
   status: "authenticated" | "unauthenticated" | "loading";
@@ -28,7 +38,7 @@ export function shouldRedirectUnauthenticatedToLogin(params: {
 
   if (alreadyTriggered) return false;
   if (status !== "unauthenticated") return false;
-  if (isExternalEmbedPath(pathname)) return false;
+  if (isPublicAppPath(pathname)) return false;
 
   return true;
 }


### PR DESCRIPTION
## Summary
- prevent protected routes from mounting the dashboard shell before auth and membership checks finish
- make the root route redirect server-side to `/login` or `/global` based on session presence
- replace the SessionGuard protected-route list with an explicit public-route whitelist so onboarding and future auth-only pages remain guarded by default

## Testing
- make lint
- make vet
- make test
- pnpm --dir web typecheck
- pnpm --dir web lint
- pnpm --dir web test
