### PR TITLE
fix(workspaces): align code validation and default scope UI

### DIFF
--- a/internal/adapter/postgres/db.go
+++ b/internal/adapter/postgres/db.go
@@ -95,6 +95,16 @@ func classifyPgError(err error) error {
 		return apperr.BadRequest("referenced resource does not exist: %s", pgErr.Detail)
 	case "23502": // not_null_violation
 		return apperr.BadRequest("missing required field: %s", pgErr.ColumnName)
+	case "23514": // check_violation
+		switch pgErr.ConstraintName {
+		case "workspaces_code_format", "tenants_code_format":
+			return apperr.Validation("invalid code format")
+		default:
+			if pgErr.Message != "" {
+				return apperr.Validation("%s", pgErr.Message)
+			}
+			return apperr.Validation("check constraint violated")
+		}
 	default:
 		return nil
 	}

--- a/internal/adapter/postgres/db_internal_test.go
+++ b/internal/adapter/postgres/db_internal_test.go
@@ -1,0 +1,29 @@
+package postgres
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/rendis/senda/pkg/apperr"
+)
+
+func TestClassifyPgError_CheckViolationBecomesValidationError(t *testing.T) {
+	err := classifyPgError(&pgconn.PgError{
+		Code:           "23514",
+		ConstraintName: "workspaces_code_format",
+		Message:        "new row for relation \"workspaces\" violates check constraint \"workspaces_code_format\"",
+	})
+	if err == nil {
+		t.Fatal("expected validation error for check violation")
+	}
+
+	var appErr *apperr.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", appErr.Code)
+	}
+}

--- a/internal/adapter/postgres/workspace_repo_test.go
+++ b/internal/adapter/postgres/workspace_repo_test.go
@@ -60,6 +60,26 @@ func TestWorkspaceRepo_Create(t *testing.T) {
 	}
 }
 
+func TestWorkspaceRepo_Create_AllowsUnderscore(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	tenantRepo := pgadapter.NewTenantRepo(pool)
+	repo := pgadapter.NewWorkspaceRepo(pool)
+
+	tenant := createTestTenant(ctx, t, tenantRepo)
+
+	ws := &domain.Workspace{
+		ID:       uuid.New(),
+		TenantID: tenant.ID,
+		Code:     "student_portal",
+		Name:     "Student Portal",
+	}
+
+	if err := repo.Create(ctx, ws); err != nil {
+		t.Fatalf("Create() with underscore error: %v", err)
+	}
+}
+
 func TestWorkspaceRepo_Create_DuplicateTenantCode(t *testing.T) {
 	ctx := context.Background()
 	pool := setupTestDB(ctx, t)

--- a/migrations/000046_workspace_code_format_alignment.down.sql
+++ b/migrations/000046_workspace_code_format_alignment.down.sql
@@ -1,0 +1,13 @@
+ALTER TABLE workspaces
+    DROP CONSTRAINT IF EXISTS workspaces_code_format;
+
+ALTER TABLE workspaces
+    ADD CONSTRAINT workspaces_code_format CHECK (
+        code = '_system' OR (
+            code ~ '^[a-z][a-z0-9-]*$'
+            AND length(code) BETWEEN 2 AND 50
+            AND code NOT LIKE '%-'
+            AND code NOT LIKE '%---%'
+            AND code NOT IN ('global', 'admin', 'api', 'system')
+        )
+    );

--- a/migrations/000046_workspace_code_format_alignment.up.sql
+++ b/migrations/000046_workspace_code_format_alignment.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE workspaces
+    DROP CONSTRAINT IF EXISTS workspaces_code_format;
+
+ALTER TABLE workspaces
+    ADD CONSTRAINT workspaces_code_format CHECK (
+        code = '_system' OR (
+            code ~ '^[a-z](?:[a-z0-9_-]*[a-z0-9])?$'
+            AND length(code) BETWEEN 2 AND 50
+            AND code NOT IN ('global', 'admin', 'api', 'system')
+        )
+    );

--- a/web/src/app/onboarding/_components/step-3-create-workspace.tsx
+++ b/web/src/app/onboarding/_components/step-3-create-workspace.tsx
@@ -13,6 +13,10 @@ import { Label } from "@/components/ui/label";
 import { createAuthenticatedApi, parseApiError } from "@/lib/api";
 import { OnboardingStepper } from "@/components/shared/onboarding-stepper";
 import { slugSchema, nameSchema, generateSlug } from "@/lib/validations/slug";
+import {
+  normalizeWorkspaceCodeInput,
+  sanitizeWorkspaceCodeInput,
+} from "@/lib/workspace-code-input";
 import { getHttpStatus } from "./api-errors";
 
 const workspaceSchema = z.object({
@@ -45,10 +49,12 @@ export function Step3CreateWorkspace({
   });
 
   const watchedName = form.watch("name");
+  const watchedCode = form.watch("code");
+  const codeField = form.register("code");
 
   useEffect(() => {
     if (!codeManuallyEdited.current && watchedName) {
-      form.setValue("code", generateSlug(watchedName), {
+      form.setValue("code", sanitizeWorkspaceCodeInput(generateSlug(watchedName)), {
         shouldValidate: form.formState.isSubmitted,
       });
     }
@@ -108,7 +114,17 @@ export function Step3CreateWorkspace({
       <OnboardingStepper currentStep={currentStep} />
 
       <form
-        onSubmit={form.handleSubmit(handleSubmit)}
+        onSubmit={(event) => {
+          const normalizedCode = normalizeWorkspaceCodeInput(form.getValues("code"));
+          if (normalizedCode !== form.getValues("code")) {
+            form.setValue("code", normalizedCode, {
+              shouldDirty: true,
+              shouldTouch: true,
+              shouldValidate: true,
+            });
+          }
+          void form.handleSubmit(handleSubmit)(event);
+        }}
         className="flex w-full flex-col gap-7"
       >
         <div className="flex flex-col gap-4">
@@ -141,11 +157,28 @@ export function Step3CreateWorkspace({
             <Input
               id="workspace-code"
               placeholder={t("workspaceCodePlaceholder")}
-              {...form.register("code", {
-                onChange: () => {
-                  codeManuallyEdited.current = true;
-                },
-              })}
+              {...codeField}
+              value={watchedCode ?? ""}
+              onChange={(event) => {
+                codeManuallyEdited.current = true;
+                form.setValue("code", sanitizeWorkspaceCodeInput(event.target.value), {
+                  shouldDirty: true,
+                  shouldValidate: form.formState.isSubmitted,
+                });
+              }}
+              onBlur={(event) => {
+                form.setValue(
+                  "code",
+                  normalizeWorkspaceCodeInput(event.target.value),
+                  {
+                    shouldDirty: true,
+                    shouldTouch: true,
+                    shouldValidate: true,
+                  },
+                );
+                codeField.onBlur(event);
+              }}
+              maxLength={50}
             />
             {form.formState.errors.code && (
               <p className="text-xs text-destructive">

--- a/web/src/components/shared/scope-switcher.tsx
+++ b/web/src/components/shared/scope-switcher.tsx
@@ -47,6 +47,16 @@ export function ScopeSwitcher({ collapsed }: ScopeSwitcherProps) {
   const router = useRouter();
   const { level, tenantCode, workspaceCode, environment } = useScope();
   const tScope = useTranslations("scopeSwitcher");
+  const isSystemWorkspace =
+    level === "workspace" && workspaceCode === SYSTEM_WORKSPACE_CODE;
+  const currentWorkspaceSearch =
+    level === "workspace" && !isSystemWorkspace
+      ? workspaceCode ?? ""
+      : "";
+  const { data: currentWorkspacePages } = usePaginatedWorkspaces(
+    tenantCode ?? "",
+    currentWorkspaceSearch,
+  );
 
   // View state
   const [view, setView] = useState<ViewMode>("tenants");
@@ -82,15 +92,24 @@ export function ScopeSwitcher({ collapsed }: ScopeSwitcherProps) {
   }
 
   // Trigger label/icon/color
-  const isSystemWorkspace =
-    level === "workspace" && workspaceCode === SYSTEM_WORKSPACE_CODE;
+  const currentWorkspaceCandidates = useMemo(
+    () => currentWorkspacePages?.pages.flatMap((page) => page.items) ?? [],
+    [currentWorkspacePages],
+  );
+  const currentWorkspace = useMemo(
+    () =>
+      currentWorkspaceCandidates.find(
+        (workspace) => workspace.code === workspaceCode,
+      ),
+    [currentWorkspaceCandidates, workspaceCode],
+  );
 
   const scopeLabel =
     level === "global"
       ? tScope("globalScope")
       : isSystemWorkspace
         ? tScope("defaultScope")
-        : getWorkspaceDisplayCode({ code: workspaceCode });
+        : getWorkspaceDisplayName(currentWorkspace ?? { code: workspaceCode });
 
   const ScopeIcon =
     level === "global"

--- a/web/src/components/workspaces/workspaces-content.tsx
+++ b/web/src/components/workspaces/workspaces-content.tsx
@@ -54,6 +54,10 @@ import {
   nameSchema,
   slugSchema,
 } from "@/lib/validations/slug";
+import {
+  normalizeWorkspaceCodeInput,
+  sanitizeWorkspaceCodeInput,
+} from "@/lib/workspace-code-input";
 import { SYSTEM_WORKSPACE_CODE, type Workspace } from "@/types/api";
 
 const createWorkspaceSchema = z.object({
@@ -549,6 +553,7 @@ function CreateWorkspaceDialog({
   });
 
   const watchedName = useWatch({ control: form.control, name: "name" });
+  const watchedCode = useWatch({ control: form.control, name: "code" });
 
   useEffect(() => {
     if (!open) {
@@ -558,7 +563,7 @@ function CreateWorkspaceDialog({
     }
 
     if (!codeManuallyEdited.current && watchedName) {
-      form.setValue("code", generateSlug(watchedName), {
+      form.setValue("code", sanitizeWorkspaceCodeInput(generateSlug(watchedName)), {
         shouldValidate: form.formState.isSubmitted,
       });
     }
@@ -566,6 +571,14 @@ function CreateWorkspaceDialog({
 
   const handleSubmit = async () => {
     let keepOpen = false;
+    const normalizedCode = normalizeWorkspaceCodeInput(form.getValues("code"));
+    if (normalizedCode !== form.getValues("code")) {
+      form.setValue("code", normalizedCode, {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true,
+      });
+    }
 
     await form.handleSubmit(
       async (values) => {
@@ -620,10 +633,24 @@ function CreateWorkspaceDialog({
           <Input
             id="workspace-code"
             {...codeField}
+            value={watchedCode ?? ""}
             onChange={(event) => {
               codeManuallyEdited.current = true;
-              codeField.onChange(event);
+              form.setValue("code", sanitizeWorkspaceCodeInput(event.target.value), {
+                shouldDirty: true,
+                shouldValidate: form.formState.isSubmitted,
+              });
             }}
+            onBlur={(event) => {
+              const normalized = normalizeWorkspaceCodeInput(event.target.value);
+              form.setValue("code", normalized, {
+                shouldDirty: true,
+                shouldTouch: true,
+                shouldValidate: true,
+              });
+              codeField.onBlur(event);
+            }}
+            maxLength={50}
           />
           {form.formState.errors.code && (
             <p className="text-xs text-destructive">

--- a/web/src/lib/workspace-code-input.test.ts
+++ b/web/src/lib/workspace-code-input.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  sanitizeWorkspaceCodeInput,
+  normalizeWorkspaceCodeInput,
+} = await import(new URL("./workspace-code-input.ts", import.meta.url).href);
+
+test("sanitizeWorkspaceCodeInput keeps only lowercase letters, digits, underscores, and hyphens", () => {
+  assert.equal(
+    sanitizeWorkspaceCodeInput(" Student Portal!__2026 "),
+    "studentportal__2026",
+  );
+});
+
+test("sanitizeWorkspaceCodeInput removes leading separators immediately", () => {
+  assert.equal(sanitizeWorkspaceCodeInput("_-main_workspace"), "main_workspace");
+});
+
+test("normalizeWorkspaceCodeInput trims trailing separators on blur", () => {
+  assert.equal(normalizeWorkspaceCodeInput("main_workspace-_"), "main_workspace");
+});

--- a/web/src/lib/workspace-code-input.ts
+++ b/web/src/lib/workspace-code-input.ts
@@ -1,0 +1,18 @@
+const MAX_WORKSPACE_CODE_LENGTH = 50;
+
+function clampWorkspaceCode(value: string) {
+  return value.slice(0, MAX_WORKSPACE_CODE_LENGTH);
+}
+
+export function sanitizeWorkspaceCodeInput(value: string): string {
+  return clampWorkspaceCode(
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]/g, "")
+      .replace(/^[\-_]+/, ""),
+  );
+}
+
+export function normalizeWorkspaceCodeInput(value: string): string {
+  return sanitizeWorkspaceCodeInput(value).replace(/[\-_]+$/, "");
+}

--- a/web/src/lib/workspace-resource-policies.test.ts
+++ b/web/src/lib/workspace-resource-policies.test.ts
@@ -202,6 +202,41 @@ test("injectors expose inherited read-only state and local policy restrictions",
   assert.deepEqual(localBlocked.badges, ["local", "readOnly"]);
 });
 
+test("system workspace owners can edit tenant default resources without read-only warnings", () => {
+  const scope = {
+    level: "workspace" as const,
+    tenantCode: "acme",
+    workspaceCode: "_system",
+  };
+
+  const templateState = getTemplateManagementState(
+    scope,
+    {
+      owner_scope: "system",
+      inherited_from_system: false,
+      is_fork: false,
+    },
+    DEFAULT_WORKSPACE_POLICIES,
+  );
+
+  assert.equal(templateState.readOnly, false);
+  assert.equal(templateState.canManageVersions, true);
+  assert.deepEqual(templateState.badges, ["defaultSystem"]);
+
+  const injectorState = getInjectorManagementState(
+    scope,
+    {
+      owner_scope: "system",
+      inherited_from_system: false,
+    },
+    DEFAULT_WORKSPACE_POLICIES,
+  );
+
+  assert.equal(injectorState.readOnly, false);
+  assert.equal(injectorState.canEdit, true);
+  assert.deepEqual(injectorState.badges, ["defaultSystem"]);
+});
+
 test("display scope resolves system-owned resources without relying on scope_level", () => {
   assert.equal(
     resolveResourceDisplayScope({

--- a/web/src/lib/workspace-resource-policies.ts
+++ b/web/src/lib/workspace-resource-policies.ts
@@ -154,7 +154,7 @@ export function getTemplateTypeManagementState(
   const resolved = resolveWorkspacePolicies(policies);
   if (!isWorkspaceScope(scope) || isSystemWorkspaceScope(scope)) {
     return {
-      ...base,
+      ...editableState(base),
       canEdit: true,
       canDelete: true,
     };
@@ -204,7 +204,7 @@ export function getTemplateManagementState(
   const resolved = resolveWorkspacePolicies(policies);
   if (!isWorkspaceScope(scope) || isSystemWorkspaceScope(scope)) {
     return {
-      ...base,
+      ...editableState(base),
       canFork: false,
       canManageVersions: true,
       canEditMetadata: true,
@@ -290,7 +290,7 @@ export function getInjectorManagementState(
   const resolved = resolveWorkspacePolicies(policies);
   if (!isWorkspaceScope(scope) || isSystemWorkspaceScope(scope)) {
     return {
-      ...base,
+      ...editableState(base),
       canEdit: true,
       canDelete: true,
     };
@@ -417,6 +417,17 @@ function appendReadOnlyBadge(state: ResourceState): ResourceState {
     ...state,
     readOnly: true,
     badges: [...state.badges, "readOnly"],
+  };
+}
+
+function editableState(state: ResourceState): ResourceState {
+  if (!state.readOnly && !state.badges.includes("readOnly")) {
+    return state;
+  }
+
+  return {
+    readOnly: false,
+    badges: state.badges.filter((badge) => badge !== "readOnly"),
   };
 }
 


### PR DESCRIPTION
## Summary

- Allow `_` in workspace codes end-to-end by aligning the database constraint, backend error mapping, and frontend workspace code sanitization.
- Prevent invalid workspace code shapes in the management and onboarding flows, and keep trailing separators out on blur/submit.
- Show the workspace display name in the sidebar scope switcher and suppress the read-only warning for tenant-owned `_system` template resources.

## Context

- Related issue: Closes #87
- Related story (if any): n/a
- Risk / tradeoffs:
  - Includes a migration that broadens `workspaces.code` to accept underscores while keeping start/end separator restrictions.
  - The scope switcher now resolves the active workspace label via the paginated workspace query so the current workspace name is available even outside the management list route.
  - Additional local validation also included targeted postgres integration coverage and browser-based UI QA for the reported regressions.

## Validation

Mark everything you actually ran.

- [ ] `make ci-backend-pr` (if backend, infra, migrations, or tests changed)
- [ ] `make ci-frontend` (if `web/` changed)
- [x] `make ci-pr` (if both backend and frontend changed)
- [x] `make ci-taxonomy-check` (if you changed docs, workflows, Makefile targets, or CI helper scripts that define the public validation contract)

Optional deeper checks when you intentionally want Docker-backed coverage:

- [ ] `make test-integration`
- [ ] `make test-e2e`

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test-only
- [ ] Security-sensitive

## Contributor checklist

- [x] I kept the change focused and reviewable.
- [x] I added or updated tests where behavior changed.
- [ ] I updated docs when behavior, setup, API, or workflows changed.
- [x] I did not add build-only validation as a substitute for the required local gates.
- [x] I did not add AI attribution or `Co-Authored-By` trailers.

## Compatibility / ops impact

- [ ] No migration
- [x] Migration included
- [x] No config changes
- [x] No security impact
- [ ] Security impact described above
