### PR TITLE
feat: add SMTP adapter support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ internal/
     pgcache/            PG UNLOGGED cache
     ses/                AWS SES sender + identity provider
     gmail/              Gmail sender + identity provider
-    smtp/               SMTP sender (dev/Mailpit)
+    smtp/               SMTP sender (plain/authenticated relays, including Mailpit)
     river/              Background workers (send + webhook)
     mjml/               MJML -> HTML compiler (gomjml)
     crypto/             AES-256-GCM encryption (HKDF)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Senda supports **selective sharing** from a tenant `_system` workspace:
 
 - **Gmail** sharing is adapter-level.
 - **SES** sharing is email-identity-level; domain identities are not shareable.
+- **SMTP** sharing is email-identity-level; sender emails are registered manually.
 - Shared entries are read-only in child workspaces.
 - Child workspaces can fork inherited template content when they need local ownership.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -212,9 +212,43 @@ Sharing rules:
 
 - manage sharing from tenant `_system`
 - Gmail sharing is adapter-level
-- SES sharing is email-identity-level
-- SES domain identities are not shareable
+- SES and SMTP sharing is email-identity-level
+- SES domain identities are not shareable; SMTP has only manual email identities
 - shared child-workspace entries are read-only
+
+Adapter create/update accepts `adapter_type` values `ses`, `gmail`, or `smtp`.
+
+SMTP adapters are relay-only. The config contains connection settings, not sender addresses:
+
+```json
+{
+  "name": "SMTP Production",
+  "adapter_type": "smtp",
+  "config": {
+    "host": "smtp.example.com",
+    "port": 587,
+    "tls_mode": "starttls",
+    "auth_mode": "plain",
+    "username": "user-or-apikey",
+    "password": "secret"
+  },
+  "is_default": false,
+  "rate_limit_per_second": 10
+}
+```
+
+SMTP `tls_mode` must be `none`, `starttls`, or `implicit_tls`. `auth_mode` is optional and may be `plain` or `login`; when either `username` or `password` is present, both are required. On update, omit `password` or send it as an empty string to keep the existing password.
+
+Create SMTP sender addresses separately through `POST /adapters/:id/identities`:
+
+```json
+{
+  "identity": "noreply-senda@tether.education",
+  "display_name": "Senda"
+}
+```
+
+SMTP does not support provider identity sync. For system-owned SMTP adapters, child workspaces can use only granted SMTP email identities, and template types select `sender_identity_id` the same way they do for SES.
 
 ### Template types
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,6 +78,7 @@ Selective sharing rules:
 
 - Gmail sharing is adapter-level from `_system`
 - SES sharing is email-identity-level from `_system`
+- SMTP sharing is email-identity-level from `_system`; sender emails are manual identities
 - shared child-workspace resources are read-only
 - template forks create local ownership from inherited resources
 - exact version cloning copies a version and all locales into a new draft

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -35,8 +35,8 @@ The master key is used to encrypt sensitive data at rest (adapter credentials, A
 | `SENDA_PORT`              | `8080`       | HTTP port                                        |
 | `SENDA_LOG_LEVEL`         | `info`       | Log level (`debug`, `info`, `warn`, `error`)     |
 | `SENDA_LOG_FORMAT`        | `json`       | Log format (`json`, `text`)                      |
-| `SENDA_SMTP_HOST`         | --           | SMTP server hostname (if using the SMTP adapter) |
-| `SENDA_SMTP_PORT`         | `1025`       | SMTP server port                                 |
+| `SENDA_SMTP_HOST`         | --           | Fallback static SMTP sender hostname for local/simple deployments |
+| `SENDA_SMTP_PORT`         | `1025`       | Fallback static SMTP sender port                 |
 | `SENDA_TRACKING_BASE_URL` | --           | Public base URL for email tracking. Enables open-tracking pixels, SES ConfigSet/SNS auto-provisioning, and SNS webhook URL. Unset = tracking disabled, auto-provisioning returns 501 |
 | `SENDA_MIGRATIONS_PATH`   | `migrations` | Path to SQL migration files inside the container |
 | `SENDA_SNS_SKIP_SIGNATURE_VERIFICATION` | `false` | Skip SNS signature verification (test-only; do not enable in production) |
@@ -117,7 +117,36 @@ Configure the adapter with an OAuth2 client ID, client secret, and refresh token
 
 ### SMTP
 
-Configure the adapter with the SMTP relay host and port. This is the most flexible option and works with any SMTP-compatible service (SendGrid, Postmark, Mailgun, self-hosted).
+Configure SMTP adapters with relay connection settings only. Sender addresses are not part of SMTP config; users create manual adapter identities for each sender email through the identities API or UI.
+
+```json
+{
+  "name": "SMTP Production",
+  "adapter_type": "smtp",
+  "config": {
+    "host": "smtp.example.com",
+    "port": 587,
+    "tls_mode": "starttls",
+    "auth_mode": "plain",
+    "username": "user-or-apikey",
+    "password": "secret"
+  },
+  "rate_limit_per_second": 10
+}
+```
+
+`tls_mode` accepts `none`, `starttls`, or `implicit_tls`. `auth_mode` is optional and accepts `plain` or `login`; credentials are optional, but `username` and `password` must be provided together when authentication is enabled. On update, omit `password` or send an empty password to keep the existing encrypted password.
+
+After creating the adapter, register sender identities separately:
+
+```json
+{
+  "identity": "noreply-senda@tether.education",
+  "display_name": "Senda"
+}
+```
+
+SMTP has no provider identity sync and no provider-domain verification. For tenant `_system` SMTP adapters, sharing is identity-scoped: child workspaces can use only granted manual email identities. Template types choose `sender_identity_id` for SMTP the same way they do for SES.
 
 ### Provider Selection
 

--- a/docs/EMAIL_FLOWS.md
+++ b/docs/EMAIL_FLOWS.md
@@ -298,6 +298,36 @@ stateDiagram-v2
 
 ---
 
+## SMTP Flow
+
+The SMTP adapter uses relay-only configuration (`host`, `port`, `tls_mode`, optional `auth_mode`, optional credentials). It does not store `from_email` or `from_name` in adapter config.
+
+Sender addresses are manual `AdapterIdentity` email records:
+
+1. Create the SMTP adapter with relay config.
+2. Create one or more manual sender email identities on that adapter.
+3. Mark a default identity or select `sender_identity_id` on the template type.
+4. For system-owned SMTP adapters, grant specific email identities to child workspaces.
+
+SMTP has no provider identity sync and no provider delivery webhooks. After the relay accepts the message, Senda records the email as `Sent`; later state changes come only from open tracking or internal failure handling.
+
+```mermaid
+sequenceDiagram
+    participant W as SendWorker
+    participant IA as Identity Access
+    participant SA as SMTP Adapter
+    participant R as SMTP Relay
+
+    W->>IA: Resolve sender_identity_id or adapter default
+    IA-->>W: Manual email identity
+    W->>SA: Raw MIME + From identity
+    SA->>R: SMTP SendMail or implicit TLS session
+    R-->>SA: Accepted
+    SA-->>W: ProviderMessageID
+```
+
+---
+
 ## Open Tracking (All Providers)
 
 Open tracking works identically across SES, Gmail, and SMTP.
@@ -414,7 +444,7 @@ To trace an email end-to-end: query by `tracking_id` via `GET /api/v1/emails/:tr
 
 | Capability | SES | Gmail | SMTP |
 |-----------|-----|-------|------|
-| **Authentication** | AWS AccessKey + SecretKey | Service Account (domain-wide delegation) | User + Password |
+| **Authentication** | AWS AccessKey + SecretKey | Service Account (domain-wide delegation) | Optional PLAIN/LOGIN relay auth |
 | **Delivery webhooks** | ✅ via SNS (Delivered, Bounce, Complaint) | ❌ Not available | ❌ Not available |
 | **Open tracking** | ✅ Pixel injection | ✅ Pixel injection | ✅ Pixel injection |
 | **Bounce detection** | ✅ Real-time via webhook | ❌ Bounce-back email only | ❌ Bounce-back email only |
@@ -437,6 +467,7 @@ To trace an email end-to-end: query by `tracking_id` via `GET /api/v1/emails/:tr
 | SES adapter | `internal/adapter/ses/adapter.go` |
 | SES tracking provisioner | `internal/adapter/ses/tracking_provisioner.go` |
 | Gmail adapter | `internal/adapter/gmail/adapter.go` |
+| SMTP adapter | `internal/adapter/smtp/adapter.go` |
 | SNS signature verifier | `internal/adapter/sns/verifier.go` |
 | SES webhook handler | `internal/http/handler/provider_webhook.go` |
 | Open tracking handler | `internal/http/handler/tracking.go` |

--- a/docs/postman/senda-api-v1.postman_collection.json
+++ b/docs/postman/senda-api-v1.postman_collection.json
@@ -1281,7 +1281,7 @@
                 "adapters"
               ]
             },
-            "description": "Create a new email adapter. Config is encrypted server-side.\n\n**Adapter types:** ses, gmail\n\n**Required role:** workspace_admin"
+            "description": "Create a new email adapter. Config is encrypted server-side.\n\n**Adapter types:** ses, gmail, smtp\n\nSMTP config is relay-only: host, port, tls_mode (none, starttls, implicit_tls), optional auth_mode (plain, login), optional username and password. Do not include from_email or from_name in SMTP config; create manual sender email identities separately through the identities endpoint.\n\n**Required role:** workspace_admin"
           },
           "response": [],
           "event": [
@@ -1489,7 +1489,7 @@
                 "identities"
               ]
             },
-            "description": "List identities for an adapter. In a regular workspace, shared SES adapters return only the granted email identities; shared Gmail adapters return their identities as usual.\n\n**Required role:** workspace_viewer+"
+            "description": "List identities for an adapter. In a regular workspace, shared SES and SMTP adapters return only the granted email identities; shared Gmail adapters return their identities as usual.\n\n**Required role:** workspace_viewer+"
           },
           "response": [],
           "event": [
@@ -1544,7 +1544,7 @@
                 "identities"
               ]
             },
-            "description": "Create a manual adapter identity. Use the tenant `_system` workspace when creating SES email identities meant to be shared later.\n\n**Required role:** workspace_admin"
+            "description": "Create a manual adapter identity. Use the tenant `_system` workspace when creating SES or SMTP email identities meant to be shared later. SMTP identities are manual sender email records and do not require provider-domain verification.\n\n**Required role:** workspace_admin"
           },
           "response": [],
           "event": [
@@ -1799,7 +1799,7 @@
                 "workspace-access"
               ]
             },
-            "description": "List workspace grants for a SES **email identity** owned by the tenant `_system` workspace. Domain identities are not shareable."
+            "description": "List workspace grants for a SES or SMTP **email identity** owned by the tenant `_system` workspace. SES domain identities are not shareable."
           },
           "response": [],
           "event": [
@@ -1850,7 +1850,7 @@
                 "workspace-access"
               ]
             },
-            "description": "Replace the set of tenant workspaces allowed to use a SES **email identity** shared from `_system`.\n\n**Rules:** only identities of type `email` can be shared; revoking an in-use grant returns `409`."
+            "description": "Replace the set of tenant workspaces allowed to use a SES or SMTP **email identity** shared from `_system`.\n\n**Rules:** only identities of type `email` can be shared; revoking an in-use grant returns `409`."
           },
           "response": [],
           "event": [

--- a/docs/superpowers/plans/2026-04-29-smtp-adapter.md
+++ b/docs/superpowers/plans/2026-04-29-smtp-adapter.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add SMTP as a first-class Senda adapter that supports plain local/internal relays and authenticated SMTP with STARTTLS or implicit TLS, then expose it in the existing Adapters frontend module.
 
-**Architecture:** Backend owns the canonical SMTP contract, DB enum, encrypted config, sender runtime, and default sender identity behavior. Frontend extends the existing Adapters module to create/edit/test SMTP adapters using that contract, without adding a separate SMTP page. SMTP does not implement provider identity sync; it seeds and maintains a manual default email identity from `from_email`.
+**Architecture:** Backend owns the canonical SMTP relay contract, DB enum, encrypted config, sender runtime, and manual identity access rules. Frontend extends the existing Adapters module to create/edit/test SMTP adapters using that contract, without adding a separate SMTP page. SMTP does not implement provider identity sync; users register full sender email addresses as manual identities and then choose/share them similarly to SES email identities.
 
 **Tech Stack:** Go 1.25, PostgreSQL migrations, Echo handlers, River send worker, `net/smtp`, `crypto/tls`, Next.js 16, React 19, TypeScript, Tailwind, TanStack Query.
 
@@ -12,7 +12,7 @@
 
 ## Contract
 
-Create/update adapter request:
+Create/update SMTP adapter request:
 
 ```json
 {
@@ -24,27 +24,36 @@ Create/update adapter request:
     "tls_mode": "starttls",
     "auth_mode": "plain",
     "username": "user-or-apikey",
-    "password": "secret",
-    "from_email": "no-reply@example.com",
-    "from_name": "Senda"
+    "password": "secret"
   },
   "is_default": false,
   "rate_limit_per_second": 10
 }
 ```
 
+SMTP sender identities are registered separately through the existing adapter identities API:
+
+```json
+{
+  "identity": "noreply-senda@tether.education",
+  "display_name": "Senda"
+}
+```
+
 Rules:
 
 - `adapter_type` accepts `smtp`.
-- `config.host`, `config.port`, `config.tls_mode`, and `config.from_email` are required for SMTP.
+- `config.host`, `config.port`, and `config.tls_mode` are required for SMTP.
 - `config.tls_mode` accepts `none`, `starttls`, or `implicit_tls`.
 - `config.auth_mode` is optional and accepts `plain` or `login`; default is `plain` when credentials are present.
 - `config.username` and `config.password` are optional. If either is set on create, both must be set.
 - On update, omitting or passing an empty `password` keeps the existing password. Passing a non-empty `password` replaces it.
-- `config.from_name` is optional.
-- `config_meta` may expose only `host`, `port`, `tls_mode`, and `from_email`.
+- `config_meta` may expose only `host`, `port`, `tls_mode`, and `auth_mode`.
 - SMTP config, including `password`, stays encrypted in `adapters.config_encrypted`.
-- SMTP creates or updates a manual default email identity from `from_email`; provider sync remains unsupported.
+- SMTP manual identities are email-only records created by the user. They do not require a verified provider-domain identity.
+- SMTP uses existing template type `sender_identity_id` selection. A template using SMTP must resolve a manual email identity, either explicit on the template type or default on the adapter.
+- System-owned SMTP adapters share at the identity level, like SES: child workspaces can use only granted sender identities.
+- Provider identity sync remains unsupported for SMTP.
 
 ---
 
@@ -52,16 +61,17 @@ Rules:
 
 Backend files:
 
-- Modify `migrations/000002_enums.up.sql` and `migrations/000002_enums.down.sql` only if the project accepts editing early migrations in local dev. Otherwise create a new migration such as `migrations/000042_add_smtp_adapter_type.up.sql` and matching down migration. Preferred: create migration `000042` to avoid rewriting applied history.
+- Modify `migrations/000002_enums.up.sql` and `migrations/000002_enums.down.sql` only if the project accepts editing early migrations in local dev. Otherwise create a new migration such as `migrations/000047_add_smtp_adapter_type.up.sql` and matching down migration. Preferred: create a new migration to avoid rewriting applied history.
 - Modify `internal/domain/adapter.go` to add `AdapterTypeSMTP`.
 - Modify `internal/adapter/smtp/adapter.go` to add SMTP config, validation, auth, STARTTLS, and implicit TLS.
 - Modify `internal/adapter/smtp/adapter_test.go` to cover config validation and sender construction behavior.
 - Modify `internal/adapter/river/send_worker.go` to add SMTP in `DefaultAdapterSenderFactory`.
 - Modify `internal/adapter/river/send_worker_test.go` to assert SMTP factory support.
-- Modify `internal/http/handler/adapter.go` to validate SMTP config, expose safe config meta, preserve password on update, and seed default SMTP identity.
+- Modify `internal/http/handler/adapter.go` to validate SMTP config, expose safe config meta, and preserve password on update.
 - Modify `internal/http/handler/adapter_test.go` to cover SMTP create/update/test-send validation.
-- Modify `internal/resolution/from_resolver.go` and `internal/service/from_email.go` so SMTP can fall back to `from_email` when no DB default identity exists.
-- Modify `internal/service/identity.go` to allow SMTP manual identities without provider-domain validation.
+- Modify `internal/service/identity.go` to allow SMTP manual email identities without provider-domain validation.
+- Modify `internal/service/adapter_access.go` so SMTP uses SES-style identity grants for system-owned shared adapters.
+- Modify `internal/http/handler/template_type.go` only if user-facing validation still says SES-specific where SMTP now also applies.
 - Modify `internal/app/identity_factory.go` tests only if they assert the unsupported type string directly.
 - Modify docs/API/Postman/OpenAPI after backend contract is final.
 
@@ -73,7 +83,7 @@ Frontend files:
 - Modify `web/src/components/adapters/adapters-content.tsx` to hide SES/Gmail-only actions for SMTP and support SMTP test send.
 - Modify `web/src/hooks/use-adapters.ts` only if request/response types need frontend-specific helpers.
 - Add focused tests beside existing frontend tests or create helper tests if the component is not currently easy to render.
-- DoD E2E data for final UI flow: host `127.0.0.1`, port `2525`, auth `PLAIN` or `LOGIN`, username from the user's provided SMTP relay, password from the user's provided SMTP relay, TLS mode `none`, from `noreply-senda@tether.education`, recipient `reynaldo@tether.education`. Do not print the password in logs, commits, docs, or final summaries.
+- DoD E2E data for final UI flow: host `127.0.0.1`, port `2525`, auth `PLAIN` or `LOGIN`, username from the user's provided SMTP relay, password from the user's provided SMTP relay, TLS mode `none`; then register manual identity `noreply-senda@tether.education` and send to `reynaldo@tether.education`. Do not print the password in logs, commits, docs, or final summaries.
 
 ---
 
@@ -82,8 +92,8 @@ Frontend files:
 ### Task 1: Add SMTP Adapter Type to Domain and Database
 
 **Files:**
-- Create: `migrations/000042_add_smtp_adapter_type.up.sql`
-- Create: `migrations/000042_add_smtp_adapter_type.down.sql`
+- Create: `migrations/000047_add_smtp_adapter_type.up.sql`
+- Create: `migrations/000047_add_smtp_adapter_type.down.sql`
 - Modify: `internal/domain/adapter.go`
 - Test: `internal/adapter/postgres/adapter_repo_test.go`
 
@@ -101,14 +111,13 @@ func TestAdapterRepo_CreateAndGet_SMTP(t *testing.T) {
 		WorkspaceID:        &deps.workspaceID,
 		Name:               "SMTP Relay",
 		AdapterType:        domain.AdapterTypeSMTP,
-		ConfigEncrypted:    []byte(`{"host":"localhost","port":1025,"tls_mode":"none","from_email":"no-reply@example.com"}`),
+		ConfigEncrypted:    []byte(`{"host":"localhost","port":1025,"tls_mode":"none"}`),
 		IsDefault:          false,
 		RateLimitPerSecond: 10,
 		ConfigMeta: map[string]string{
 			"host":       "localhost",
 			"port":       "1025",
 			"tls_mode":   "none",
-			"from_email": "no-reply@example.com",
 		},
 	}
 
@@ -153,13 +162,13 @@ const (
 
 - [ ] **Step 4: Add the migration**
 
-Create `migrations/000042_add_smtp_adapter_type.up.sql`:
+Create `migrations/000047_add_smtp_adapter_type.up.sql`:
 
 ```sql
 ALTER TYPE adapter_type ADD VALUE IF NOT EXISTS 'smtp';
 ```
 
-Create `migrations/000042_add_smtp_adapter_type.down.sql`:
+Create `migrations/000047_add_smtp_adapter_type.down.sql`:
 
 ```sql
 -- PostgreSQL cannot remove enum values safely without recreating dependent columns.
@@ -179,7 +188,7 @@ Expected: PASS.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add migrations/000042_add_smtp_adapter_type.up.sql migrations/000042_add_smtp_adapter_type.down.sql internal/domain/adapter.go internal/adapter/postgres/adapter_repo_test.go
+git add migrations/000047_add_smtp_adapter_type.up.sql migrations/000047_add_smtp_adapter_type.down.sql internal/domain/adapter.go internal/adapter/postgres/adapter_repo_test.go
 git commit -m "feat: add smtp adapter type"
 ```
 
@@ -196,31 +205,28 @@ Add these tests to `internal/adapter/smtp/adapter_test.go`:
 ```go
 func TestConfigValidate_PlainSMTP(t *testing.T) {
 	cfg := Config{
-		Host:      "localhost",
-		Port:      1025,
-		TLSMode:   TLSModeNone,
-		FromEmail: "no-reply@example.com",
+		Host:    "localhost",
+		Port:    1025,
+		TLSMode: TLSModeNone,
 	}
 	require.NoError(t, cfg.Validate())
 }
 
 func TestConfigValidate_AuthenticatedSMTPRequiresUsernameAndPasswordTogether(t *testing.T) {
 	cfg := Config{
-		Host:      "smtp.example.com",
-		Port:      587,
-		TLSMode:   TLSModeStartTLS,
-		Username:  "apikey",
-		FromEmail: "no-reply@example.com",
+		Host:     "smtp.example.com",
+		Port:     587,
+		TLSMode:  TLSModeStartTLS,
+		Username: "apikey",
 	}
 	require.ErrorContains(t, cfg.Validate(), "smtp username and password must be provided together")
 }
 
 func TestConfigValidate_RejectsUnknownTLSMode(t *testing.T) {
 	cfg := Config{
-		Host:      "smtp.example.com",
-		Port:      587,
-		TLSMode:   TLSMode("ssl-ish"),
-		FromEmail: "no-reply@example.com",
+		Host:    "smtp.example.com",
+		Port:    587,
+		TLSMode: TLSMode("ssl-ish"),
 	}
 	require.ErrorContains(t, cfg.Validate(), "invalid SMTP tls_mode")
 }
@@ -256,8 +262,6 @@ type Config struct {
 	AuthMode  string  `json:"auth_mode,omitempty"`
 	Username  string  `json:"username,omitempty"`
 	Password  string  `json:"password,omitempty"`
-	FromEmail string  `json:"from_email"`
-	FromName  string  `json:"from_name,omitempty"`
 }
 
 func (c Config) Validate() error {
@@ -273,9 +277,6 @@ func (c Config) Validate() error {
 		return fmt.Errorf("missing SMTP tls_mode")
 	default:
 		return fmt.Errorf("invalid SMTP tls_mode %q", c.TLSMode)
-	}
-	if strings.TrimSpace(c.FromEmail) == "" {
-		return fmt.Errorf("missing SMTP from_email")
 	}
 	if c.AuthMode != "" && c.AuthMode != "plain" && c.AuthMode != "login" {
 		return fmt.Errorf("invalid SMTP auth_mode %q", c.AuthMode)
@@ -460,7 +461,7 @@ Add this test to `internal/adapter/river/send_worker_test.go`:
 ```go
 func TestDefaultAdapterSenderFactory_SMTP(t *testing.T) {
 	adapter := &domain.Adapter{AdapterType: domain.AdapterTypeSMTP}
-	cfg := []byte(`{"host":"localhost","port":1025,"tls_mode":"none","from_email":"no-reply@example.com"}`)
+	cfg := []byte(`{"host":"localhost","port":1025,"tls_mode":"none"}`)
 
 	sender, err := DefaultAdapterSenderFactory(context.Background(), adapter, cfg)
 	if err != nil {
@@ -541,9 +542,7 @@ func TestAdapterHandler_Create_SMTPValidatesAndStoresSafeMeta(t *testing.T) {
 			"tls_mode":"starttls",
 			"auth_mode":"plain",
 			"username":"apikey",
-			"password":"secret",
-			"from_email":"no-reply@example.com",
-			"from_name":"Senda"
+			"password":"secret"
 		},
 		"rate_limit_per_second":10
 	}`
@@ -621,8 +620,8 @@ case domain.AdapterTypeSMTP:
 	if v, ok := cfgMap["tls_mode"].(string); ok && v != "" {
 		meta["tls_mode"] = v
 	}
-	if v, ok := cfgMap["from_email"].(string); ok && v != "" {
-		meta["from_email"] = v
+	if v, ok := cfgMap["auth_mode"].(string); ok && v != "" {
+		meta["auth_mode"] = v
 	}
 	switch v := cfgMap["port"].(type) {
 	case float64:
@@ -668,7 +667,7 @@ func TestAdapterHandler_Update_SMTPKeepsPasswordWhenBlank(t *testing.T) {
 	h, deps := setupAdapterHandlerTest(t)
 	adapterID := uuid.Must(uuid.NewV7())
 	deps.crypto.decryptFn = func(_ []byte) ([]byte, error) {
-		return []byte(`{"host":"smtp.example.com","port":587,"tls_mode":"starttls","auth_mode":"plain","username":"apikey","password":"old-secret","from_email":"old@example.com"}`), nil
+		return []byte(`{"host":"smtp.example.com","port":587,"tls_mode":"starttls","auth_mode":"plain","username":"apikey","password":"old-secret"}`), nil
 	}
 	deps.adapterStore.adapter = &domain.Adapter{
 		ID:              adapterID,
@@ -678,7 +677,7 @@ func TestAdapterHandler_Update_SMTPKeepsPasswordWhenBlank(t *testing.T) {
 		ConfigEncrypted: []byte("encrypted"),
 	}
 
-	body := `{"config":{"host":"smtp.example.com","port":587,"tls_mode":"starttls","auth_mode":"plain","username":"apikey","password":"","from_email":"new@example.com"}}`
+	body := `{"config":{"host":"smtp.example.com","port":587,"tls_mode":"starttls","auth_mode":"plain","username":"apikey","password":""}}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/adapters/"+adapterID.String(), strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -769,107 +768,68 @@ git add internal/http/handler/adapter.go internal/http/handler/adapter_test.go
 git commit -m "feat: preserve smtp password on update"
 ```
 
-### Task 6: Resolve SMTP From Address and Manual Identity
+### Task 6: Support SMTP Manual Sender Identities and Sharing
 
 **Files:**
-- Modify: `internal/resolution/from_resolver.go`
-- Modify: `internal/service/from_email.go`
 - Modify: `internal/service/identity.go`
-- Modify: `internal/http/handler/adapter.go`
-- Test: `internal/service/test_send_test.go`
+- Modify: `internal/service/adapter_access.go`
+- Modify: `internal/http/handler/template_type.go`
 - Test: `internal/service/identity_factory_test.go` or `internal/service/identity_test.go`
+- Test: `internal/service/adapter_access_test.go`
+- Test: `internal/http/handler/template_type_test.go`
 
-- [ ] **Step 1: Add failing SMTP fallback test**
+- [ ] **Step 1: Add failing manual identity test**
 
-Add this test to `internal/service/test_send_test.go`:
+Add a service test that proves SMTP can register full sender email identities without a provider-domain identity:
 
 ```go
-func TestTestSendService_FallsBackToSMTPFromEmailWhenNoDefaultIdentity(t *testing.T) {
-	f := newTestSendFixture(t)
-	f.adapter.AdapterType = domain.AdapterTypeSMTP
-	f.adapter.ConfigEncrypted = []byte(`{"host":"localhost","port":1025,"tls_mode":"none","from_email":"smtp@example.com","from_name":"SMTP"}`)
-	f.crypto.decryptFn = func(_ []byte) ([]byte, error) {
-		return f.adapter.ConfigEncrypted, nil
+func TestIdentityService_CreateManual_AllowsSMTPEmailWithoutProviderDomain(t *testing.T) {
+	adapterID := uuid.Must(uuid.NewV7())
+	adapterStore := &mockAdapterStore{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				t.Fatalf("adapter id = %s, want %s", id, adapterID)
+			}
+			return &domain.Adapter{ID: adapterID, AdapterType: domain.AdapterTypeSMTP}, nil
+		},
 	}
-	f.identityStore.getDefaultFn = func(_ context.Context, _ uuid.UUID) (*domain.AdapterIdentity, error) {
-		return nil, domain.ErrNoDefaultIdentity
+	identityStore := &mockAdapterIdentityStoreSend{
+		createFn: func(_ context.Context, identity *domain.AdapterIdentity) error {
+			if identity.Identity != "noreply-senda@tether.education" {
+				t.Fatalf("identity = %q", identity.Identity)
+			}
+			if identity.IdentityType != domain.IdentityTypeEmail {
+				t.Fatalf("identity type = %q", identity.IdentityType)
+			}
+			if identity.Source != domain.IdentitySourceManual {
+				t.Fatalf("source = %q", identity.Source)
+			}
+			return nil
+		},
 	}
+	svc := service.NewIdentityService(identityStore, adapterStore, nil, nil)
 
-	result, err := f.service.Send(context.Background(), &service.TestSendRequest{
-		TemplateID: f.template.ID,
-		To:         "recipient@example.com",
-	})
+	identity, err := svc.CreateManual(context.Background(), adapterID, "noreply-senda@tether.education", nil)
 	if err != nil {
-		t.Fatalf("Send() error = %v", err)
+		t.Fatalf("CreateManual() error = %v", err)
 	}
-	if result.FromAddress != "smtp@example.com" {
-		t.Fatalf("FromAddress = %q, want smtp@example.com", result.FromAddress)
+	if identity.Identity != "noreply-senda@tether.education" {
+		t.Fatalf("identity = %q", identity.Identity)
 	}
 }
 ```
 
-- [ ] **Step 2: Run the failing test**
+- [ ] **Step 2: Run the failing identity test**
 
 Run:
 
 ```bash
-go test ./internal/service -run TestTestSendService_FallsBackToSMTPFromEmailWhenNoDefaultIdentity -count=1
+go test ./internal/service -run TestIdentityService_CreateManual_AllowsSMTPEmailWithoutProviderDomain -count=1
 ```
 
-Expected: FAIL because `ResolveFromAddress` only knows `delegate_email`.
+Expected: FAIL because `CreateManual` requires a verified domain identity.
 
-- [ ] **Step 3: Add SMTP from fallback**
-
-Update `internal/resolution/from_resolver.go` comments and logic:
-
-```go
-// ResolveFromAddress determines the sender email address for an adapter by trying:
-// 1. The default identity from the identity store.
-// 2. SMTP from_email from config_meta.
-// 3. Gmail delegate_email from config_meta.
-// 4. SMTP from_email or Gmail delegate_email from decrypted config JSON.
-```
-
-Add before delegate lookup:
-
-```go
-if fromEmail := adapter.ConfigMeta["from_email"]; fromEmail != "" {
-	from.Address = fromEmail
-	return from
-}
-```
-
-In decrypted fallback, add:
-
-```go
-if smtpFrom, ok := cfgMap["from_email"].(string); ok && smtpFrom != "" {
-	from.Address = smtpFrom
-	if name, ok := cfgMap["from_name"].(string); ok && name != "" {
-		from.Name = name
-	}
-	return from
-}
-```
-
-Update `resolveFromEmail` in `internal/service/from_email.go` so SMTP can use the config fallback when called from real send. Change signature to:
-
-```go
-func resolveFromEmail(identityStore port.AdapterIdentityStore, ctx context.Context, adapter *domain.Adapter, decryptedConfig []byte, senderIdentityID *uuid.UUID) (string, error)
-```
-
-When no explicit identity is set and default identity lookup fails:
-
-```go
-from := resolution.ResolveFromAddress(ctx, identityStore, adapter, decryptedConfig)
-if from.Address != "" {
-	return from.Address, nil
-}
-return "", fmt.Errorf("%w: adapter %s", domain.ErrNoDefaultIdentity, adapter.ID)
-```
-
-Update callers in `internal/service/send.go` and `internal/service/send_context.go` to pass decrypted config from the resolved adapter path if available. If the prepared send path does not have decrypted config, decrypt it before resolving from.
-
-- [ ] **Step 4: Allow SMTP manual identity without provider domain**
+- [ ] **Step 3: Allow SMTP manual identities**
 
 In `internal/service/identity.go`, load the adapter at the beginning of `CreateManual`:
 
@@ -880,7 +840,7 @@ if err != nil {
 }
 ```
 
-Wrap the domain-verified check:
+Wrap the existing provider-domain verification so it is skipped only for SMTP:
 
 ```go
 if adapter.AdapterType != domain.AdapterTypeSMTP {
@@ -903,42 +863,88 @@ if adapter.AdapterType != domain.AdapterTypeSMTP {
 }
 ```
 
-- [ ] **Step 5: Seed SMTP default identity on create/update**
+- [ ] **Step 4: Add failing access tests for shared SMTP**
 
-In `internal/http/handler/adapter.go`, add helper:
+Add tests in `internal/service/adapter_access_test.go` mirroring the shared SES behavior, but using `domain.AdapterTypeSMTP`:
 
 ```go
-func smtpIdentityFromConfig(raw []byte) (identity string, displayName *string, ok bool) {
-	var cfg smtpadapter.Config
-	if err := json.Unmarshal(raw, &cfg); err != nil || cfg.FromEmail == "" {
-		return "", nil, false
+func TestAdapterAccessService_ValidateTemplateTypeSelection_SharedSMTPRequiresGrantedSenderIdentity(t *testing.T) {
+	systemWorkspace, childWorkspace, adapterID, identityID := accessFixtureIDs(t)
+	svc := newAdapterAccessServiceFixture(t,
+		withAdapter(&domain.Adapter{ID: adapterID, WorkspaceID: &systemWorkspace.ID, AdapterType: domain.AdapterTypeSMTP}),
+		withWorkspace(systemWorkspace),
+		withIdentity(&domain.AdapterIdentity{ID: identityID, AdapterID: adapterID, Identity: "noreply-senda@tether.education", IdentityType: domain.IdentityTypeEmail}),
+		withIdentityGrant(identityID, childWorkspace.ID),
+	)
+
+	err := svc.ValidateTemplateTypeSelection(context.Background(), childWorkspace, &adapterID, &identityID)
+	if err != nil {
+		t.Fatalf("ValidateTemplateTypeSelection() error = %v", err)
 	}
-	if cfg.FromName != "" {
-		name := cfg.FromName
-		displayName = &name
+}
+
+func TestAdapterAccessService_ValidateTemplateTypeSelection_SharedSMTPRejectsMissingSenderIdentity(t *testing.T) {
+	systemWorkspace, childWorkspace, adapterID, _ := accessFixtureIDs(t)
+	svc := newAdapterAccessServiceFixture(t,
+		withAdapter(&domain.Adapter{ID: adapterID, WorkspaceID: &systemWorkspace.ID, AdapterType: domain.AdapterTypeSMTP}),
+		withWorkspace(systemWorkspace),
+	)
+
+	err := svc.ValidateTemplateTypeSelection(context.Background(), childWorkspace, &adapterID, nil)
+	if !errors.Is(err, domain.ErrSenderIdentityRequired) {
+		t.Fatalf("error = %v, want ErrSenderIdentityRequired", err)
 	}
-	return cfg.FromEmail, displayName, true
 }
 ```
 
-After successful create/update for SMTP, call `IdentityService.CreateManual` or a new small service helper that upserts the default SMTP identity. If the existing identity already exists, set it default through the store rather than creating a duplicate.
+If this repo does not have the helper names above, implement the same assertions with the existing manual mocks in `adapter_access_test.go`.
 
-- [ ] **Step 6: Run service and handler tests**
+- [ ] **Step 5: Extend identity-grant access rules to SMTP**
+
+In `internal/service/adapter_access.go`, treat SMTP like SES where access is identity-scoped:
+
+```go
+func usesIdentityGrants(adapterType domain.AdapterType) bool {
+	return adapterType == domain.AdapterTypeSES || adapterType == domain.AdapterTypeSMTP
+}
+```
+
+Use `usesIdentityGrants` in:
+
+- `GetAdapterAccess`
+- `ListIdentitiesForWorkspace`
+- `ValidateTemplateTypeSelection`
+- `ReplaceIdentityWorkspaceAccess`
+- `ListIdentityWorkspaceAccess`
+
+Keep Gmail on adapter-level grants. Do not give SMTP provider sync.
+
+- [ ] **Step 6: Update validation messages**
+
+In `internal/http/handler/template_type.go`, change SES-specific error text:
+
+```go
+response.FieldError{Field: "sender_identity_id", Message: "is required for shared adapter sender identities"}
+```
+
+In comments and docs, use “identity-scoped adapters” or “SES/SMTP” instead of “SES” when the rule now applies to both.
+
+- [ ] **Step 7: Run service and handler tests**
 
 Run:
 
 ```bash
-go test ./internal/service -run 'TestTestSendService_FallsBackToSMTPFromEmail|TestIdentityService' -count=1
-go test ./internal/http/handler -run 'TestAdapterHandler_Create_SMTP|TestAdapterHandler_Update_SMTP' -count=1
+go test ./internal/service -run 'TestIdentityService_CreateManual_AllowsSMTP|TestAdapterAccessService_.*SMTP|TestAdapterAccessService_.*SES|TestAdapterAccessService_.*Gmail' -count=1
+go test ./internal/http/handler -run 'TestTemplateTypeHandler_Create_SharedSESRequiresSenderIdentity|TestTemplateTypeHandler_.*SMTP|TestIdentityHandler' -count=1
 ```
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
-git add internal/resolution/from_resolver.go internal/service/from_email.go internal/service/identity.go internal/http/handler/adapter.go internal/service/test_send_test.go internal/http/handler/adapter_test.go
-git commit -m "feat: resolve smtp sender identities"
+git add internal/service/identity.go internal/service/adapter_access.go internal/http/handler/template_type.go internal/service/*test.go internal/http/handler/*test.go
+git commit -m "feat: support smtp sender identities"
 ```
 
 ### Task 7: Backend Contract Docs and Verification
@@ -1005,8 +1011,6 @@ export interface SmtpConfig {
   auth_mode?: "plain" | "login";
   username?: string;
   password?: string;
-  from_email: string;
-  from_name?: string;
 }
 ```
 
@@ -1066,8 +1070,6 @@ const [smtpTLSMode, setSmtpTLSMode] = useState<"none" | "starttls" | "implicit_t
 const [smtpAuthMode, setSmtpAuthMode] = useState<"plain" | "login">("plain");
 const [smtpUsername, setSmtpUsername] = useState("");
 const [smtpPassword, setSmtpPassword] = useState("");
-const [smtpFromEmail, setSmtpFromEmail] = useState(defaults?.config_meta?.from_email ?? "");
-const [smtpFromName, setSmtpFromName] = useState("");
 ```
 
 - [ ] **Step 3: Include SMTP in type selector**
@@ -1095,8 +1097,6 @@ const config =
           ...(smtpUsername || smtpPassword ? { auth_mode: smtpAuthMode } : {}),
           ...(smtpUsername ? { username: smtpUsername } : {}),
           ...(smtpPassword ? { password: smtpPassword } : {}),
-          from_email: smtpFromEmail,
-          ...(smtpFromName ? { from_name: smtpFromName } : {}),
         };
 ```
 
@@ -1151,16 +1151,6 @@ Refactor the config section to branch `ses`, `gmail`, `smtp`. Add this SMTP bloc
         <Input id="smtp-password" type="password" value={smtpPassword} onChange={(e) => setSmtpPassword(e.target.value)} placeholder={isEdit ? "Leave empty to keep current" : "secret"} className="font-mono" />
       </div>
     </div>
-    <div className="grid grid-cols-2 gap-3">
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="smtp-from-email">From Email</Label>
-        <Input id="smtp-from-email" type="email" value={smtpFromEmail} onChange={(e) => setSmtpFromEmail(e.target.value)} placeholder="no-reply@example.com" className="font-mono" required={!isEdit} />
-      </div>
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="smtp-from-name">From Name</Label>
-        <Input id="smtp-from-name" value={smtpFromName} onChange={(e) => setSmtpFromName(e.target.value)} placeholder="Senda" />
-      </div>
-    </div>
   </div>
 )}
 ```
@@ -1187,6 +1177,7 @@ git commit -m "feat: add smtp adapter form"
 **Files:**
 - Modify: `web/src/components/adapters/adapter-type-badge.tsx`
 - Modify: `web/src/components/adapters/adapters-content.tsx`
+- Modify: `web/src/components/templates/template-types-content.tsx`
 
 - [ ] **Step 1: Add SMTP badge**
 
@@ -1221,23 +1212,43 @@ In `adapters-content.tsx`, ensure checks are explicit:
 ```ts
 const supportsIdentitySync = adapter.adapter_type === "ses" || adapter.adapter_type === "gmail";
 const supportsProvisioning = adapter.adapter_type === "ses";
-const supportsSenderSharing = adapter.adapter_type === "ses";
+const supportsSenderSharing = adapter.adapter_type === "ses" || adapter.adapter_type === "smtp";
 const supportsAdapterSharing = adapter.adapter_type === "gmail";
 ```
 
-Use these booleans to render sync/provisioning/sharing actions. Do not render SES/Gmail actions for SMTP.
+Use these booleans to render sync/provisioning/sharing actions. SMTP should not render provider sync or SES provisioning, but it should render identity-level sender sharing for manual SMTP email identities.
 
-- [ ] **Step 3: Test send from SMTP**
+- [ ] **Step 3: Show sender identity selection for SMTP template types**
+
+In `web/src/components/templates/template-types-content.tsx`, update adapter identity logic:
+
+```ts
+const usesSenderIdentity = !!selectedAdapter && (
+  selectedAdapter.adapter_type === "ses" || selectedAdapter.adapter_type === "smtp"
+);
+const showIdentitySelect = usesSenderIdentity;
+const requireExplicitSender = usesSenderIdentity && selectedAdapter.is_shared;
+```
+
+Also update create validation that currently checks only shared SES:
+
+```ts
+if ((selectedAdapter?.adapter_type === "ses" || selectedAdapter?.adapter_type === "smtp") && selectedAdapter.is_shared && !newSenderIdentityId) {
+  // preserve existing validation behavior/message shape
+}
+```
+
+- [ ] **Step 4: Test send from SMTP**
 
 Change test-send payload:
 
 ```ts
-...(adapter.adapter_type === "ses" && from ? { from } : {}),
+...((adapter.adapter_type === "ses" || adapter.adapter_type === "smtp") && from ? { from } : {}),
 ```
 
-Keep this SES-only unless backend later supports choosing SMTP identities manually in the test dialog. SMTP should use the backend default `from_email`.
+The test dialog should show the same sender email picker for SMTP that it shows for SES, using manual verified email identities.
 
-- [ ] **Step 4: Run frontend checks**
+- [ ] **Step 5: Run frontend checks**
 
 Run:
 
@@ -1248,10 +1259,10 @@ corepack pnpm --dir web lint
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add web/src/components/adapters/adapter-type-badge.tsx web/src/components/adapters/adapters-content.tsx
+git add web/src/components/adapters/adapter-type-badge.tsx web/src/components/adapters/adapters-content.tsx web/src/components/templates/template-types-content.tsx
 git commit -m "feat: show smtp adapters in ui"
 ```
 
@@ -1289,13 +1300,24 @@ TLS Mode: None
 Auth Mode: PLAIN or LOGIN
 Username: use the relay username provided by the user
 Password: use the relay password provided by the user
-From Email: noreply-senda@tether.education
 Rate Limit: 10
 ```
 
 Expected: create succeeds and table shows SMTP badge.
 
-- [ ] **Step 4: Send test email**
+- [ ] **Step 4: Register SMTP sender identity**
+
+Use the adapter identity UI to add:
+
+```text
+Identity: noreply-senda@tether.education
+Display Name: Senda
+Set as default: yes, if the UI exposes the default action separately
+```
+
+Expected: the identity appears as a verified manual email identity and can be selected by template types/test send.
+
+- [ ] **Step 5: Send test email**
 
 Use Test Send with:
 
@@ -1307,7 +1329,7 @@ Body: <p>Hello from SMTP</p>
 
 Expected: success toast. The user will validate whether the message arrives at `reynaldo@tether.education`.
 
-- [ ] **Step 5: Commit visual fixes if needed**
+- [ ] **Step 6: Commit visual fixes if needed**
 
 If visual fixes are needed:
 
@@ -1369,6 +1391,6 @@ Skip the commit if all prior task commits already captured every change.
 
 ## Self-Review Notes
 
-- Spec coverage: backend contract, DB enum, sender runtime, handler validation, password preservation, identity fallback, UI form, badge, action gating, test send, docs, and gates are covered.
+- Spec coverage: backend contract, DB enum, sender runtime, handler validation, password preservation, SMTP manual identities, identity-level sharing, UI form, badge, action gating, test send, docs, and gates are covered.
 - Placeholder scan: no unresolved placeholder markers are intentionally left. The one migration down file is intentionally irreversible because PostgreSQL enum value removal is unsafe after application.
-- Type consistency: canonical names are `AdapterTypeSMTP`, `smtp`, `SmtpConfig`, `tls_mode`, `from_email`, and `implicit_tls`.
+- Type consistency: canonical names are `AdapterTypeSMTP`, `smtp`, `SmtpConfig`, `tls_mode`, `auth_mode`, and `implicit_tls`; sender addresses are `AdapterIdentity` records, not SMTP config fields.

--- a/docs/superpowers/plans/2026-04-29-smtp-adapter.md
+++ b/docs/superpowers/plans/2026-04-29-smtp-adapter.md
@@ -1177,6 +1177,7 @@ git commit -m "feat: add smtp adapter form"
 **Files:**
 - Modify: `web/src/components/adapters/adapter-type-badge.tsx`
 - Modify: `web/src/components/adapters/adapters-content.tsx`
+- Modify: `web/src/components/adapters/identity-panel.tsx`
 - Modify: `web/src/components/templates/template-types-content.tsx`
 
 - [ ] **Step 1: Add SMTP badge**
@@ -1218,7 +1219,47 @@ const supportsAdapterSharing = adapter.adapter_type === "gmail";
 
 Use these booleans to render sync/provisioning/sharing actions. SMTP should not render provider sync or SES provisioning, but it should render identity-level sender sharing for manual SMTP email identities.
 
-- [ ] **Step 3: Show sender identity selection for SMTP template types**
+- [ ] **Step 3: Add full-email identity creation for SMTP**
+
+In `web/src/components/adapters/identity-panel.tsx`, SMTP should not depend on provider domains. Add a simple full email form for editable SMTP adapters:
+
+```tsx
+function ManualEmailAddInput({
+  adapterId,
+  scopedPath,
+  disabled,
+}: {
+  adapterId: string;
+  scopedPath: string;
+  disabled?: boolean;
+}) {
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const create = useCreateIdentity(scopedPath, adapterId);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const identity = email.trim();
+    if (!identity) return;
+    create.mutate(
+      { identity, ...(displayName.trim() ? { display_name: displayName.trim() } : {}) },
+      { onSuccess: () => { setEmail(""); setDisplayName(""); } },
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 rounded-md border border-dashed p-3">
+      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="no-reply@example.com" className="h-8 rounded-md border bg-transparent px-2 text-xs font-mono" />
+      <input value={displayName} onChange={(e) => setDisplayName(e.target.value)} placeholder="Display name" className="h-8 rounded-md border bg-transparent px-2 text-xs" />
+      <Button type="submit" size="sm" disabled={disabled || !email.trim() || create.isPending}>Add sender</Button>
+    </form>
+  );
+}
+```
+
+Render it for `adapter.adapter_type === "smtp"` and `adapter.is_editable`. Hide the provider sync button for SMTP and adjust empty copy to say SMTP sender emails are added manually.
+
+- [ ] **Step 4: Show sender identity selection for SMTP template types**
 
 In `web/src/components/templates/template-types-content.tsx`, update adapter identity logic:
 
@@ -1238,7 +1279,7 @@ if ((selectedAdapter?.adapter_type === "ses" || selectedAdapter?.adapter_type ==
 }
 ```
 
-- [ ] **Step 4: Test send from SMTP**
+- [ ] **Step 5: Test send from SMTP**
 
 Change test-send payload:
 
@@ -1248,7 +1289,7 @@ Change test-send payload:
 
 The test dialog should show the same sender email picker for SMTP that it shows for SES, using manual verified email identities.
 
-- [ ] **Step 5: Run frontend checks**
+- [ ] **Step 6: Run frontend checks**
 
 Run:
 
@@ -1259,10 +1300,10 @@ corepack pnpm --dir web lint
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add web/src/components/adapters/adapter-type-badge.tsx web/src/components/adapters/adapters-content.tsx web/src/components/templates/template-types-content.tsx
+git add web/src/components/adapters/adapter-type-badge.tsx web/src/components/adapters/adapters-content.tsx web/src/components/adapters/identity-panel.tsx web/src/components/templates/template-types-content.tsx
 git commit -m "feat: show smtp adapters in ui"
 ```
 

--- a/docs/superpowers/plans/2026-04-29-smtp-adapter.md
+++ b/docs/superpowers/plans/2026-04-29-smtp-adapter.md
@@ -1,0 +1,1374 @@
+# SMTP Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add SMTP as a first-class Senda adapter that supports plain local/internal relays and authenticated SMTP with STARTTLS or implicit TLS, then expose it in the existing Adapters frontend module.
+
+**Architecture:** Backend owns the canonical SMTP contract, DB enum, encrypted config, sender runtime, and default sender identity behavior. Frontend extends the existing Adapters module to create/edit/test SMTP adapters using that contract, without adding a separate SMTP page. SMTP does not implement provider identity sync; it seeds and maintains a manual default email identity from `from_email`.
+
+**Tech Stack:** Go 1.25, PostgreSQL migrations, Echo handlers, River send worker, `net/smtp`, `crypto/tls`, Next.js 16, React 19, TypeScript, Tailwind, TanStack Query.
+
+---
+
+## Contract
+
+Create/update adapter request:
+
+```json
+{
+  "name": "SMTP Production",
+  "adapter_type": "smtp",
+  "config": {
+    "host": "smtp.example.com",
+    "port": 587,
+    "tls_mode": "starttls",
+    "auth_mode": "plain",
+    "username": "user-or-apikey",
+    "password": "secret",
+    "from_email": "no-reply@example.com",
+    "from_name": "Senda"
+  },
+  "is_default": false,
+  "rate_limit_per_second": 10
+}
+```
+
+Rules:
+
+- `adapter_type` accepts `smtp`.
+- `config.host`, `config.port`, `config.tls_mode`, and `config.from_email` are required for SMTP.
+- `config.tls_mode` accepts `none`, `starttls`, or `implicit_tls`.
+- `config.auth_mode` is optional and accepts `plain` or `login`; default is `plain` when credentials are present.
+- `config.username` and `config.password` are optional. If either is set on create, both must be set.
+- On update, omitting or passing an empty `password` keeps the existing password. Passing a non-empty `password` replaces it.
+- `config.from_name` is optional.
+- `config_meta` may expose only `host`, `port`, `tls_mode`, and `from_email`.
+- SMTP config, including `password`, stays encrypted in `adapters.config_encrypted`.
+- SMTP creates or updates a manual default email identity from `from_email`; provider sync remains unsupported.
+
+---
+
+## File Structure
+
+Backend files:
+
+- Modify `migrations/000002_enums.up.sql` and `migrations/000002_enums.down.sql` only if the project accepts editing early migrations in local dev. Otherwise create a new migration such as `migrations/000042_add_smtp_adapter_type.up.sql` and matching down migration. Preferred: create migration `000042` to avoid rewriting applied history.
+- Modify `internal/domain/adapter.go` to add `AdapterTypeSMTP`.
+- Modify `internal/adapter/smtp/adapter.go` to add SMTP config, validation, auth, STARTTLS, and implicit TLS.
+- Modify `internal/adapter/smtp/adapter_test.go` to cover config validation and sender construction behavior.
+- Modify `internal/adapter/river/send_worker.go` to add SMTP in `DefaultAdapterSenderFactory`.
+- Modify `internal/adapter/river/send_worker_test.go` to assert SMTP factory support.
+- Modify `internal/http/handler/adapter.go` to validate SMTP config, expose safe config meta, preserve password on update, and seed default SMTP identity.
+- Modify `internal/http/handler/adapter_test.go` to cover SMTP create/update/test-send validation.
+- Modify `internal/resolution/from_resolver.go` and `internal/service/from_email.go` so SMTP can fall back to `from_email` when no DB default identity exists.
+- Modify `internal/service/identity.go` to allow SMTP manual identities without provider-domain validation.
+- Modify `internal/app/identity_factory.go` tests only if they assert the unsupported type string directly.
+- Modify docs/API/Postman/OpenAPI after backend contract is final.
+
+Frontend files:
+
+- Modify `web/src/types/adapters.ts` to add `smtp` and `SmtpConfig`.
+- Modify `web/src/components/adapters/adapter-form.tsx` to render SMTP fields and build the SMTP request.
+- Modify `web/src/components/adapters/adapter-type-badge.tsx` to add SMTP badge.
+- Modify `web/src/components/adapters/adapters-content.tsx` to hide SES/Gmail-only actions for SMTP and support SMTP test send.
+- Modify `web/src/hooks/use-adapters.ts` only if request/response types need frontend-specific helpers.
+- Add focused tests beside existing frontend tests or create helper tests if the component is not currently easy to render.
+- DoD E2E data for final UI flow: host `127.0.0.1`, port `2525`, auth `PLAIN` or `LOGIN`, username from the user's provided SMTP relay, password from the user's provided SMTP relay, TLS mode `none`, from `noreply-senda@tether.education`, recipient `reynaldo@tether.education`. Do not print the password in logs, commits, docs, or final summaries.
+
+---
+
+## Issue 1: Backend/API/Modelo
+
+### Task 1: Add SMTP Adapter Type to Domain and Database
+
+**Files:**
+- Create: `migrations/000042_add_smtp_adapter_type.up.sql`
+- Create: `migrations/000042_add_smtp_adapter_type.down.sql`
+- Modify: `internal/domain/adapter.go`
+- Test: `internal/adapter/postgres/adapter_repo_test.go`
+
+- [ ] **Step 1: Write the failing repository test**
+
+Add this test to `internal/adapter/postgres/adapter_repo_test.go`:
+
+```go
+func TestAdapterRepo_CreateAndGet_SMTP(t *testing.T) {
+	ctx := context.Background()
+	deps := setupAdapterRepoTest(t)
+
+	adapter := &domain.Adapter{
+		ID:                 uuid.Must(uuid.NewV7()),
+		WorkspaceID:        &deps.workspaceID,
+		Name:               "SMTP Relay",
+		AdapterType:        domain.AdapterTypeSMTP,
+		ConfigEncrypted:    []byte(`{"host":"localhost","port":1025,"tls_mode":"none","from_email":"no-reply@example.com"}`),
+		IsDefault:          false,
+		RateLimitPerSecond: 10,
+		ConfigMeta: map[string]string{
+			"host":       "localhost",
+			"port":       "1025",
+			"tls_mode":   "none",
+			"from_email": "no-reply@example.com",
+		},
+	}
+
+	if err := deps.repo.Create(ctx, adapter); err != nil {
+		t.Fatalf("Create() SMTP error = %v", err)
+	}
+
+	got, err := deps.repo.GetByID(ctx, adapter.ID)
+	if err != nil {
+		t.Fatalf("GetByID() SMTP error = %v", err)
+	}
+	if got.AdapterType != domain.AdapterTypeSMTP {
+		t.Fatalf("AdapterType = %q, want %q", got.AdapterType, domain.AdapterTypeSMTP)
+	}
+	if got.ConfigMeta["tls_mode"] != "none" {
+		t.Fatalf("ConfigMeta[tls_mode] = %q, want none", got.ConfigMeta["tls_mode"])
+	}
+}
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+go test ./internal/adapter/postgres -run TestAdapterRepo_CreateAndGet_SMTP -count=1
+```
+
+Expected: FAIL because `domain.AdapterTypeSMTP` is undefined or the DB enum rejects `smtp`.
+
+- [ ] **Step 3: Add the domain constant**
+
+Change `internal/domain/adapter.go`:
+
+```go
+const (
+	AdapterTypeSES   AdapterType = "ses"
+	AdapterTypeGmail AdapterType = "gmail"
+	AdapterTypeSMTP  AdapterType = "smtp"
+)
+```
+
+- [ ] **Step 4: Add the migration**
+
+Create `migrations/000042_add_smtp_adapter_type.up.sql`:
+
+```sql
+ALTER TYPE adapter_type ADD VALUE IF NOT EXISTS 'smtp';
+```
+
+Create `migrations/000042_add_smtp_adapter_type.down.sql`:
+
+```sql
+-- PostgreSQL cannot remove enum values safely without recreating dependent columns.
+-- Keep this migration irreversible; rolling back code should simply stop creating smtp adapters.
+```
+
+- [ ] **Step 5: Run the repository test**
+
+Run:
+
+```bash
+go test ./internal/adapter/postgres -run TestAdapterRepo_CreateAndGet_SMTP -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add migrations/000042_add_smtp_adapter_type.up.sql migrations/000042_add_smtp_adapter_type.down.sql internal/domain/adapter.go internal/adapter/postgres/adapter_repo_test.go
+git commit -m "feat: add smtp adapter type"
+```
+
+### Task 2: Implement SMTP Config and Transport Modes
+
+**Files:**
+- Modify: `internal/adapter/smtp/adapter.go`
+- Modify: `internal/adapter/smtp/adapter_test.go`
+
+- [ ] **Step 1: Add failing config validation tests**
+
+Add these tests to `internal/adapter/smtp/adapter_test.go`:
+
+```go
+func TestConfigValidate_PlainSMTP(t *testing.T) {
+	cfg := Config{
+		Host:      "localhost",
+		Port:      1025,
+		TLSMode:   TLSModeNone,
+		FromEmail: "no-reply@example.com",
+	}
+	require.NoError(t, cfg.Validate())
+}
+
+func TestConfigValidate_AuthenticatedSMTPRequiresUsernameAndPasswordTogether(t *testing.T) {
+	cfg := Config{
+		Host:      "smtp.example.com",
+		Port:      587,
+		TLSMode:   TLSModeStartTLS,
+		Username:  "apikey",
+		FromEmail: "no-reply@example.com",
+	}
+	require.ErrorContains(t, cfg.Validate(), "smtp username and password must be provided together")
+}
+
+func TestConfigValidate_RejectsUnknownTLSMode(t *testing.T) {
+	cfg := Config{
+		Host:      "smtp.example.com",
+		Port:      587,
+		TLSMode:   TLSMode("ssl-ish"),
+		FromEmail: "no-reply@example.com",
+	}
+	require.ErrorContains(t, cfg.Validate(), "invalid SMTP tls_mode")
+}
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+go test ./internal/adapter/smtp -run 'TestConfigValidate' -count=1
+```
+
+Expected: FAIL because `Config`, `TLSModeNone`, and related symbols are undefined.
+
+- [ ] **Step 3: Add Config, TLSMode, and constructor**
+
+Update `internal/adapter/smtp/adapter.go` with these definitions:
+
+```go
+type TLSMode string
+
+const (
+	TLSModeNone        TLSMode = "none"
+	TLSModeStartTLS    TLSMode = "starttls"
+	TLSModeImplicitTLS TLSMode = "implicit_tls"
+)
+
+type Config struct {
+	Host      string  `json:"host"`
+	Port      int     `json:"port"`
+	TLSMode   TLSMode `json:"tls_mode"`
+	AuthMode  string  `json:"auth_mode,omitempty"`
+	Username  string  `json:"username,omitempty"`
+	Password  string  `json:"password,omitempty"`
+	FromEmail string  `json:"from_email"`
+	FromName  string  `json:"from_name,omitempty"`
+}
+
+func (c Config) Validate() error {
+	if strings.TrimSpace(c.Host) == "" {
+		return fmt.Errorf("missing SMTP host")
+	}
+	if c.Port <= 0 || c.Port > 65535 {
+		return fmt.Errorf("invalid SMTP port")
+	}
+	switch c.TLSMode {
+	case TLSModeNone, TLSModeStartTLS, TLSModeImplicitTLS:
+	case "":
+		return fmt.Errorf("missing SMTP tls_mode")
+	default:
+		return fmt.Errorf("invalid SMTP tls_mode %q", c.TLSMode)
+	}
+	if strings.TrimSpace(c.FromEmail) == "" {
+		return fmt.Errorf("missing SMTP from_email")
+	}
+	if c.AuthMode != "" && c.AuthMode != "plain" && c.AuthMode != "login" {
+		return fmt.Errorf("invalid SMTP auth_mode %q", c.AuthMode)
+	}
+	if (c.Username == "") != (c.Password == "") {
+		return fmt.Errorf("smtp username and password must be provided together")
+	}
+	return nil
+}
+
+func NewAdapterFromConfig(cfg Config) (*Adapter, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &Adapter{cfg: cfg}, nil
+}
+```
+
+Change the adapter struct and legacy constructor:
+
+```go
+type Adapter struct {
+	cfg Config
+}
+
+func NewAdapter(host string, port int) *Adapter {
+	return &Adapter{cfg: Config{Host: host, Port: port, TLSMode: TLSModeNone}}
+}
+```
+
+Add imports:
+
+```go
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strconv"
+	"strings"
+	"time"
+)
+```
+
+- [ ] **Step 4: Implement send paths**
+
+Replace the body of `Send` and add helpers in `internal/adapter/smtp/adapter.go`:
+
+```go
+func (a *Adapter) Send(ctx context.Context, msg *port.OutgoingEmail) (string, error) {
+	rawMsg, err := sendamime.BuildRawMessage(msg)
+	if err != nil {
+		return "", fmt.Errorf("smtp: build message: %w", err)
+	}
+
+	addr := net.JoinHostPort(a.cfg.Host, strconv.Itoa(a.cfg.Port))
+	recipients := allRecipients(msg)
+	auth := a.auth()
+
+	switch a.cfg.TLSMode {
+	case TLSModeImplicitTLS:
+		err = a.sendImplicitTLS(ctx, addr, auth, msg.From.Address, recipients, rawMsg)
+	default:
+		err = smtp.SendMail(addr, auth, msg.From.Address, recipients, rawMsg)
+	}
+	if err != nil {
+		return "", fmt.Errorf("smtp: send: %w", err)
+	}
+
+	return fmt.Sprintf("<trk-%s@senda>", msg.TrackingID), nil
+}
+
+func (a *Adapter) auth() smtp.Auth {
+	if a.cfg.Username == "" && a.cfg.Password == "" {
+		return nil
+	}
+	if a.cfg.AuthMode == "login" {
+		return loginAuth{username: a.cfg.Username, password: a.cfg.Password}
+	}
+	return smtp.PlainAuth("", a.cfg.Username, a.cfg.Password, a.cfg.Host)
+}
+
+type loginAuth struct {
+	username string
+	password string
+}
+
+func (a loginAuth) Start(_ *smtp.ServerInfo) (string, []byte, error) {
+	return "LOGIN", []byte(a.username), nil
+}
+
+func (a loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
+	if !more {
+		return nil, nil
+	}
+	prompt := strings.ToLower(string(fromServer))
+	if strings.Contains(prompt, "password") {
+		return []byte(a.password), nil
+	}
+	return []byte(a.username), nil
+}
+
+func (a *Adapter) sendImplicitTLS(ctx context.Context, addr string, auth smtp.Auth, from string, to []string, rawMsg []byte) error {
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	conn, err := tls.DialWithDialer(dialer, "tcp", addr, &tls.Config{ServerName: a.cfg.Host, MinVersion: tls.VersionTLS12})
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	client, err := smtp.NewClient(conn, a.cfg.Host)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	return sendWithClient(client, auth, from, to, rawMsg)
+}
+
+func sendWithClient(client *smtp.Client, auth smtp.Auth, from string, to []string, rawMsg []byte) error {
+	if auth != nil {
+		if err := client.Auth(auth); err != nil {
+			return err
+		}
+	}
+	if err := client.Mail(from); err != nil {
+		return err
+	}
+	for _, addr := range to {
+		if err := client.Rcpt(addr); err != nil {
+			return err
+		}
+	}
+	w, err := client.Data()
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(rawMsg); err != nil {
+		_ = w.Close()
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	return client.Quit()
+}
+```
+
+Update `HealthCheck` to use `a.cfg.Host` and `a.cfg.Port`.
+
+- [ ] **Step 5: Run SMTP package tests**
+
+Run:
+
+```bash
+go test ./internal/adapter/smtp -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/adapter/smtp/adapter.go internal/adapter/smtp/adapter_test.go
+git commit -m "feat: support smtp auth and tls modes"
+```
+
+### Task 3: Add SMTP to Sender Factory
+
+**Files:**
+- Modify: `internal/adapter/river/send_worker.go`
+- Modify: `internal/adapter/river/send_worker_test.go`
+
+- [ ] **Step 1: Add failing factory test**
+
+Add this test to `internal/adapter/river/send_worker_test.go`:
+
+```go
+func TestDefaultAdapterSenderFactory_SMTP(t *testing.T) {
+	adapter := &domain.Adapter{AdapterType: domain.AdapterTypeSMTP}
+	cfg := []byte(`{"host":"localhost","port":1025,"tls_mode":"none","from_email":"no-reply@example.com"}`)
+
+	sender, err := DefaultAdapterSenderFactory(context.Background(), adapter, cfg)
+	if err != nil {
+		t.Fatalf("DefaultAdapterSenderFactory() SMTP error = %v", err)
+	}
+	if sender.Name() != "smtp" {
+		t.Fatalf("sender.Name() = %q, want smtp", sender.Name())
+	}
+}
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+go test ./internal/adapter/river -run TestDefaultAdapterSenderFactory_SMTP -count=1
+```
+
+Expected: FAIL with unsupported adapter type.
+
+- [ ] **Step 3: Add SMTP factory branch**
+
+Update imports in `internal/adapter/river/send_worker.go`:
+
+```go
+smtpadapter "github.com/rendis/senda/internal/adapter/smtp"
+```
+
+Add this case:
+
+```go
+case domain.AdapterTypeSMTP:
+	var cfg smtpadapter.Config
+	if err := json.Unmarshal(decryptedConfig, &cfg); err != nil {
+		return nil, fmt.Errorf("%w: unmarshal SMTP config: %w", domain.ErrValidation, err)
+	}
+	return smtpadapter.NewAdapterFromConfig(cfg)
+```
+
+- [ ] **Step 4: Run factory test**
+
+Run:
+
+```bash
+go test ./internal/adapter/river -run TestDefaultAdapterSenderFactory_SMTP -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/adapter/river/send_worker.go internal/adapter/river/send_worker_test.go
+git commit -m "feat: build smtp senders from adapter config"
+```
+
+### Task 4: Validate SMTP Config in Adapter Handler
+
+**Files:**
+- Modify: `internal/http/handler/adapter.go`
+- Modify: `internal/http/handler/adapter_test.go`
+
+- [ ] **Step 1: Add failing create validation test**
+
+Add this test to `internal/http/handler/adapter_test.go` near the create validation tests:
+
+```go
+func TestAdapterHandler_Create_SMTPValidatesAndStoresSafeMeta(t *testing.T) {
+	h, deps := setupAdapterHandlerTest(t)
+
+	body := `{
+		"name":"SMTP Relay",
+		"adapter_type":"smtp",
+		"config":{
+			"host":"smtp.example.com",
+			"port":587,
+			"tls_mode":"starttls",
+			"auth_mode":"plain",
+			"username":"apikey",
+			"password":"secret",
+			"from_email":"no-reply@example.com",
+			"from_name":"Senda"
+		},
+		"rate_limit_per_second":10
+	}`
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/adapters", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c := deps.echo.NewContext(req, rec)
+	deps.withWorkspace(c)
+
+	if err := h.Create(&c); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if deps.adapterStore.created.AdapterType != domain.AdapterTypeSMTP {
+		t.Fatalf("adapter type = %q, want smtp", deps.adapterStore.created.AdapterType)
+	}
+	if deps.adapterStore.created.ConfigMeta["host"] != "smtp.example.com" {
+		t.Fatalf("host meta = %q", deps.adapterStore.created.ConfigMeta["host"])
+	}
+	if _, leaked := deps.adapterStore.created.ConfigMeta["password"]; leaked {
+		t.Fatal("password must not be stored in config_meta")
+	}
+}
+```
+
+- [ ] **Step 2: Run the failing handler test**
+
+Run:
+
+```bash
+go test ./internal/http/handler -run TestAdapterHandler_Create_SMTPValidatesAndStoresSafeMeta -count=1
+```
+
+Expected: FAIL because `smtp` is invalid.
+
+- [ ] **Step 3: Import SMTP config and update validation**
+
+Add import:
+
+```go
+smtpadapter "github.com/rendis/senda/internal/adapter/smtp"
+```
+
+Update `isValidAdapterType`:
+
+```go
+case domain.AdapterTypeSES, domain.AdapterTypeGmail, domain.AdapterTypeSMTP:
+	return true
+```
+
+Update `validateConfig`:
+
+```go
+case domain.AdapterTypeSMTP:
+	var cfg smtpadapter.Config
+	if err := json.Unmarshal(config, &cfg); err != nil {
+		errs = append(errs, response.FieldError{Field: "config", Message: "must be a valid SMTP config object"})
+		break
+	}
+	if err := cfg.Validate(); err != nil {
+		errs = append(errs, response.FieldError{Field: "config", Message: err.Error()})
+	}
+```
+
+Update `extractPublicConfigFields`:
+
+```go
+case domain.AdapterTypeSMTP:
+	if v, ok := cfgMap["host"].(string); ok && v != "" {
+		meta["host"] = v
+	}
+	if v, ok := cfgMap["tls_mode"].(string); ok && v != "" {
+		meta["tls_mode"] = v
+	}
+	if v, ok := cfgMap["from_email"].(string); ok && v != "" {
+		meta["from_email"] = v
+	}
+	switch v := cfgMap["port"].(type) {
+	case float64:
+		meta["port"] = strconv.Itoa(int(v))
+	case string:
+		if v != "" {
+			meta["port"] = v
+		}
+	}
+```
+
+Add `strconv` import if not already present.
+
+- [ ] **Step 4: Run handler test**
+
+Run:
+
+```bash
+go test ./internal/http/handler -run TestAdapterHandler_Create_SMTPValidatesAndStoresSafeMeta -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/http/handler/adapter.go internal/http/handler/adapter_test.go
+git commit -m "feat: validate smtp adapter config"
+```
+
+### Task 5: Preserve SMTP Password on Update
+
+**Files:**
+- Modify: `internal/http/handler/adapter.go`
+- Modify: `internal/http/handler/adapter_test.go`
+
+- [ ] **Step 1: Add failing update test**
+
+Add this test to `internal/http/handler/adapter_test.go`:
+
+```go
+func TestAdapterHandler_Update_SMTPKeepsPasswordWhenBlank(t *testing.T) {
+	h, deps := setupAdapterHandlerTest(t)
+	adapterID := uuid.Must(uuid.NewV7())
+	deps.crypto.decryptFn = func(_ []byte) ([]byte, error) {
+		return []byte(`{"host":"smtp.example.com","port":587,"tls_mode":"starttls","auth_mode":"plain","username":"apikey","password":"old-secret","from_email":"old@example.com"}`), nil
+	}
+	deps.adapterStore.adapter = &domain.Adapter{
+		ID:              adapterID,
+		WorkspaceID:     &deps.workspace.ID,
+		Name:            "SMTP Relay",
+		AdapterType:     domain.AdapterTypeSMTP,
+		ConfigEncrypted: []byte("encrypted"),
+	}
+
+	body := `{"config":{"host":"smtp.example.com","port":587,"tls_mode":"starttls","auth_mode":"plain","username":"apikey","password":"","from_email":"new@example.com"}}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/adapters/"+adapterID.String(), strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c := deps.echo.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(adapterID.String())
+	deps.withWorkspace(c)
+
+	if err := h.Update(&c); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	var encryptedConfig map[string]any
+	if err := json.Unmarshal(deps.crypto.lastPlaintext, &encryptedConfig); err != nil {
+		t.Fatalf("updated config JSON error = %v", err)
+	}
+	if encryptedConfig["password"] != "old-secret" {
+		t.Fatalf("password = %v, want old-secret", encryptedConfig["password"])
+	}
+}
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+go test ./internal/http/handler -run TestAdapterHandler_Update_SMTPKeepsPasswordWhenBlank -count=1
+```
+
+Expected: FAIL because update replaces the password with an empty string.
+
+- [ ] **Step 3: Add SMTP password merge helper**
+
+Add this helper in `internal/http/handler/adapter.go`:
+
+```go
+func mergeSMTPPassword(existingRaw []byte, updated json.RawMessage) (json.RawMessage, error) {
+	var updatedMap map[string]any
+	if err := json.Unmarshal(updated, &updatedMap); err != nil {
+		return nil, err
+	}
+	if password, ok := updatedMap["password"].(string); ok && password != "" {
+		return updated, nil
+	}
+	var existingMap map[string]any
+	if err := json.Unmarshal(existingRaw, &existingMap); err != nil {
+		return nil, err
+	}
+	if password, ok := existingMap["password"].(string); ok && password != "" {
+		updatedMap["password"] = password
+	}
+	merged, err := json.Marshal(updatedMap)
+	if err != nil {
+		return nil, err
+	}
+	return merged, nil
+}
+```
+
+In the update path, after decrypting existing config and before validation/encryption, apply:
+
+```go
+updated := *req.Config
+if adapter.AdapterType == domain.AdapterTypeSMTP {
+	merged, err := mergeSMTPPassword(decrypted, updated)
+	if err != nil {
+		return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "invalid SMTP config")
+	}
+	updated = merged
+}
+```
+
+- [ ] **Step 4: Run the update test**
+
+Run:
+
+```bash
+go test ./internal/http/handler -run TestAdapterHandler_Update_SMTPKeepsPasswordWhenBlank -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/http/handler/adapter.go internal/http/handler/adapter_test.go
+git commit -m "feat: preserve smtp password on update"
+```
+
+### Task 6: Resolve SMTP From Address and Manual Identity
+
+**Files:**
+- Modify: `internal/resolution/from_resolver.go`
+- Modify: `internal/service/from_email.go`
+- Modify: `internal/service/identity.go`
+- Modify: `internal/http/handler/adapter.go`
+- Test: `internal/service/test_send_test.go`
+- Test: `internal/service/identity_factory_test.go` or `internal/service/identity_test.go`
+
+- [ ] **Step 1: Add failing SMTP fallback test**
+
+Add this test to `internal/service/test_send_test.go`:
+
+```go
+func TestTestSendService_FallsBackToSMTPFromEmailWhenNoDefaultIdentity(t *testing.T) {
+	f := newTestSendFixture(t)
+	f.adapter.AdapterType = domain.AdapterTypeSMTP
+	f.adapter.ConfigEncrypted = []byte(`{"host":"localhost","port":1025,"tls_mode":"none","from_email":"smtp@example.com","from_name":"SMTP"}`)
+	f.crypto.decryptFn = func(_ []byte) ([]byte, error) {
+		return f.adapter.ConfigEncrypted, nil
+	}
+	f.identityStore.getDefaultFn = func(_ context.Context, _ uuid.UUID) (*domain.AdapterIdentity, error) {
+		return nil, domain.ErrNoDefaultIdentity
+	}
+
+	result, err := f.service.Send(context.Background(), &service.TestSendRequest{
+		TemplateID: f.template.ID,
+		To:         "recipient@example.com",
+	})
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if result.FromAddress != "smtp@example.com" {
+		t.Fatalf("FromAddress = %q, want smtp@example.com", result.FromAddress)
+	}
+}
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+go test ./internal/service -run TestTestSendService_FallsBackToSMTPFromEmailWhenNoDefaultIdentity -count=1
+```
+
+Expected: FAIL because `ResolveFromAddress` only knows `delegate_email`.
+
+- [ ] **Step 3: Add SMTP from fallback**
+
+Update `internal/resolution/from_resolver.go` comments and logic:
+
+```go
+// ResolveFromAddress determines the sender email address for an adapter by trying:
+// 1. The default identity from the identity store.
+// 2. SMTP from_email from config_meta.
+// 3. Gmail delegate_email from config_meta.
+// 4. SMTP from_email or Gmail delegate_email from decrypted config JSON.
+```
+
+Add before delegate lookup:
+
+```go
+if fromEmail := adapter.ConfigMeta["from_email"]; fromEmail != "" {
+	from.Address = fromEmail
+	return from
+}
+```
+
+In decrypted fallback, add:
+
+```go
+if smtpFrom, ok := cfgMap["from_email"].(string); ok && smtpFrom != "" {
+	from.Address = smtpFrom
+	if name, ok := cfgMap["from_name"].(string); ok && name != "" {
+		from.Name = name
+	}
+	return from
+}
+```
+
+Update `resolveFromEmail` in `internal/service/from_email.go` so SMTP can use the config fallback when called from real send. Change signature to:
+
+```go
+func resolveFromEmail(identityStore port.AdapterIdentityStore, ctx context.Context, adapter *domain.Adapter, decryptedConfig []byte, senderIdentityID *uuid.UUID) (string, error)
+```
+
+When no explicit identity is set and default identity lookup fails:
+
+```go
+from := resolution.ResolveFromAddress(ctx, identityStore, adapter, decryptedConfig)
+if from.Address != "" {
+	return from.Address, nil
+}
+return "", fmt.Errorf("%w: adapter %s", domain.ErrNoDefaultIdentity, adapter.ID)
+```
+
+Update callers in `internal/service/send.go` and `internal/service/send_context.go` to pass decrypted config from the resolved adapter path if available. If the prepared send path does not have decrypted config, decrypt it before resolving from.
+
+- [ ] **Step 4: Allow SMTP manual identity without provider domain**
+
+In `internal/service/identity.go`, load the adapter at the beginning of `CreateManual`:
+
+```go
+adapter, err := s.adapterStore.GetByID(ctx, adapterID)
+if err != nil {
+	return nil, err
+}
+```
+
+Wrap the domain-verified check:
+
+```go
+if adapter.AdapterType != domain.AdapterTypeSMTP {
+	existing, err := s.identityStore.ListByAdapter(ctx, adapterID)
+	if err != nil {
+		return nil, err
+	}
+	domainVerified := false
+	for _, ident := range existing {
+		if ident.IdentityType == domain.IdentityTypeDomain &&
+			ident.Identity == emailDomain &&
+			ident.Status == domain.IdentityStatusVerified {
+			domainVerified = true
+			break
+		}
+	}
+	if !domainVerified {
+		return nil, fmt.Errorf("%w: domain %s is not verified in this adapter", domain.ErrIdentityNotInDomain, emailDomain)
+	}
+}
+```
+
+- [ ] **Step 5: Seed SMTP default identity on create/update**
+
+In `internal/http/handler/adapter.go`, add helper:
+
+```go
+func smtpIdentityFromConfig(raw []byte) (identity string, displayName *string, ok bool) {
+	var cfg smtpadapter.Config
+	if err := json.Unmarshal(raw, &cfg); err != nil || cfg.FromEmail == "" {
+		return "", nil, false
+	}
+	if cfg.FromName != "" {
+		name := cfg.FromName
+		displayName = &name
+	}
+	return cfg.FromEmail, displayName, true
+}
+```
+
+After successful create/update for SMTP, call `IdentityService.CreateManual` or a new small service helper that upserts the default SMTP identity. If the existing identity already exists, set it default through the store rather than creating a duplicate.
+
+- [ ] **Step 6: Run service and handler tests**
+
+Run:
+
+```bash
+go test ./internal/service -run 'TestTestSendService_FallsBackToSMTPFromEmail|TestIdentityService' -count=1
+go test ./internal/http/handler -run 'TestAdapterHandler_Create_SMTP|TestAdapterHandler_Update_SMTP' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/resolution/from_resolver.go internal/service/from_email.go internal/service/identity.go internal/http/handler/adapter.go internal/service/test_send_test.go internal/http/handler/adapter_test.go
+git commit -m "feat: resolve smtp sender identities"
+```
+
+### Task 7: Backend Contract Docs and Verification
+
+**Files:**
+- Modify: `docs/API.md`
+- Modify: `docs/DEPLOYMENT.md`
+- Modify: `docs/EMAIL_FLOWS.md`
+- Modify: `docs/postman/senda-api-v1.postman_collection.json`
+
+- [ ] **Step 1: Update docs with SMTP contract**
+
+Add the contract JSON from this plan to the Adapters section in `docs/API.md` and the SMTP section in `docs/DEPLOYMENT.md`.
+
+- [ ] **Step 2: Update Postman adapter type text**
+
+Replace “Adapter types: ses, gmail” with “Adapter types: ses, gmail, smtp” in `docs/postman/senda-api-v1.postman_collection.json`.
+
+- [ ] **Step 3: Run backend gate**
+
+Run:
+
+```bash
+make lint
+make vet
+make test
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/API.md docs/DEPLOYMENT.md docs/EMAIL_FLOWS.md docs/postman/senda-api-v1.postman_collection.json
+git commit -m "docs: document smtp adapter contract"
+```
+
+---
+
+## Issue 2: Frontend Adapters Module
+
+### Task 8: Add SMTP Types
+
+**Files:**
+- Modify: `web/src/types/adapters.ts`
+- Test: use TypeScript typecheck.
+
+- [ ] **Step 1: Update adapter types**
+
+Change `web/src/types/adapters.ts`:
+
+```ts
+export type AdapterType = "ses" | "gmail" | "smtp";
+export type SmtpTLSMode = "none" | "starttls" | "implicit_tls";
+```
+
+Add:
+
+```ts
+export interface SmtpConfig {
+  host: string;
+  port: number;
+  tls_mode: SmtpTLSMode;
+  auth_mode?: "plain" | "login";
+  username?: string;
+  password?: string;
+  from_email: string;
+  from_name?: string;
+}
+```
+
+Update request unions:
+
+```ts
+config: SesConfig | GmailConfig | SmtpConfig;
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+corepack pnpm --dir web typecheck
+```
+
+Expected: TypeScript fails in components that assume only SES/Gmail.
+
+- [ ] **Step 3: Commit after fixing only type definitions if typecheck still passes**
+
+If typecheck passes after the type-only change:
+
+```bash
+git add web/src/types/adapters.ts
+git commit -m "feat: add smtp adapter frontend types"
+```
+
+If it fails, continue to Task 9 and commit both tasks together.
+
+### Task 9: Add SMTP Fields to Adapter Form
+
+**Files:**
+- Modify: `web/src/components/adapters/adapter-form.tsx`
+
+- [ ] **Step 1: Add SMTP defaults**
+
+Update `ADAPTER_DEFAULTS`:
+
+```ts
+smtp: {
+  rateLimit: 10,
+  description: "SMTP relay rate limits depend on your provider or internal relay policy.",
+},
+```
+
+- [ ] **Step 2: Add SMTP state**
+
+Add state near SES/Gmail state:
+
+```tsx
+const [smtpHost, setSmtpHost] = useState(defaults?.config_meta?.host ?? "");
+const [smtpPort, setSmtpPort] = useState(defaults?.config_meta?.port ?? "587");
+const [smtpTLSMode, setSmtpTLSMode] = useState<"none" | "starttls" | "implicit_tls">(
+  (defaults?.config_meta?.tls_mode as "none" | "starttls" | "implicit_tls" | undefined) ?? "starttls"
+);
+const [smtpAuthMode, setSmtpAuthMode] = useState<"plain" | "login">("plain");
+const [smtpUsername, setSmtpUsername] = useState("");
+const [smtpPassword, setSmtpPassword] = useState("");
+const [smtpFromEmail, setSmtpFromEmail] = useState(defaults?.config_meta?.from_email ?? "");
+const [smtpFromName, setSmtpFromName] = useState("");
+```
+
+- [ ] **Step 3: Include SMTP in type selector**
+
+Add:
+
+```tsx
+<SelectItem value="smtp">SMTP</SelectItem>
+```
+
+- [ ] **Step 4: Add SMTP payload construction**
+
+In submit construction, build SMTP config:
+
+```ts
+const config =
+  adapterType === "ses"
+    ? { region: sesRegion, access_key_id: sesAccessKey, secret_access_key: sesSecretKey }
+    : adapterType === "gmail"
+      ? { service_account_json: gmailServiceAccountJSON, delegate_email: gmailDelegateEmail }
+      : {
+          host: smtpHost,
+          port: Number(smtpPort),
+          tls_mode: smtpTLSMode,
+          ...(smtpUsername || smtpPassword ? { auth_mode: smtpAuthMode } : {}),
+          ...(smtpUsername ? { username: smtpUsername } : {}),
+          ...(smtpPassword ? { password: smtpPassword } : {}),
+          from_email: smtpFromEmail,
+          ...(smtpFromName ? { from_name: smtpFromName } : {}),
+        };
+```
+
+- [ ] **Step 5: Render SMTP fields**
+
+Refactor the config section to branch `ses`, `gmail`, `smtp`. Add this SMTP block:
+
+```tsx
+{adapterType === "smtp" && (
+  <div className="flex flex-col gap-3">
+    <div className="grid grid-cols-2 gap-3">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="smtp-host">Host</Label>
+        <Input id="smtp-host" value={smtpHost} onChange={(e) => setSmtpHost(e.target.value)} placeholder="smtp.example.com" className="font-mono" required={!isEdit} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="smtp-port">Port</Label>
+        <Input id="smtp-port" type="number" value={smtpPort} onChange={(e) => setSmtpPort(e.target.value)} placeholder="587" className="font-mono" required={!isEdit} />
+      </div>
+    </div>
+    <div className="flex flex-col gap-2">
+      <Label>Auth Mode</Label>
+      <Select value={smtpAuthMode} onValueChange={(v) => setSmtpAuthMode(v as "plain" | "login")}>
+        <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+        <SelectContent>
+          <SelectItem value="plain">PLAIN</SelectItem>
+          <SelectItem value="login">LOGIN</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+    <div className="flex flex-col gap-2">
+      <Label>TLS Mode</Label>
+      <Select value={smtpTLSMode} onValueChange={(v) => setSmtpTLSMode(v as "none" | "starttls" | "implicit_tls")}>
+        <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+        <SelectContent>
+          <SelectItem value="starttls">STARTTLS</SelectItem>
+          <SelectItem value="implicit_tls">Implicit TLS</SelectItem>
+          <SelectItem value="none">None</SelectItem>
+        </SelectContent>
+      </Select>
+      {smtpTLSMode === "none" && (
+        <p className="text-xs text-amber-400">Plain SMTP sends without transport encryption. Use only for Mailpit, local testing, or trusted internal relays.</p>
+      )}
+    </div>
+    <div className="grid grid-cols-2 gap-3">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="smtp-username">Username</Label>
+        <Input id="smtp-username" value={smtpUsername} onChange={(e) => setSmtpUsername(e.target.value)} placeholder="user or API key" className="font-mono" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="smtp-password">Password</Label>
+        <Input id="smtp-password" type="password" value={smtpPassword} onChange={(e) => setSmtpPassword(e.target.value)} placeholder={isEdit ? "Leave empty to keep current" : "secret"} className="font-mono" />
+      </div>
+    </div>
+    <div className="grid grid-cols-2 gap-3">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="smtp-from-email">From Email</Label>
+        <Input id="smtp-from-email" type="email" value={smtpFromEmail} onChange={(e) => setSmtpFromEmail(e.target.value)} placeholder="no-reply@example.com" className="font-mono" required={!isEdit} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="smtp-from-name">From Name</Label>
+        <Input id="smtp-from-name" value={smtpFromName} onChange={(e) => setSmtpFromName(e.target.value)} placeholder="Senda" />
+      </div>
+    </div>
+  </div>
+)}
+```
+
+- [ ] **Step 6: Run frontend typecheck**
+
+Run:
+
+```bash
+corepack pnpm --dir web typecheck
+```
+
+Expected: PASS after fixing branch exhaustiveness and submit readiness.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/types/adapters.ts web/src/components/adapters/adapter-form.tsx
+git commit -m "feat: add smtp adapter form"
+```
+
+### Task 10: Add SMTP Badge and Action Rules
+
+**Files:**
+- Modify: `web/src/components/adapters/adapter-type-badge.tsx`
+- Modify: `web/src/components/adapters/adapters-content.tsx`
+
+- [ ] **Step 1: Add SMTP badge**
+
+In `adapter-type-badge.tsx`, add an SMTP icon:
+
+```tsx
+function SmtpIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
+      <path d="M2 4h10v6H2z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+      <path d="M4 2h6M4 12h6M7 2v2M7 10v2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+```
+
+Add config:
+
+```tsx
+smtp: {
+  label: "SMTP",
+  textColor: "text-cyan-300",
+  bgColor: "bg-cyan-500/10",
+  icon: <SmtpIcon className="h-3.5 w-3.5" />,
+},
+```
+
+- [ ] **Step 2: Hide provider-only actions for SMTP**
+
+In `adapters-content.tsx`, ensure checks are explicit:
+
+```ts
+const supportsIdentitySync = adapter.adapter_type === "ses" || adapter.adapter_type === "gmail";
+const supportsProvisioning = adapter.adapter_type === "ses";
+const supportsSenderSharing = adapter.adapter_type === "ses";
+const supportsAdapterSharing = adapter.adapter_type === "gmail";
+```
+
+Use these booleans to render sync/provisioning/sharing actions. Do not render SES/Gmail actions for SMTP.
+
+- [ ] **Step 3: Test send from SMTP**
+
+Change test-send payload:
+
+```ts
+...(adapter.adapter_type === "ses" && from ? { from } : {}),
+```
+
+Keep this SES-only unless backend later supports choosing SMTP identities manually in the test dialog. SMTP should use the backend default `from_email`.
+
+- [ ] **Step 4: Run frontend checks**
+
+Run:
+
+```bash
+corepack pnpm --dir web typecheck
+corepack pnpm --dir web lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/adapters/adapter-type-badge.tsx web/src/components/adapters/adapters-content.tsx
+git commit -m "feat: show smtp adapters in ui"
+```
+
+### Task 11: Frontend Verification in Browser
+
+**Files:**
+- No source files unless visual QA finds issues.
+
+- [ ] **Step 1: Start local app if it is not already running**
+
+Run:
+
+```bash
+make dev
+```
+
+Expected: frontend available at `http://localhost:3000`.
+
+- [ ] **Step 2: Open Adapters page**
+
+Use the in-app browser to navigate to the tenant/workspace Adapters route for the local seeded workspace.
+
+Expected: existing adapters list renders.
+
+- [ ] **Step 3: Create SMTP authenticated plain adapter**
+
+Use the UI:
+
+```text
+Type: SMTP
+Name: Postal SMTP
+Host: 127.0.0.1
+Port: 2525
+TLS Mode: None
+Auth Mode: PLAIN or LOGIN
+Username: use the relay username provided by the user
+Password: use the relay password provided by the user
+From Email: noreply-senda@tether.education
+Rate Limit: 10
+```
+
+Expected: create succeeds and table shows SMTP badge.
+
+- [ ] **Step 4: Send test email**
+
+Use Test Send with:
+
+```text
+Recipient: reynaldo@tether.education
+Subject: SMTP UI test
+Body: <p>Hello from SMTP</p>
+```
+
+Expected: success toast. The user will validate whether the message arrives at `reynaldo@tether.education`.
+
+- [ ] **Step 5: Commit visual fixes if needed**
+
+If visual fixes are needed:
+
+```bash
+git add web/src/components/adapters
+git commit -m "fix: polish smtp adapter ui"
+```
+
+### Task 12: Final Gates
+
+**Files:**
+- All touched files.
+
+- [ ] **Step 1: Run backend gate**
+
+Run:
+
+```bash
+make lint
+make vet
+make test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend gate**
+
+Run:
+
+```bash
+corepack pnpm --dir web typecheck
+corepack pnpm --dir web lint
+```
+
+Expected: PASS. Node may warn if local Node is not the package engine version; warnings are acceptable when commands pass.
+
+- [ ] **Step 3: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff --check
+```
+
+Expected: no whitespace errors; diff only touches SMTP-related files and docs.
+
+- [ ] **Step 4: Final commit if any changes remain**
+
+```bash
+git status --short
+git add .
+git commit -m "feat: add smtp adapter support"
+```
+
+Skip the commit if all prior task commits already captured every change.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: backend contract, DB enum, sender runtime, handler validation, password preservation, identity fallback, UI form, badge, action gating, test send, docs, and gates are covered.
+- Placeholder scan: no unresolved placeholder markers are intentionally left. The one migration down file is intentionally irreversible because PostgreSQL enum value removal is unsafe after application.
+- Type consistency: canonical names are `AdapterTypeSMTP`, `smtp`, `SmtpConfig`, `tls_mode`, `from_email`, and `implicit_tls`.

--- a/docs/superpowers/plans/2026-04-29-smtp-adapter.md
+++ b/docs/superpowers/plans/2026-04-29-smtp-adapter.md
@@ -992,7 +992,7 @@ git commit -m "docs: document smtp adapter contract"
 - Modify: `web/src/types/adapters.ts`
 - Test: use TypeScript typecheck.
 
-- [ ] **Step 1: Update adapter types**
+- [x] **Step 1: Update adapter types**
 
 Change `web/src/types/adapters.ts`:
 
@@ -1020,7 +1020,7 @@ Update request unions:
 config: SesConfig | GmailConfig | SmtpConfig;
 ```
 
-- [ ] **Step 2: Run typecheck**
+- [x] **Step 2: Run typecheck**
 
 Run:
 
@@ -1030,7 +1030,7 @@ corepack pnpm --dir web typecheck
 
 Expected: TypeScript fails in components that assume only SES/Gmail.
 
-- [ ] **Step 3: Commit after fixing only type definitions if typecheck still passes**
+- [x] **Step 3: Commit after fixing only type definitions if typecheck still passes**
 
 If typecheck passes after the type-only change:
 
@@ -1046,7 +1046,7 @@ If it fails, continue to Task 9 and commit both tasks together.
 **Files:**
 - Modify: `web/src/components/adapters/adapter-form.tsx`
 
-- [ ] **Step 1: Add SMTP defaults**
+- [x] **Step 1: Add SMTP defaults**
 
 Update `ADAPTER_DEFAULTS`:
 
@@ -1057,7 +1057,7 @@ smtp: {
 },
 ```
 
-- [ ] **Step 2: Add SMTP state**
+- [x] **Step 2: Add SMTP state**
 
 Add state near SES/Gmail state:
 
@@ -1072,7 +1072,7 @@ const [smtpUsername, setSmtpUsername] = useState("");
 const [smtpPassword, setSmtpPassword] = useState("");
 ```
 
-- [ ] **Step 3: Include SMTP in type selector**
+- [x] **Step 3: Include SMTP in type selector**
 
 Add:
 
@@ -1080,7 +1080,7 @@ Add:
 <SelectItem value="smtp">SMTP</SelectItem>
 ```
 
-- [ ] **Step 4: Add SMTP payload construction**
+- [x] **Step 4: Add SMTP payload construction**
 
 In submit construction, build SMTP config:
 
@@ -1100,7 +1100,7 @@ const config =
         };
 ```
 
-- [ ] **Step 5: Render SMTP fields**
+- [x] **Step 5: Render SMTP fields**
 
 Refactor the config section to branch `ses`, `gmail`, `smtp`. Add this SMTP block:
 
@@ -1155,7 +1155,7 @@ Refactor the config section to branch `ses`, `gmail`, `smtp`. Add this SMTP bloc
 )}
 ```
 
-- [ ] **Step 6: Run frontend typecheck**
+- [x] **Step 6: Run frontend typecheck**
 
 Run:
 
@@ -1165,7 +1165,7 @@ corepack pnpm --dir web typecheck
 
 Expected: PASS after fixing branch exhaustiveness and submit readiness.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add web/src/types/adapters.ts web/src/components/adapters/adapter-form.tsx
@@ -1180,7 +1180,7 @@ git commit -m "feat: add smtp adapter form"
 - Modify: `web/src/components/adapters/identity-panel.tsx`
 - Modify: `web/src/components/templates/template-types-content.tsx`
 
-- [ ] **Step 1: Add SMTP badge**
+- [x] **Step 1: Add SMTP badge**
 
 In `adapter-type-badge.tsx`, add an SMTP icon:
 
@@ -1206,7 +1206,7 @@ smtp: {
 },
 ```
 
-- [ ] **Step 2: Hide provider-only actions for SMTP**
+- [x] **Step 2: Hide provider-only actions for SMTP**
 
 In `adapters-content.tsx`, ensure checks are explicit:
 
@@ -1219,7 +1219,7 @@ const supportsAdapterSharing = adapter.adapter_type === "gmail";
 
 Use these booleans to render sync/provisioning/sharing actions. SMTP should not render provider sync or SES provisioning, but it should render identity-level sender sharing for manual SMTP email identities.
 
-- [ ] **Step 3: Add full-email identity creation for SMTP**
+- [x] **Step 3: Add full-email identity creation for SMTP**
 
 In `web/src/components/adapters/identity-panel.tsx`, SMTP should not depend on provider domains. Add a simple full email form for editable SMTP adapters:
 
@@ -1259,7 +1259,7 @@ function ManualEmailAddInput({
 
 Render it for `adapter.adapter_type === "smtp"` and `adapter.is_editable`. Hide the provider sync button for SMTP and adjust empty copy to say SMTP sender emails are added manually.
 
-- [ ] **Step 4: Show sender identity selection for SMTP template types**
+- [x] **Step 4: Show sender identity selection for SMTP template types**
 
 In `web/src/components/templates/template-types-content.tsx`, update adapter identity logic:
 
@@ -1279,7 +1279,7 @@ if ((selectedAdapter?.adapter_type === "ses" || selectedAdapter?.adapter_type ==
 }
 ```
 
-- [ ] **Step 5: Test send from SMTP**
+- [x] **Step 5: Test send from SMTP**
 
 Change test-send payload:
 
@@ -1289,7 +1289,7 @@ Change test-send payload:
 
 The test dialog should show the same sender email picker for SMTP that it shows for SES, using manual verified email identities.
 
-- [ ] **Step 6: Run frontend checks**
+- [x] **Step 6: Run frontend checks**
 
 Run:
 
@@ -1300,7 +1300,7 @@ corepack pnpm --dir web lint
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add web/src/components/adapters/adapter-type-badge.tsx web/src/components/adapters/adapters-content.tsx web/src/components/adapters/identity-panel.tsx web/src/components/templates/template-types-content.tsx

--- a/internal/adapter/postgres/adapter_access_repo.go
+++ b/internal/adapter/postgres/adapter_access_repo.go
@@ -87,7 +87,7 @@ func (r *AdapterGrantRepo) HasAdapterWorkspaceGrant(ctx context.Context, adapter
 }
 
 // ListVisibleAdaptersForWorkspace returns workspace-owned adapters plus system-owned adapters
-// shared either through adapter grants (Gmail) or identity grants (SES).
+// shared either through adapter grants (Gmail) or identity grants (SES/SMTP).
 func (r *AdapterGrantRepo) ListVisibleAdaptersForWorkspace(ctx context.Context, workspaceID uuid.UUID, opts port.ListOptions) (*port.PageResult[domain.Adapter], error) {
 	limit, afterID, err := ApplyPagination(opts)
 	if err != nil {
@@ -128,7 +128,7 @@ SELECT DISTINCT a.id, a.workspace_id, a.name, a.adapter_type, a.config_encrypted
            )
        )
        OR (
-           a.adapter_type = 'ses'
+           a.adapter_type IN ('ses', 'smtp')
            AND EXISTS (
                SELECT 1
                  FROM adapter_identities ai

--- a/internal/adapter/postgres/adapter_access_repo_test.go
+++ b/internal/adapter/postgres/adapter_access_repo_test.go
@@ -60,7 +60,15 @@ func TestAdapterGrantRepo_ListVisibleAdaptersForWorkspace_IncludesOwnedAndShared
 		ConfigEncrypted:    []byte("ses"),
 		RateLimitPerSecond: 10,
 	}
-	for _, adapter := range []*domain.Adapter{ownedAdapter, sharedGmail, sharedSES} {
+	sharedSMTP := &domain.Adapter{
+		ID:                 uuid.New(),
+		WorkspaceID:        &systemWS.ID,
+		Name:               "System SMTP",
+		AdapterType:        domain.AdapterTypeSMTP,
+		ConfigEncrypted:    []byte("smtp"),
+		RateLimitPerSecond: 10,
+	}
+	for _, adapter := range []*domain.Adapter{ownedAdapter, sharedGmail, sharedSES, sharedSMTP} {
 		if err := adapterRepo.Create(ctx, adapter); err != nil {
 			t.Fatalf("create adapter %s: %v", adapter.Name, err)
 		}
@@ -80,6 +88,20 @@ func TestAdapterGrantRepo_ListVisibleAdaptersForWorkspace_IncludesOwnedAndShared
 	if err := identityRepo.Create(ctx, emailIdentity); err != nil {
 		t.Fatalf("create email identity: %v", err)
 	}
+	smtpIdentity := &domain.AdapterIdentity{
+		ID:             uuid.New(),
+		AdapterID:      sharedSMTP.ID,
+		Identity:       "smtp@example.dev",
+		IdentityType:   domain.IdentityTypeEmail,
+		Status:         domain.IdentityStatusVerified,
+		SendingEnabled: true,
+		Source:         domain.IdentitySourceManual,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+	if err := identityRepo.Create(ctx, smtpIdentity); err != nil {
+		t.Fatalf("create smtp identity: %v", err)
+	}
 
 	if err := grantRepo.ReplaceAdapterWorkspaceGrants(ctx, sharedGmail.ID, []uuid.UUID{workspace.ID}); err != nil {
 		t.Fatalf("grant gmail adapter: %v", err)
@@ -87,13 +109,16 @@ func TestAdapterGrantRepo_ListVisibleAdaptersForWorkspace_IncludesOwnedAndShared
 	if err := identityGrantRepo.ReplaceIdentityWorkspaceGrants(ctx, emailIdentity.ID, []uuid.UUID{workspace.ID}); err != nil {
 		t.Fatalf("grant ses identity: %v", err)
 	}
+	if err := identityGrantRepo.ReplaceIdentityWorkspaceGrants(ctx, smtpIdentity.ID, []uuid.UUID{workspace.ID}); err != nil {
+		t.Fatalf("grant smtp identity: %v", err)
+	}
 
 	page, err := grantRepo.ListVisibleAdaptersForWorkspace(ctx, workspace.ID, port.ListOptions{Limit: 10})
 	if err != nil {
 		t.Fatalf("ListVisibleAdaptersForWorkspace() error: %v", err)
 	}
-	if len(page.Items) != 3 {
-		t.Fatalf("expected 3 visible adapters, got %d", len(page.Items))
+	if len(page.Items) != 4 {
+		t.Fatalf("expected 4 visible adapters, got %d", len(page.Items))
 	}
 
 	names := make([]string, 0, len(page.Items))
@@ -101,7 +126,7 @@ func TestAdapterGrantRepo_ListVisibleAdaptersForWorkspace_IncludesOwnedAndShared
 		names = append(names, item.Name)
 	}
 	sort.Strings(names)
-	expected := []string{"Owned Gmail", "System Gmail", "System SES"}
+	expected := []string{"Owned Gmail", "System Gmail", "System SES", "System SMTP"}
 	for i := range expected {
 		if names[i] != expected[i] {
 			t.Fatalf("expected visible adapters %v, got %v", expected, names)

--- a/internal/adapter/postgres/adapter_repo_test.go
+++ b/internal/adapter/postgres/adapter_repo_test.go
@@ -56,14 +56,13 @@ func TestAdapterRepo_CreateAndGet_SMTP(t *testing.T) {
 		WorkspaceID:        &ws.ID,
 		Name:               "SMTP Relay",
 		AdapterType:        domain.AdapterTypeSMTP,
-		ConfigEncrypted:    []byte(`{"host":"localhost","port":1025,"tls_mode":"none","from_email":"no-reply@example.com"}`),
+		ConfigEncrypted:    []byte(`{"host":"localhost","port":1025,"tls_mode":"none"}`),
 		IsDefault:          false,
 		RateLimitPerSecond: 10,
 		ConfigMeta: map[string]string{
-			"host":       "localhost",
-			"port":       "1025",
-			"tls_mode":   "none",
-			"from_email": "no-reply@example.com",
+			"host":     "localhost",
+			"port":     "1025",
+			"tls_mode": "none",
 		},
 	}
 

--- a/internal/adapter/postgres/adapter_repo_test.go
+++ b/internal/adapter/postgres/adapter_repo_test.go
@@ -43,6 +43,46 @@ func TestAdapterRepo_Create(t *testing.T) {
 	}
 }
 
+func TestAdapterRepo_CreateAndGet_SMTP(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	repo := pgadapter.NewAdapterRepo(pool)
+	tenantRepo := pgadapter.NewTenantRepo(pool)
+	wsRepo := pgadapter.NewWorkspaceRepo(pool)
+	ws := createTestWorkspaceWith(ctx, t, tenantRepo, wsRepo)
+
+	adapter := &domain.Adapter{
+		ID:                 uuid.Must(uuid.NewV7()),
+		WorkspaceID:        &ws.ID,
+		Name:               "SMTP Relay",
+		AdapterType:        domain.AdapterTypeSMTP,
+		ConfigEncrypted:    []byte(`{"host":"localhost","port":1025,"tls_mode":"none","from_email":"no-reply@example.com"}`),
+		IsDefault:          false,
+		RateLimitPerSecond: 10,
+		ConfigMeta: map[string]string{
+			"host":       "localhost",
+			"port":       "1025",
+			"tls_mode":   "none",
+			"from_email": "no-reply@example.com",
+		},
+	}
+
+	if err := repo.Create(ctx, adapter); err != nil {
+		t.Fatalf("Create() SMTP error = %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, adapter.ID)
+	if err != nil {
+		t.Fatalf("GetByID() SMTP error = %v", err)
+	}
+	if got.AdapterType != domain.AdapterTypeSMTP {
+		t.Fatalf("AdapterType = %q, want %q", got.AdapterType, domain.AdapterTypeSMTP)
+	}
+	if got.ConfigMeta["tls_mode"] != "none" {
+		t.Fatalf("ConfigMeta[tls_mode] = %q, want none", got.ConfigMeta["tls_mode"])
+	}
+}
+
 func TestAdapterRepo_Create_Global(t *testing.T) {
 	ctx := context.Background()
 	pool := setupTestDB(ctx, t)

--- a/internal/adapter/river/send_worker.go
+++ b/internal/adapter/river/send_worker.go
@@ -15,6 +15,7 @@ import (
 
 	gmailadapter "github.com/rendis/senda/internal/adapter/gmail"
 	sesadapter "github.com/rendis/senda/internal/adapter/ses"
+	smtpadapter "github.com/rendis/senda/internal/adapter/smtp"
 	"github.com/rendis/senda/internal/domain"
 	"github.com/rendis/senda/internal/metrics"
 	"github.com/rendis/senda/internal/port"
@@ -42,6 +43,12 @@ func DefaultAdapterSenderFactory(ctx context.Context, adapter *domain.Adapter, d
 			return nil, fmt.Errorf("%w: %w", domain.ErrValidation, err)
 		}
 		return gmailadapter.NewAdapterFromConfig(ctx, cfg)
+	case domain.AdapterTypeSMTP:
+		var cfg smtpadapter.Config
+		if err := json.Unmarshal(decryptedConfig, &cfg); err != nil {
+			return nil, fmt.Errorf("%w: unmarshal SMTP config: %w", domain.ErrValidation, err)
+		}
+		return smtpadapter.NewAdapterFromConfig(cfg)
 	default:
 		return nil, fmt.Errorf("%w: unsupported adapter type %s", domain.ErrValidation, adapter.AdapterType)
 	}

--- a/internal/adapter/river/send_worker_test.go
+++ b/internal/adapter/river/send_worker_test.go
@@ -305,6 +305,19 @@ func makeJob(args SendJobArgs, attempt int) *goriver.Job[SendJobArgs] {
 
 // --- Tests ---
 
+func TestDefaultAdapterSenderFactory_SMTP(t *testing.T) {
+	adapter := &domain.Adapter{AdapterType: domain.AdapterTypeSMTP}
+	cfg := []byte(`{"host":"localhost","port":1025,"tls_mode":"none"}`)
+
+	sender, err := DefaultAdapterSenderFactory(context.Background(), adapter, cfg)
+	if err != nil {
+		t.Fatalf("DefaultAdapterSenderFactory() SMTP error = %v", err)
+	}
+	if sender.Name() != "smtp" {
+		t.Fatalf("sender.Name() = %q, want smtp", sender.Name())
+	}
+}
+
 func TestSendWorker_SuccessfulSend(t *testing.T) {
 	email := newTestEmail()
 	emailStore := &mockEmailStore{

--- a/internal/adapter/river/send_worker_test.go
+++ b/internal/adapter/river/send_worker_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"net/textproto"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	goriver "github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
 
+	smtpadapter "github.com/rendis/senda/internal/adapter/smtp"
 	"github.com/rendis/senda/internal/domain"
 	"github.com/rendis/senda/internal/port"
 )
@@ -1053,6 +1055,35 @@ func TestIsPermanentSendError(t *testing.T) {
 	got := isPermanentSendError(nil, errors.New("any error"))
 	if got {
 		t.Error("isPermanentSendError with nil sender should return false")
+	}
+}
+
+func TestIsPermanentSendError_SMTPStatusCodes(t *testing.T) {
+	sender, err := smtpadapter.NewAdapterFromConfig(smtpadapter.Config{
+		Host:    "localhost",
+		Port:    2525,
+		TLSMode: smtpadapter.TLSModeNone,
+	})
+	if err != nil {
+		t.Fatalf("NewAdapterFromConfig() error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		err       error
+		permanent bool
+	}{
+		{name: "5xx", err: &textproto.Error{Code: 550, Msg: "mailbox unavailable"}, permanent: true},
+		{name: "4xx", err: &textproto.Error{Code: 450, Msg: "mailbox busy"}, permanent: false},
+		{name: "unknown", err: errors.New("connection reset"), permanent: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPermanentSendError(sender, tt.err)
+			if got != tt.permanent {
+				t.Fatalf("isPermanentSendError() = %v, want %v", got, tt.permanent)
+			}
+		})
 	}
 }
 

--- a/internal/adapter/smtp/adapter.go
+++ b/internal/adapter/smtp/adapter.go
@@ -2,44 +2,103 @@ package smtp
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/smtp"
 	"strconv"
+	"strings"
 	"time"
 
 	sendamime "github.com/rendis/senda/internal/mime"
 	"github.com/rendis/senda/internal/port"
 )
 
-// Adapter implements port.EmailSender using plain SMTP.
-// Designed for local development with Mailpit or similar SMTP test servers.
+// TLSMode controls the SMTP transport security mode.
+type TLSMode string
+
+const (
+	TLSModeNone        TLSMode = "none"
+	TLSModeStartTLS    TLSMode = "starttls"
+	TLSModeImplicitTLS TLSMode = "implicit_tls"
+)
+
+const authModeLogin = "login"
+
+// Config defines relay-only SMTP adapter configuration.
+type Config struct {
+	Host     string  `json:"host"`
+	Port     int     `json:"port"`
+	TLSMode  TLSMode `json:"tls_mode"`
+	AuthMode string  `json:"auth_mode,omitempty"`
+	Username string  `json:"username,omitempty"`
+	Password string  `json:"password,omitempty"`
+}
+
+// Validate checks the SMTP relay configuration.
+func (c Config) Validate() error {
+	if strings.TrimSpace(c.Host) == "" {
+		return fmt.Errorf("missing SMTP host")
+	}
+	if c.Port <= 0 || c.Port > 65535 {
+		return fmt.Errorf("invalid SMTP port")
+	}
+	switch c.TLSMode {
+	case TLSModeNone, TLSModeStartTLS, TLSModeImplicitTLS:
+	case "":
+		return fmt.Errorf("missing SMTP tls_mode")
+	default:
+		return fmt.Errorf("invalid SMTP tls_mode %q", c.TLSMode)
+	}
+	if c.AuthMode != "" && c.AuthMode != "plain" && c.AuthMode != authModeLogin {
+		return fmt.Errorf("invalid SMTP auth_mode %q", c.AuthMode)
+	}
+	if (c.Username == "") != (c.Password == "") {
+		return fmt.Errorf("smtp username and password must be provided together")
+	}
+	return nil
+}
+
+// NewAdapterFromConfig creates a configured SMTP adapter.
+func NewAdapterFromConfig(cfg Config) (*Adapter, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &Adapter{cfg: cfg}, nil
+}
+
+// Adapter implements port.EmailSender using SMTP relays.
 type Adapter struct {
-	host string
-	port int
+	cfg Config
 }
 
 // NewAdapter creates a new SMTP adapter.
 func NewAdapter(host string, port int) *Adapter {
-	return &Adapter{host: host, port: port}
+	return &Adapter{cfg: Config{Host: host, Port: port, TLSMode: TLSModeNone}}
 }
 
 // Send delivers an email via SMTP.
-func (a *Adapter) Send(_ context.Context, msg *port.OutgoingEmail) (string, error) {
+func (a *Adapter) Send(ctx context.Context, msg *port.OutgoingEmail) (string, error) {
 	rawMsg, err := sendamime.BuildRawMessage(msg)
 	if err != nil {
 		return "", fmt.Errorf("smtp: build message: %w", err)
 	}
 
-	addr := net.JoinHostPort(a.host, strconv.Itoa(a.port))
+	addr := net.JoinHostPort(a.cfg.Host, strconv.Itoa(a.cfg.Port))
 	recipients := allRecipients(msg)
+	auth := a.auth()
 
-	if err := smtp.SendMail(addr, nil, msg.From.Address, recipients, rawMsg); err != nil {
+	switch a.cfg.TLSMode {
+	case TLSModeImplicitTLS:
+		err = a.sendImplicitTLS(ctx, addr, auth, msg.From.Address, recipients, rawMsg)
+	default:
+		err = smtp.SendMail(addr, auth, msg.From.Address, recipients, rawMsg)
+	}
+	if err != nil {
 		return "", fmt.Errorf("smtp: send: %w", err)
 	}
 
-	providerID := fmt.Sprintf("<trk-%s@senda>", msg.TrackingID)
-	return providerID, nil
+	return fmt.Sprintf("<trk-%s@senda>", msg.TrackingID), nil
 }
 
 // Name returns the adapter identifier.
@@ -47,7 +106,7 @@ func (a *Adapter) Name() string { return "smtp" }
 
 // HealthCheck verifies the SMTP server is reachable.
 func (a *Adapter) HealthCheck(_ context.Context) error {
-	addr := net.JoinHostPort(a.host, strconv.Itoa(a.port))
+	addr := net.JoinHostPort(a.cfg.Host, strconv.Itoa(a.cfg.Port))
 	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
 	if err != nil {
 		return fmt.Errorf("smtp: health check: %w", err)
@@ -58,6 +117,85 @@ func (a *Adapter) HealthCheck(_ context.Context) error {
 
 // Compile-time interface check.
 var _ port.EmailSender = (*Adapter)(nil)
+
+func (a *Adapter) auth() smtp.Auth {
+	if a.cfg.Username == "" && a.cfg.Password == "" {
+		return nil
+	}
+	if a.cfg.AuthMode == authModeLogin {
+		return loginAuth{username: a.cfg.Username, password: a.cfg.Password}
+	}
+	return smtp.PlainAuth("", a.cfg.Username, a.cfg.Password, a.cfg.Host)
+}
+
+type loginAuth struct {
+	username string
+	password string
+}
+
+func (a loginAuth) Start(_ *smtp.ServerInfo) (string, []byte, error) {
+	return "LOGIN", []byte(a.username), nil
+}
+
+func (a loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
+	if !more {
+		return nil, nil
+	}
+	prompt := strings.ToLower(string(fromServer))
+	if strings.Contains(prompt, "password") {
+		return []byte(a.password), nil
+	}
+	return []byte(a.username), nil
+}
+
+func (a *Adapter) sendImplicitTLS(ctx context.Context, addr string, auth smtp.Auth, from string, to []string, rawMsg []byte) error {
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	conn, err := tls.DialWithDialer(dialer, "tcp", addr, &tls.Config{ServerName: a.cfg.Host, MinVersion: tls.VersionTLS12})
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+
+	client, err := smtp.NewClient(conn, a.cfg.Host)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	return sendWithClient(client, auth, from, to, rawMsg)
+}
+
+func sendWithClient(client *smtp.Client, auth smtp.Auth, from string, to []string, rawMsg []byte) error {
+	if auth != nil {
+		if err := client.Auth(auth); err != nil {
+			return err
+		}
+	}
+	if err := client.Mail(from); err != nil {
+		return err
+	}
+	for _, addr := range to {
+		if err := client.Rcpt(addr); err != nil {
+			return err
+		}
+	}
+	w, err := client.Data()
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(rawMsg); err != nil {
+		_ = w.Close()
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	return client.Quit()
+}
 
 func allRecipients(msg *port.OutgoingEmail) []string {
 	var addrs []string

--- a/internal/adapter/smtp/adapter.go
+++ b/internal/adapter/smtp/adapter.go
@@ -3,9 +3,11 @@ package smtp
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/smtp"
+	"net/textproto"
 	"strconv"
 	"strings"
 	"time"
@@ -55,6 +57,9 @@ func (c Config) Validate() error {
 	}
 	if (c.Username == "") != (c.Password == "") {
 		return fmt.Errorf("smtp username and password must be provided together")
+	}
+	if c.Username != "" && c.Password != "" && c.TLSMode == TLSModeNone && !isLoopbackHost(c.Host) {
+		return fmt.Errorf("smtp cleartext auth is only allowed for loopback hosts")
 	}
 	return nil
 }
@@ -121,6 +126,24 @@ func (a *Adapter) HealthCheck(_ context.Context) error {
 
 // Compile-time interface check.
 var _ port.EmailSender = (*Adapter)(nil)
+
+// IsPermanentSendError classifies SMTP reply codes: 5xx permanent, 4xx transient.
+func (a *Adapter) IsPermanentSendError(err error) bool {
+	var smtpErr *textproto.Error
+	if errors.As(err, &smtpErr) {
+		return smtpErr.Code >= 500 && smtpErr.Code < 600
+	}
+	return false
+}
+
+func isLoopbackHost(host string) bool {
+	normalized := strings.ToLower(strings.Trim(strings.TrimSpace(host), "[]"))
+	if normalized == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(normalized)
+	return ip != nil && ip.IsLoopback()
+}
 
 func (a *Adapter) auth() smtp.Auth {
 	if a.cfg.Username == "" && a.cfg.Password == "" {

--- a/internal/adapter/smtp/adapter.go
+++ b/internal/adapter/smtp/adapter.go
@@ -89,10 +89,14 @@ func (a *Adapter) Send(ctx context.Context, msg *port.OutgoingEmail) (string, er
 	auth := a.auth()
 
 	switch a.cfg.TLSMode {
+	case TLSModeNone:
+		err = a.sendPlain(ctx, addr, auth, msg.From.Address, recipients, rawMsg)
+	case TLSModeStartTLS:
+		err = a.sendStartTLS(ctx, addr, auth, msg.From.Address, recipients, rawMsg)
 	case TLSModeImplicitTLS:
 		err = a.sendImplicitTLS(ctx, addr, auth, msg.From.Address, recipients, rawMsg)
 	default:
-		err = smtp.SendMail(addr, auth, msg.From.Address, recipients, rawMsg)
+		err = fmt.Errorf("unsupported SMTP tls_mode %q", a.cfg.TLSMode)
 	}
 	if err != nil {
 		return "", fmt.Errorf("smtp: send: %w", err)
@@ -148,6 +152,33 @@ func (a loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 	return []byte(a.username), nil
 }
 
+func (a *Adapter) sendPlain(ctx context.Context, addr string, auth smtp.Auth, from string, to []string, rawMsg []byte) error {
+	client, err := a.dialPlainClient(ctx, addr)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	return sendWithClient(client, auth, from, to, rawMsg)
+}
+
+func (a *Adapter) sendStartTLS(ctx context.Context, addr string, auth smtp.Auth, from string, to []string, rawMsg []byte) error {
+	client, err := a.dialPlainClient(ctx, addr)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	if ok, _ := client.Extension("STARTTLS"); !ok {
+		return fmt.Errorf("smtp: STARTTLS not supported by server")
+	}
+	if err := client.StartTLS(&tls.Config{ServerName: a.cfg.Host, MinVersion: tls.VersionTLS12}); err != nil {
+		return err
+	}
+
+	return sendWithClient(client, auth, from, to, rawMsg)
+}
+
 func (a *Adapter) sendImplicitTLS(ctx context.Context, addr string, auth smtp.Auth, from string, to []string, rawMsg []byte) error {
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
 	conn, err := tls.DialWithDialer(dialer, "tcp", addr, &tls.Config{ServerName: a.cfg.Host, MinVersion: tls.VersionTLS12})
@@ -167,6 +198,25 @@ func (a *Adapter) sendImplicitTLS(ctx context.Context, addr string, auth smtp.Au
 	defer func() { _ = client.Close() }()
 
 	return sendWithClient(client, auth, from, to, rawMsg)
+}
+
+func (a *Adapter) dialPlainClient(ctx context.Context, addr string) (*smtp.Client, error) {
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+
+	client, err := smtp.NewClient(conn, a.cfg.Host)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return client, nil
 }
 
 func sendWithClient(client *smtp.Client, auth smtp.Auth, from string, to []string, rawMsg []byte) error {

--- a/internal/adapter/smtp/adapter.go
+++ b/internal/adapter/smtp/adapter.go
@@ -154,7 +154,7 @@ func (a *Adapter) sendImplicitTLS(ctx context.Context, addr string, auth smtp.Au
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	if deadline, ok := ctx.Deadline(); ok {
 		_ = conn.SetDeadline(deadline)
@@ -164,7 +164,7 @@ func (a *Adapter) sendImplicitTLS(ctx context.Context, addr string, auth smtp.Au
 	if err != nil {
 		return err
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	return sendWithClient(client, auth, from, to, rawMsg)
 }

--- a/internal/adapter/smtp/adapter_test.go
+++ b/internal/adapter/smtp/adapter_test.go
@@ -102,6 +102,37 @@ func TestAllRecipients(t *testing.T) {
 	require.Equal(t, []string{"to@test.com", "cc@test.com", "bcc@test.com"}, addrs)
 }
 
+func TestConfigValidate_PlainSMTP(t *testing.T) {
+	cfg := Config{
+		Host:    "localhost",
+		Port:    1025,
+		TLSMode: TLSModeNone,
+	}
+
+	require.NoError(t, cfg.Validate())
+}
+
+func TestConfigValidate_AuthenticatedSMTPRequiresUsernameAndPasswordTogether(t *testing.T) {
+	cfg := Config{
+		Host:     "smtp.example.com",
+		Port:     587,
+		TLSMode:  TLSModeStartTLS,
+		Username: "apikey",
+	}
+
+	require.ErrorContains(t, cfg.Validate(), "smtp username and password must be provided together")
+}
+
+func TestConfigValidate_RejectsUnknownTLSMode(t *testing.T) {
+	cfg := Config{
+		Host:    "smtp.example.com",
+		Port:    587,
+		TLSMode: TLSMode("ssl-ish"),
+	}
+
+	require.ErrorContains(t, cfg.Validate(), "invalid SMTP tls_mode")
+}
+
 func TestBuildRawMessage_HeaderInjectionPrevented(t *testing.T) {
 	msg := &port.OutgoingEmail{
 		From:       port.EmailAddress{Address: "noreply@test.com"},
@@ -110,9 +141,9 @@ func TestBuildRawMessage_HeaderInjectionPrevented(t *testing.T) {
 		BodyText:   "text",
 		TrackingID: "trk-005",
 		Headers: map[string]string{
-			"X-Custom":          "safe",
-			"X-Bad\r\nBcc":     "injected",
-			"X-Valid-Header":    "ok\r\nInjected: bad",
+			"X-Custom":       "safe",
+			"X-Bad\r\nBcc":   "injected",
+			"X-Valid-Header": "ok\r\nInjected: bad",
 		},
 	}
 

--- a/internal/adapter/smtp/adapter_test.go
+++ b/internal/adapter/smtp/adapter_test.go
@@ -1,7 +1,11 @@
 package smtp
 
 import (
+	"bufio"
+	"context"
+	"net"
 	"strings"
+	"sync"
 	"testing"
 
 	sendamime "github.com/rendis/senda/internal/mime"
@@ -133,6 +137,36 @@ func TestConfigValidate_RejectsUnknownTLSMode(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "invalid SMTP tls_mode")
 }
 
+func TestAdapterSend_TLSModeNoneDoesNotStartTLS(t *testing.T) {
+	server := startFakeSMTPServer(t, fakeSMTPOptions{advertiseStartTLS: true})
+
+	adapter, err := NewAdapterFromConfig(Config{
+		Host:    server.host,
+		Port:    server.port,
+		TLSMode: TLSModeNone,
+	})
+	require.NoError(t, err)
+
+	_, err = adapter.Send(context.Background(), testOutgoingEmail())
+	require.NoError(t, err)
+	require.NotContains(t, server.commands(), "STARTTLS")
+}
+
+func TestAdapterSend_TLSModeStartTLSRequiresServerSupport(t *testing.T) {
+	server := startFakeSMTPServer(t, fakeSMTPOptions{})
+
+	adapter, err := NewAdapterFromConfig(Config{
+		Host:    server.host,
+		Port:    server.port,
+		TLSMode: TLSModeStartTLS,
+	})
+	require.NoError(t, err)
+
+	_, err = adapter.Send(context.Background(), testOutgoingEmail())
+	require.ErrorContains(t, err, "STARTTLS")
+	require.NotContains(t, server.commands(), "MAIL")
+}
+
 func TestBuildRawMessage_HeaderInjectionPrevented(t *testing.T) {
 	msg := &port.OutgoingEmail{
 		From:       port.EmailAddress{Address: "noreply@test.com"},
@@ -160,4 +194,132 @@ func TestBuildRawMessage_HeaderInjectionPrevented(t *testing.T) {
 func TestAdapter_Name(t *testing.T) {
 	a := NewAdapter("localhost", 1025)
 	require.Equal(t, "smtp", a.Name())
+}
+
+func testOutgoingEmail() *port.OutgoingEmail {
+	return &port.OutgoingEmail{
+		From:       port.EmailAddress{Address: "sender@example.com"},
+		To:         port.EmailAddress{Address: "recipient@example.com"},
+		Subject:    "SMTP test",
+		BodyText:   "hello",
+		TrackingID: "trk-smtp-test",
+	}
+}
+
+type fakeSMTPOptions struct {
+	advertiseStartTLS bool
+}
+
+type fakeSMTPServer struct {
+	host string
+	port int
+
+	listener net.Listener
+	done     chan struct{}
+
+	mu           sync.Mutex
+	commandsSeen []string
+}
+
+func startFakeSMTPServer(t *testing.T, opts fakeSMTPOptions) *fakeSMTPServer {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	host, portString, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+	port, err := net.LookupPort("tcp", portString)
+	require.NoError(t, err)
+
+	server := &fakeSMTPServer{
+		host:     host,
+		port:     port,
+		listener: listener,
+		done:     make(chan struct{}),
+	}
+	go server.serve(opts)
+
+	t.Cleanup(func() {
+		_ = listener.Close()
+		<-server.done
+	})
+
+	return server
+}
+
+func (s *fakeSMTPServer) commands() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.commandsSeen...)
+}
+
+func (s *fakeSMTPServer) record(command string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.commandsSeen = append(s.commandsSeen, command)
+}
+
+func (s *fakeSMTPServer) serve(opts fakeSMTPOptions) {
+	defer close(s.done)
+
+	conn, err := s.listener.Accept()
+	if err != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+	writer := bufio.NewWriter(conn)
+	writeSMTPLine(writer, "220 fake-smtp ESMTP")
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		command := strings.TrimSpace(line)
+		upper := strings.ToUpper(command)
+		if idx := strings.IndexByte(upper, ' '); idx >= 0 {
+			upper = upper[:idx]
+		}
+		s.record(upper)
+
+		switch upper {
+		case "EHLO":
+			writeSMTPLine(writer, "250-fake-smtp")
+			if opts.advertiseStartTLS {
+				writeSMTPLine(writer, "250-STARTTLS")
+			}
+			writeSMTPLine(writer, "250 OK")
+		case "HELO":
+			writeSMTPLine(writer, "250 OK")
+		case "STARTTLS":
+			writeSMTPLine(writer, "454 TLS unavailable in fake server")
+		case "MAIL", "RCPT":
+			writeSMTPLine(writer, "250 OK")
+		case "DATA":
+			writeSMTPLine(writer, "354 End data with <CR><LF>.<CR><LF>")
+			for {
+				dataLine, err := reader.ReadString('\n')
+				if err != nil {
+					return
+				}
+				if strings.TrimSpace(dataLine) == "." {
+					break
+				}
+			}
+			writeSMTPLine(writer, "250 queued")
+		case "QUIT":
+			writeSMTPLine(writer, "221 bye")
+			return
+		default:
+			writeSMTPLine(writer, "250 OK")
+		}
+	}
+}
+
+func writeSMTPLine(writer *bufio.Writer, line string) {
+	_, _ = writer.WriteString(line + "\r\n")
+	_ = writer.Flush()
 }

--- a/internal/adapter/smtp/adapter_test.go
+++ b/internal/adapter/smtp/adapter_test.go
@@ -3,7 +3,9 @@ package smtp
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"net"
+	"net/textproto"
 	"strings"
 	"sync"
 	"testing"
@@ -127,6 +129,42 @@ func TestConfigValidate_AuthenticatedSMTPRequiresUsernameAndPasswordTogether(t *
 	require.ErrorContains(t, cfg.Validate(), "smtp username and password must be provided together")
 }
 
+func TestConfigValidate_RejectsCleartextAuthForNonLoopback(t *testing.T) {
+	for _, authMode := range []string{"plain", authModeLogin} {
+		t.Run(authMode, func(t *testing.T) {
+			cfg := Config{
+				Host:     "smtp.example.com",
+				Port:     2525,
+				TLSMode:  TLSModeNone,
+				AuthMode: authMode,
+				Username: "apikey",
+				Password: "secret",
+			}
+
+			require.ErrorContains(t, cfg.Validate(), "smtp cleartext auth is only allowed for loopback hosts")
+		})
+	}
+}
+
+func TestConfigValidate_AllowsCleartextAuthForLoopback(t *testing.T) {
+	for _, host := range []string{"127.0.0.1", "::1", "localhost"} {
+		for _, authMode := range []string{"plain", authModeLogin} {
+			t.Run(host+"_"+authMode, func(t *testing.T) {
+				cfg := Config{
+					Host:     host,
+					Port:     2525,
+					TLSMode:  TLSModeNone,
+					AuthMode: authMode,
+					Username: "apikey",
+					Password: "secret",
+				}
+
+				require.NoError(t, cfg.Validate())
+			})
+		}
+	}
+}
+
 func TestConfigValidate_RejectsUnknownTLSMode(t *testing.T) {
 	cfg := Config{
 		Host:    "smtp.example.com",
@@ -135,6 +173,15 @@ func TestConfigValidate_RejectsUnknownTLSMode(t *testing.T) {
 	}
 
 	require.ErrorContains(t, cfg.Validate(), "invalid SMTP tls_mode")
+}
+
+func TestAdapter_IsPermanentSendError_ClassifiesSMTPStatus(t *testing.T) {
+	adapter, err := NewAdapterFromConfig(Config{Host: "localhost", Port: 2525, TLSMode: TLSModeNone})
+	require.NoError(t, err)
+
+	require.True(t, adapter.IsPermanentSendError(&textproto.Error{Code: 550, Msg: "mailbox unavailable"}))
+	require.False(t, adapter.IsPermanentSendError(&textproto.Error{Code: 450, Msg: "mailbox busy"}))
+	require.False(t, adapter.IsPermanentSendError(context.DeadlineExceeded))
 }
 
 func TestAdapterSend_TLSModeNoneDoesNotStartTLS(t *testing.T) {
@@ -150,6 +197,29 @@ func TestAdapterSend_TLSModeNoneDoesNotStartTLS(t *testing.T) {
 	_, err = adapter.Send(context.Background(), testOutgoingEmail())
 	require.NoError(t, err)
 	require.NotContains(t, server.commands(), "STARTTLS")
+}
+
+func TestAdapterSend_TLSModeNoneAllowsLoopbackAuth(t *testing.T) {
+	for _, authMode := range []string{"plain", authModeLogin} {
+		t.Run(authMode, func(t *testing.T) {
+			server := startFakeSMTPServer(t, fakeSMTPOptions{supportAuth: true})
+
+			adapter, err := NewAdapterFromConfig(Config{
+				Host:     server.host,
+				Port:     server.port,
+				TLSMode:  TLSModeNone,
+				AuthMode: authMode,
+				Username: "apikey",
+				Password: "secret",
+			})
+			require.NoError(t, err)
+
+			_, err = adapter.Send(context.Background(), testOutgoingEmail())
+			require.NoError(t, err)
+			require.Contains(t, server.commands(), "AUTH")
+			require.NotContains(t, server.commands(), "STARTTLS")
+		})
+	}
 }
 
 func TestAdapterSend_TLSModeStartTLSRequiresServerSupport(t *testing.T) {
@@ -208,6 +278,7 @@ func testOutgoingEmail() *port.OutgoingEmail {
 
 type fakeSMTPOptions struct {
 	advertiseStartTLS bool
+	supportAuth       bool
 }
 
 type fakeSMTPServer struct {
@@ -285,38 +356,84 @@ func (s *fakeSMTPServer) serve(opts fakeSMTPOptions) {
 		}
 		s.record(upper)
 
-		switch upper {
-		case "EHLO":
-			writeSMTPLine(writer, "250-fake-smtp")
-			if opts.advertiseStartTLS {
-				writeSMTPLine(writer, "250-STARTTLS")
-			}
-			writeSMTPLine(writer, "250 OK")
-		case "HELO":
-			writeSMTPLine(writer, "250 OK")
-		case "STARTTLS":
-			writeSMTPLine(writer, "454 TLS unavailable in fake server")
-		case "MAIL", "RCPT":
-			writeSMTPLine(writer, "250 OK")
-		case "DATA":
-			writeSMTPLine(writer, "354 End data with <CR><LF>.<CR><LF>")
-			for {
-				dataLine, err := reader.ReadString('\n')
-				if err != nil {
-					return
-				}
-				if strings.TrimSpace(dataLine) == "." {
-					break
-				}
-			}
-			writeSMTPLine(writer, "250 queued")
-		case "QUIT":
-			writeSMTPLine(writer, "221 bye")
+		keepServing, err := handleFakeSMTPCommand(reader, writer, opts, command, upper)
+		if err != nil {
 			return
-		default:
-			writeSMTPLine(writer, "250 OK")
+		}
+		if !keepServing {
+			return
 		}
 	}
+}
+
+func handleFakeSMTPCommand(
+	reader *bufio.Reader,
+	writer *bufio.Writer,
+	opts fakeSMTPOptions,
+	command string,
+	upper string,
+) (bool, error) {
+	switch upper {
+	case "EHLO":
+		writeFakeSMTPEHLO(writer, opts)
+	case "HELO":
+		writeSMTPLine(writer, "250 OK")
+	case "STARTTLS":
+		writeSMTPLine(writer, "454 TLS unavailable in fake server")
+	case "AUTH":
+		if err := handleFakeSMTPAuth(reader, writer, command); err != nil {
+			return false, err
+		}
+	case "MAIL", "RCPT":
+		writeSMTPLine(writer, "250 OK")
+	case "DATA":
+		if err := handleFakeSMTPData(reader, writer); err != nil {
+			return false, err
+		}
+	case "QUIT":
+		writeSMTPLine(writer, "221 bye")
+		return false, nil
+	default:
+		writeSMTPLine(writer, "250 OK")
+	}
+	return true, nil
+}
+
+func writeFakeSMTPEHLO(writer *bufio.Writer, opts fakeSMTPOptions) {
+	writeSMTPLine(writer, "250-fake-smtp")
+	if opts.advertiseStartTLS {
+		writeSMTPLine(writer, "250-STARTTLS")
+	}
+	if opts.supportAuth {
+		writeSMTPLine(writer, "250-AUTH PLAIN LOGIN")
+	}
+	writeSMTPLine(writer, "250 OK")
+}
+
+func handleFakeSMTPAuth(reader *bufio.Reader, writer *bufio.Writer, command string) error {
+	if strings.HasPrefix(strings.ToUpper(command), "AUTH LOGIN") {
+		writeSMTPLine(writer, "334 "+base64.StdEncoding.EncodeToString([]byte("Password:")))
+		if _, err := reader.ReadString('\n'); err != nil {
+			return err
+		}
+	}
+	writeSMTPLine(writer, "235 authenticated")
+	return nil
+}
+
+func handleFakeSMTPData(reader *bufio.Reader, writer *bufio.Writer) error {
+	writeSMTPLine(writer, "354 End data with <CR><LF>.<CR><LF>")
+	for {
+		dataLine, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(dataLine) == "." {
+			break
+		}
+	}
+	writeSMTPLine(writer, "250 queued")
+	return nil
 }
 
 func writeSMTPLine(writer *bufio.Writer, line string) {

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -17,7 +17,6 @@ import (
 	sesadapter "github.com/rendis/senda/internal/adapter/ses"
 	smtpadapter "github.com/rendis/senda/internal/adapter/smtp"
 	"github.com/rendis/senda/internal/adapter/testauth"
-	"github.com/rendis/senda/internal/domain"
 	sendahttp "github.com/rendis/senda/internal/http"
 	"github.com/rendis/senda/internal/http/handler"
 	"github.com/rendis/senda/internal/port"
@@ -303,13 +302,6 @@ func newServiceBundle(cfg *config.Config, pool *pgxpool.Pool, repos repositoryBu
 	templateSvc := service.NewTemplateService(repos.templateRepo, infra.compiler)
 	onboardingSvc := service.NewOnboardingService(pool, repos.memberRepo, repos.tenantRepo, repos.workspaceRepo, repos.auditRepo)
 
-	testSendSenderFactory := river.DefaultAdapterSenderFactory
-	if infra.emailSender != nil {
-		testSendSenderFactory = func(context.Context, *domain.Adapter, []byte) (port.EmailSender, error) {
-			return infra.emailSender, nil
-		}
-	}
-
 	return serviceBundle{
 		webhookSvc:       webhookSvc,
 		identitySvc:      identitySvc,
@@ -326,13 +318,17 @@ func newServiceBundle(cfg *config.Config, pool *pgxpool.Pool, repos repositoryBu
 			infra.aesCrypto,
 			infra.compiler,
 			infra.renderer,
-			testSendSenderFactory,
+			newTestSendSenderFactory(infra.emailSender),
 			resolvers.injectorMerger,
 			repos.tenantRepo,
 			repos.workspaceRepo,
 		),
 		eventProcessor: service.NewEventProcessor(repos.emailRepo, repos.emailRepo, repos.suppressionRepo, webhookSvc, logger),
 	}
+}
+
+func newTestSendSenderFactory(_ port.EmailSender) port.SenderFactory {
+	return river.DefaultAdapterSenderFactory
 }
 
 func newServerHandlerBundle(

--- a/internal/app/wiring_test.go
+++ b/internal/app/wiring_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/labstack/echo/v5/echotest"
 	"github.com/rendis/senda/config"
+	"github.com/rendis/senda/internal/domain"
+	"github.com/rendis/senda/internal/port"
 )
 
 func testAppLogger() *slog.Logger {
@@ -87,6 +90,39 @@ func TestBuildMediaHandler_UsesConfiguredAllowlist(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for non-allowlisted media host, got %d", rec.Code)
 	}
+}
+
+func TestNewTestSendSenderFactory_UsesAssignedAdapterConfig(t *testing.T) {
+	globalSender := namedEmailSender{name: "global-smtp"}
+	factory := newTestSendSenderFactory(globalSender)
+
+	sender, err := factory(
+		context.Background(),
+		&domain.Adapter{AdapterType: domain.AdapterTypeSMTP},
+		[]byte(`{"host":"127.0.0.1","port":2525,"tls_mode":"none","auth_mode":"plain","username":"user","password":"pass"}`),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sender.Name() == globalSender.Name() {
+		t.Fatalf("expected template test-send to use the assigned adapter config, got global sender %q", sender.Name())
+	}
+}
+
+type namedEmailSender struct {
+	name string
+}
+
+func (s namedEmailSender) Send(context.Context, *port.OutgoingEmail) (string, error) {
+	return "", nil
+}
+
+func (s namedEmailSender) Name() string {
+	return s.name
+}
+
+func (s namedEmailSender) HealthCheck(context.Context) error {
+	return nil
 }
 
 func jsonMarshal(t *testing.T, v any) ([]byte, error) {

--- a/internal/domain/adapter.go
+++ b/internal/domain/adapter.go
@@ -11,6 +11,7 @@ type AdapterType string
 const (
 	AdapterTypeSES   AdapterType = "ses"
 	AdapterTypeGmail AdapterType = "gmail"
+	AdapterTypeSMTP  AdapterType = "smtp"
 )
 
 type Adapter struct {

--- a/internal/http/handler/adapter.go
+++ b/internal/http/handler/adapter.go
@@ -297,6 +297,9 @@ func (h *AdapterHandler) update(c *echo.Context, workspace *domain.Workspace) er
 		if err != nil {
 			return response.WriteError(c, http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error")
 		}
+		if fieldErrors := validateConfig(adapter.AdapterType, updated); len(fieldErrors) > 0 {
+			return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed", fieldErrors...)
+		}
 		encrypted, err := h.crypto.Encrypt(updated)
 		if err != nil {
 			return response.WriteError(c, http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error")

--- a/internal/http/handler/adapter.go
+++ b/internal/http/handler/adapter.go
@@ -493,7 +493,10 @@ func (h *AdapterHandler) testSend(c *echo.Context, workspace *domain.Workspace) 
 		}
 		from = resolution.IdentityToEmailAddress(matched)
 	} else {
-		from = resolution.ResolveFromAddress(ctx, h.identityStore, adapter, decrypted)
+		from, err = h.resolveDefaultFromAddress(ctx, workspace, adapter, decrypted)
+		if err != nil {
+			return mapAdapterAccessHandlerError(c, err)
+		}
 	}
 	if from.Address == "" {
 		return response.WriteError(c, http.StatusUnprocessableEntity, "NO_DEFAULT_IDENTITY", "no default sender identity and no delegate_email in config")
@@ -661,6 +664,28 @@ func mapAdapterAccessHandlerError(c *echo.Context, err error) error {
 	}
 }
 
+func (h *AdapterHandler) resolveDefaultFromAddress(ctx context.Context, workspace *domain.Workspace, adapter *domain.Adapter, decryptedConfig []byte) (port.EmailAddress, error) {
+	if workspace != nil && h.accessSvc != nil && identityScopedAdapter(adapter.AdapterType) {
+		access, err := h.accessSvc.GetAdapterAccess(ctx, workspace, adapter.ID)
+		if err != nil {
+			return port.EmailAddress{}, err
+		}
+		if access.Shared {
+			identities, err := h.accessSvc.ListIdentitiesForWorkspace(ctx, workspace, adapter.ID)
+			if err != nil {
+				return port.EmailAddress{}, err
+			}
+			for _, identity := range identities {
+				if identity.IsDefault && identity.IdentityType == domain.IdentityTypeEmail {
+					return resolution.IdentityToEmailAddress(identity), nil
+				}
+			}
+			return port.EmailAddress{}, nil
+		}
+	}
+	return resolution.ResolveFromAddress(ctx, h.identityStore, adapter, decryptedConfig), nil
+}
+
 // decryptConfigMap decrypts the adapter config and unmarshals it into a map.
 func (h *AdapterHandler) decryptConfigMap(adapter *domain.Adapter) (map[string]any, error) {
 	decrypted, err := h.crypto.Decrypt(adapter.ConfigEncrypted)
@@ -742,6 +767,12 @@ func validateConfig(adapterType domain.AdapterType, config json.RawMessage) []re
 			errs = append(errs, response.FieldError{Field: "config.delegate_email", Message: "is required"})
 		}
 	case domain.AdapterTypeSMTP:
+		if _, ok := cfgMap["from_email"]; ok {
+			errs = append(errs, response.FieldError{Field: "config.from_email", Message: "is not allowed for SMTP adapters; create a sender identity instead"})
+		}
+		if _, ok := cfgMap["from_name"]; ok {
+			errs = append(errs, response.FieldError{Field: "config.from_name", Message: "is not allowed for SMTP adapters; create a sender identity instead"})
+		}
 		var cfg smtpadapter.Config
 		if err := json.Unmarshal(config, &cfg); err != nil {
 			errs = append(errs, response.FieldError{Field: "config", Message: "must be a valid SMTP config object"})
@@ -760,6 +791,10 @@ func isValidAdapterType(t string) bool {
 		return true
 	}
 	return false
+}
+
+func identityScopedAdapter(adapterType domain.AdapterType) bool {
+	return adapterType == domain.AdapterTypeSES || adapterType == domain.AdapterTypeSMTP
 }
 
 // sameScope checks that both pointers are nil or point to the same UUID.

--- a/internal/http/handler/adapter.go
+++ b/internal/http/handler/adapter.go
@@ -283,12 +283,7 @@ func (h *AdapterHandler) update(c *echo.Context, workspace *domain.Workspace) er
 			if err := json.Unmarshal(*req.Config, &patch); err != nil {
 				return response.WriteError(c, http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error")
 			}
-			for k, v := range patch {
-				if s, ok := v.(string); ok && s == "" {
-					continue
-				}
-				cfgMap[k] = v
-			}
+			mergeAdapterConfigPatch(adapter.AdapterType, cfgMap, patch)
 		}
 		if req.ConfigurationSetName != nil {
 			cfgMap["configuration_set_name"] = *req.ConfigurationSetName
@@ -323,6 +318,25 @@ func (h *AdapterHandler) update(c *echo.Context, workspace *domain.Workspace) er
 		return c.JSON(http.StatusOK, response.NewAdapterResponse(adapter))
 	}
 	return c.JSON(http.StatusOK, response.NewAdapterResponseForWorkspace(adapter, workspace))
+}
+
+func mergeAdapterConfigPatch(adapterType domain.AdapterType, cfgMap map[string]any, patch map[string]any) {
+	if adapterType == domain.AdapterTypeSMTP {
+		if username, ok := patch["username"].(string); ok && username == "" {
+			delete(cfgMap, "username")
+			delete(cfgMap, "password")
+			delete(cfgMap, "auth_mode")
+			delete(patch, "username")
+			delete(patch, "password")
+			delete(patch, "auth_mode")
+		}
+	}
+	for k, v := range patch {
+		if s, ok := v.(string); ok && s == "" {
+			continue
+		}
+		cfgMap[k] = v
+	}
 }
 
 // SoftDelete handles DELETE /tenants/:tenant_code/workspaces/:workspace_code/adapters/:id.

--- a/internal/http/handler/adapter.go
+++ b/internal/http/handler/adapter.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	sesadapter "github.com/rendis/senda/internal/adapter/ses"
+	smtpadapter "github.com/rendis/senda/internal/adapter/smtp"
 	"github.com/rendis/senda/internal/domain"
 	"github.com/rendis/senda/internal/http/pagination"
 	"github.com/rendis/senda/internal/http/request"
@@ -97,7 +99,7 @@ func (h *AdapterHandler) create(c *echo.Context, workspaceID *uuid.UUID) error {
 		fieldErrors = append(fieldErrors, response.FieldError{Field: "name", Message: "is required"})
 	}
 	if !isValidAdapterType(req.AdapterType) {
-		fieldErrors = append(fieldErrors, response.FieldError{Field: "adapter_type", Message: "must be one of: ses, gmail"})
+		fieldErrors = append(fieldErrors, response.FieldError{Field: "adapter_type", Message: "must be one of: ses, gmail, smtp"})
 	}
 	if len(req.Config) == 0 {
 		fieldErrors = append(fieldErrors, response.FieldError{Field: "config", Message: "is required"})
@@ -685,6 +687,24 @@ func extractPublicConfigFields(adapterType domain.AdapterType, rawConfig []byte)
 		if v, ok := cfgMap["delegate_email"].(string); ok && v != "" {
 			meta["delegate_email"] = v
 		}
+	case domain.AdapterTypeSMTP:
+		if v, ok := cfgMap["host"].(string); ok && v != "" {
+			meta["host"] = v
+		}
+		if v, ok := cfgMap["tls_mode"].(string); ok && v != "" {
+			meta["tls_mode"] = v
+		}
+		if v, ok := cfgMap["auth_mode"].(string); ok && v != "" {
+			meta["auth_mode"] = v
+		}
+		switch v := cfgMap["port"].(type) {
+		case float64:
+			meta["port"] = strconv.Itoa(int(v))
+		case string:
+			if v != "" {
+				meta["port"] = v
+			}
+		}
 	}
 	if len(meta) == 0 {
 		return nil
@@ -718,13 +738,22 @@ func validateConfig(adapterType domain.AdapterType, config json.RawMessage) []re
 		if str("delegate_email") == "" {
 			errs = append(errs, response.FieldError{Field: "config.delegate_email", Message: "is required"})
 		}
+	case domain.AdapterTypeSMTP:
+		var cfg smtpadapter.Config
+		if err := json.Unmarshal(config, &cfg); err != nil {
+			errs = append(errs, response.FieldError{Field: "config", Message: "must be a valid SMTP config object"})
+			break
+		}
+		if err := cfg.Validate(); err != nil {
+			errs = append(errs, response.FieldError{Field: "config", Message: err.Error()})
+		}
 	}
 	return errs
 }
 
 func isValidAdapterType(t string) bool {
 	switch domain.AdapterType(t) {
-	case domain.AdapterTypeSES, domain.AdapterTypeGmail:
+	case domain.AdapterTypeSES, domain.AdapterTypeGmail, domain.AdapterTypeSMTP:
 		return true
 	}
 	return false

--- a/internal/http/handler/adapter_test.go
+++ b/internal/http/handler/adapter_test.go
@@ -387,6 +387,100 @@ func TestAdapterHandler_Update_SMTPKeepsPasswordWhenBlank(t *testing.T) {
 	}
 }
 
+func TestAdapterHandler_Update_SMTPReplacesPasswordWhenProvided(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+	adapterID := uuid.Must(uuid.NewV7())
+	now := time.Now().UTC()
+
+	as := &mockAdapterStore{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Adapter{
+				ID:              adapterID,
+				WorkspaceID:     &ws.ID,
+				Name:            "SMTP Relay",
+				AdapterType:     domain.AdapterTypeSMTP,
+				ConfigEncrypted: []byte("encrypted"),
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			}, nil
+		},
+	}
+	crypto := &mockCrypto{
+		decryptFn: func(_ []byte) ([]byte, error) {
+			return []byte(`{"host":"smtp.example.com","port":587,"tls_mode":"starttls","auth_mode":"plain","username":"apikey","password":"old-secret"}`), nil
+		},
+	}
+	e, _ := setupAdapterTest(as, crypto, ts, wsStore)
+
+	body := `{"config":{"username":"apikey","password":"new-secret"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/default/adapters/"+adapterID.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var encryptedConfig map[string]any
+	if err := json.Unmarshal(crypto.lastPlaintext, &encryptedConfig); err != nil {
+		t.Fatalf("updated config JSON error = %v", err)
+	}
+	if encryptedConfig["password"] != "new-secret" {
+		t.Fatalf("password = %v, want new-secret", encryptedConfig["password"])
+	}
+}
+
+func TestAdapterHandler_Update_SMTPClearsAuthWhenUsernameEmpty(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+	adapterID := uuid.Must(uuid.NewV7())
+	now := time.Now().UTC()
+
+	as := &mockAdapterStore{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Adapter{
+				ID:              adapterID,
+				WorkspaceID:     &ws.ID,
+				Name:            "SMTP Relay",
+				AdapterType:     domain.AdapterTypeSMTP,
+				ConfigEncrypted: []byte("encrypted"),
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			}, nil
+		},
+	}
+	crypto := &mockCrypto{
+		decryptFn: func(_ []byte) ([]byte, error) {
+			return []byte(`{"host":"smtp.example.com","port":587,"tls_mode":"starttls","auth_mode":"plain","username":"apikey","password":"old-secret"}`), nil
+		},
+	}
+	e, _ := setupAdapterTest(as, crypto, ts, wsStore)
+
+	body := `{"config":{"username":""}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/default/adapters/"+adapterID.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var encryptedConfig map[string]any
+	if err := json.Unmarshal(crypto.lastPlaintext, &encryptedConfig); err != nil {
+		t.Fatalf("updated config JSON error = %v", err)
+	}
+	for _, key := range []string{"username", "password", "auth_mode"} {
+		if _, ok := encryptedConfig[key]; ok {
+			t.Fatalf("%s should be removed when username is cleared: %#v", key, encryptedConfig)
+		}
+	}
+}
+
 func TestAdapterHandler_Update_SMTPValidatesMergedConfig(t *testing.T) {
 	_, ws, ts, wsStore := testTenantAndWorkspace()
 	adapterID := uuid.Must(uuid.NewV7())

--- a/internal/http/handler/adapter_test.go
+++ b/internal/http/handler/adapter_test.go
@@ -346,7 +346,7 @@ func TestAdapterHandler_GetWorkspaceAccess_SystemScope(t *testing.T) {
 	workspaceBID := uuid.Must(uuid.NewV7())
 	adapterID := uuid.Must(uuid.NewV7())
 
-wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
+	wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID == tenant.ID && code == "_system" {
 			return &domain.Workspace{
 				ID:       systemWSID,
@@ -358,7 +358,7 @@ wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code 
 		}
 		return nil, domain.ErrNotFound
 	}
-wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+	wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 		if tenantID != tenant.ID {
 			return nil, "", domain.ErrNotFound
 		}
@@ -428,7 +428,7 @@ func TestAdapterHandler_UpdateWorkspaceAccess_WritesAudit(t *testing.T) {
 	systemWS := &domain.Workspace{ID: systemWSID, TenantID: tenant.ID, Code: "_system", Name: "System", IsSystem: true}
 	workspaceA := &domain.Workspace{ID: workspaceAID, TenantID: tenant.ID, Code: "alpha", Name: "Alpha"}
 
-wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
+	wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code string, _ domain.Environment) (*domain.Workspace, error) {
 		if tenantID != tenant.ID {
 			return nil, domain.ErrNotFound
 		}
@@ -441,7 +441,7 @@ wsStore.getByTenantAndCodeFn = func(_ context.Context, tenantID uuid.UUID, code 
 			return nil, domain.ErrNotFound
 		}
 	}
-wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+	wsStore.listByTenantFn = func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
 		if tenantID != tenant.ID {
 			return nil, "", domain.ErrNotFound
 		}
@@ -736,7 +736,7 @@ func TestAdapterHandler_Create_InvalidType(t *testing.T) {
 
 	e, _ := setupAdapterTest(&mockAdapterStore{}, &mockCrypto{}, ts, wsStore)
 
-	body := `{"name":"Bad Adapter","adapter_type":"smtp","config":{"host":"localhost"}}`
+	body := `{"name":"Bad Adapter","adapter_type":"mailgun","config":{"host":"localhost"}}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/adapters", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -744,6 +744,65 @@ func TestAdapterHandler_Create_InvalidType(t *testing.T) {
 
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAdapterHandler_Create_SMTPValidatesAndStoresSafeMeta(t *testing.T) {
+	_, _, ts, wsStore := testTenantAndWorkspace()
+
+	var created *domain.Adapter
+	as := &mockAdapterStore{
+		createFn: func(_ context.Context, adapter *domain.Adapter) error {
+			created = adapter
+			return nil
+		},
+	}
+	e, _ := setupAdapterTest(as, &mockCrypto{}, ts, wsStore)
+
+	body := `{
+		"name":"SMTP Relay",
+		"adapter_type":"smtp",
+		"config":{
+			"host":"smtp.example.com",
+			"port":587,
+			"tls_mode":"starttls",
+			"auth_mode":"plain",
+			"username":"apikey",
+			"password":"secret"
+		},
+		"rate_limit_per_second":10
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/adapters", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if created == nil {
+		t.Fatal("expected adapter to be created")
+	}
+	if created.AdapterType != domain.AdapterTypeSMTP {
+		t.Fatalf("adapter type = %q, want smtp", created.AdapterType)
+	}
+	if created.ConfigMeta["host"] != "smtp.example.com" {
+		t.Fatalf("host meta = %q", created.ConfigMeta["host"])
+	}
+	if created.ConfigMeta["port"] != "587" {
+		t.Fatalf("port meta = %q", created.ConfigMeta["port"])
+	}
+	if created.ConfigMeta["tls_mode"] != "starttls" {
+		t.Fatalf("tls_mode meta = %q", created.ConfigMeta["tls_mode"])
+	}
+	if created.ConfigMeta["auth_mode"] != "plain" {
+		t.Fatalf("auth_mode meta = %q", created.ConfigMeta["auth_mode"])
+	}
+	if _, leaked := created.ConfigMeta["password"]; leaked {
+		t.Fatal("password must not be stored in config_meta")
+	}
+	if _, leaked := created.ConfigMeta["username"]; leaked {
+		t.Fatal("username must not be stored in config_meta")
 	}
 }
 

--- a/internal/http/handler/adapter_test.go
+++ b/internal/http/handler/adapter_test.go
@@ -70,11 +70,13 @@ func (m *mockAdapterStore) ListByWorkspace(ctx context.Context, workspaceID *uui
 // --- Mock Crypto ---
 
 type mockCrypto struct {
-	encryptFn func(plaintext []byte) ([]byte, error)
-	decryptFn func(ciphertext []byte) ([]byte, error)
+	encryptFn     func(plaintext []byte) ([]byte, error)
+	decryptFn     func(ciphertext []byte) ([]byte, error)
+	lastPlaintext []byte
 }
 
 func (m *mockCrypto) Encrypt(plaintext []byte) ([]byte, error) {
+	m.lastPlaintext = append([]byte(nil), plaintext...)
 	if m.encryptFn != nil {
 		return m.encryptFn(plaintext)
 	}
@@ -336,6 +338,99 @@ func TestAdapterHandler_Update_SharedAdapterIsReadOnly(t *testing.T) {
 	}
 	if updated {
 		t.Fatal("shared adapter update should not reach store.Update")
+	}
+}
+
+func TestAdapterHandler_Update_SMTPKeepsPasswordWhenBlank(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+	adapterID := uuid.Must(uuid.NewV7())
+	now := time.Now().UTC()
+
+	as := &mockAdapterStore{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Adapter{
+				ID:              adapterID,
+				WorkspaceID:     &ws.ID,
+				Name:            "SMTP Relay",
+				AdapterType:     domain.AdapterTypeSMTP,
+				ConfigEncrypted: []byte("encrypted"),
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			}, nil
+		},
+	}
+	crypto := &mockCrypto{
+		decryptFn: func(_ []byte) ([]byte, error) {
+			return []byte(`{"host":"smtp.example.com","port":587,"tls_mode":"starttls","auth_mode":"plain","username":"apikey","password":"old-secret"}`), nil
+		},
+	}
+	e, _ := setupAdapterTest(as, crypto, ts, wsStore)
+
+	body := `{"config":{"host":"smtp.example.com","port":587,"tls_mode":"starttls","auth_mode":"plain","username":"apikey","password":""}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/default/adapters/"+adapterID.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var encryptedConfig map[string]any
+	if err := json.Unmarshal(crypto.lastPlaintext, &encryptedConfig); err != nil {
+		t.Fatalf("updated config JSON error = %v", err)
+	}
+	if encryptedConfig["password"] != "old-secret" {
+		t.Fatalf("password = %v, want old-secret", encryptedConfig["password"])
+	}
+}
+
+func TestAdapterHandler_Update_SMTPValidatesMergedConfig(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+	adapterID := uuid.Must(uuid.NewV7())
+	now := time.Now().UTC()
+
+	var updated bool
+	as := &mockAdapterStore{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Adapter{
+				ID:              adapterID,
+				WorkspaceID:     &ws.ID,
+				Name:            "SMTP Relay",
+				AdapterType:     domain.AdapterTypeSMTP,
+				ConfigEncrypted: []byte("encrypted"),
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			}, nil
+		},
+		updateFn: func(_ context.Context, _ *domain.Adapter) error {
+			updated = true
+			return nil
+		},
+	}
+	crypto := &mockCrypto{
+		decryptFn: func(_ []byte) ([]byte, error) {
+			return []byte(`{"host":"smtp.example.com","port":587,"tls_mode":"starttls","auth_mode":"plain","username":"apikey","password":"old-secret"}`), nil
+		},
+	}
+	e, _ := setupAdapterTest(as, crypto, ts, wsStore)
+
+	body := `{"config":{"tls_mode":"ssl-ish"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/default/adapters/"+adapterID.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if updated {
+		t.Fatal("invalid SMTP config should not reach store.Update")
 	}
 }
 

--- a/internal/http/handler/adapter_test.go
+++ b/internal/http/handler/adapter_test.go
@@ -434,6 +434,56 @@ func TestAdapterHandler_Update_SMTPValidatesMergedConfig(t *testing.T) {
 	}
 }
 
+func TestAdapterHandler_Update_SMTPRejectsSenderFields(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+	adapterID := uuid.Must(uuid.NewV7())
+	now := time.Now().UTC()
+
+	var updated bool
+	as := &mockAdapterStore{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Adapter{
+				ID:              adapterID,
+				WorkspaceID:     &ws.ID,
+				Name:            "SMTP Relay",
+				AdapterType:     domain.AdapterTypeSMTP,
+				ConfigEncrypted: []byte("encrypted"),
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			}, nil
+		},
+		updateFn: func(_ context.Context, _ *domain.Adapter) error {
+			updated = true
+			return nil
+		},
+	}
+	crypto := &mockCrypto{
+		decryptFn: func(_ []byte) ([]byte, error) {
+			return []byte(`{"host":"smtp.example.com","port":587,"tls_mode":"starttls"}`), nil
+		},
+	}
+	e, _ := setupAdapterTest(as, crypto, ts, wsStore)
+
+	body := `{"config":{"from_email":"sender@example.com","from_name":"Sender"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/default/adapters/"+adapterID.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if updated {
+		t.Fatal("invalid SMTP config should not reach store.Update")
+	}
+	if !strings.Contains(rec.Body.String(), "from_email") || !strings.Contains(rec.Body.String(), "from_name") {
+		t.Fatalf("expected sender field validation errors, got %s", rec.Body.String())
+	}
+}
+
 func TestAdapterHandler_GetWorkspaceAccess_SystemScope(t *testing.T) {
 	tenant, _, ts, wsStore := testTenantAndWorkspace()
 	systemWSID := uuid.Must(uuid.NewV7())
@@ -901,6 +951,49 @@ func TestAdapterHandler_Create_SMTPValidatesAndStoresSafeMeta(t *testing.T) {
 	}
 }
 
+func TestAdapterHandler_Create_SMTPRejectsSenderFields(t *testing.T) {
+	_, _, ts, wsStore := testTenantAndWorkspace()
+
+	var created bool
+	as := &mockAdapterStore{
+		createFn: func(_ context.Context, _ *domain.Adapter) error {
+			created = true
+			return nil
+		},
+	}
+	crypto := &mockCrypto{}
+	e, _ := setupAdapterTest(as, crypto, ts, wsStore)
+
+	body := `{
+		"name":"SMTP Relay",
+		"adapter_type":"smtp",
+		"config":{
+			"host":"smtp.example.com",
+			"port":587,
+			"tls_mode":"starttls",
+			"from_email":"sender@example.com",
+			"from_name":"Sender"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/adapters", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if created {
+		t.Fatal("invalid SMTP config should not reach store.Create")
+	}
+	if crypto.lastPlaintext != nil {
+		t.Fatalf("invalid SMTP config should not be encrypted, got %s", string(crypto.lastPlaintext))
+	}
+	if !strings.Contains(rec.Body.String(), "from_email") || !strings.Contains(rec.Body.String(), "from_name") {
+		t.Fatalf("expected sender field validation errors, got %s", rec.Body.String())
+	}
+}
+
 func TestAdapterHandler_GlobalCreate_Success(t *testing.T) {
 	var created *domain.Adapter
 	as := &mockAdapterStore{
@@ -1051,6 +1144,108 @@ func TestAdapterHandler_TestSend_NoDefaultIdentity(t *testing.T) {
 
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAdapterHandler_TestSend_SharedSMTPWithoutFromDoesNotUseUngrantedDefaultIdentity(t *testing.T) {
+	tenant, ws, ts, wsStore := testTenantAndWorkspace()
+	systemWSID := uuid.Must(uuid.NewV7())
+	adapterID := uuid.Must(uuid.NewV7())
+	grantedIdentityID := uuid.Must(uuid.NewV7())
+	rawDefaultIdentityID := uuid.Must(uuid.NewV7())
+	now := time.Now().UTC()
+
+	systemWS := &domain.Workspace{ID: systemWSID, TenantID: tenant.ID, Code: "_system", Name: "System", IsSystem: true}
+	wsStore.getByIDFn = func(_ context.Context, id uuid.UUID) (*domain.Workspace, error) {
+		switch id {
+		case systemWSID:
+			return systemWS, nil
+		case ws.ID:
+			return ws, nil
+		default:
+			return nil, domain.ErrNotFound
+		}
+	}
+
+	as := &mockAdapterStore{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Adapter{
+				ID:              adapterID,
+				WorkspaceID:     &systemWSID,
+				Name:            "Shared SMTP",
+				AdapterType:     domain.AdapterTypeSMTP,
+				ConfigEncrypted: []byte("enc:test"),
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			}, nil
+		},
+	}
+
+	var sent bool
+	sf := func(_ context.Context, _ *domain.Adapter, _ []byte) (port.EmailSender, error) {
+		return &mockEmailSender{
+			sendFn: func(_ context.Context, _ *port.OutgoingEmail) (string, error) {
+				sent = true
+				return "test-provider-id-123", nil
+			},
+		}, nil
+	}
+
+	is := &mockAdapterIdentityStore{
+		getDefaultFn: func(_ context.Context, _ uuid.UUID) (*domain.AdapterIdentity, error) {
+			return &domain.AdapterIdentity{
+				ID:           rawDefaultIdentityID,
+				AdapterID:    adapterID,
+				Identity:     "system-default@example.com",
+				IdentityType: domain.IdentityTypeEmail,
+				IsDefault:    true,
+			}, nil
+		},
+	}
+
+	e, h := setupAdapterTestFull(as, &mockCrypto{}, ts, wsStore, sf, is, nil)
+	accessSvc := service.NewAdapterAccessService(
+		as,
+		is,
+		wsStore,
+		&mockAdapterGrantStoreHandler{},
+		&mockIdentityGrantStoreHandler{
+			listGrantedIdentitiesFn: func(_ context.Context, gotAdapterID uuid.UUID, workspaceID uuid.UUID) ([]*domain.AdapterIdentity, error) {
+				if gotAdapterID != adapterID || workspaceID != ws.ID {
+					return nil, domain.ErrNotFound
+				}
+				return []*domain.AdapterIdentity{
+					{
+						ID:           grantedIdentityID,
+						AdapterID:    adapterID,
+						Identity:     "granted@example.com",
+						IdentityType: domain.IdentityTypeEmail,
+						IsDefault:    false,
+					},
+				}, nil
+			},
+		},
+		&mockTemplateTypeUsageStoreHandler{},
+	)
+	h.SetAdapterAccessService(accessSvc)
+
+	body := `{"to":"recipient@example.com","subject":"Test","body":"Hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/manage/tenants/acme/workspaces/default/adapters/"+adapterID.String()+"/test", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if sent {
+		t.Fatal("test send should not use an ungranted raw default identity")
+	}
+	if !strings.Contains(rec.Body.String(), "NO_DEFAULT_IDENTITY") {
+		t.Fatalf("expected no default identity error, got %s", rec.Body.String())
 	}
 }
 

--- a/internal/http/handler/template_type.go
+++ b/internal/http/handler/template_type.go
@@ -411,7 +411,7 @@ func mapTemplateTypeAccessError(c *echo.Context, err error) error {
 		)
 	case errors.Is(err, domain.ErrSenderIdentityRequired):
 		return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed",
-			response.FieldError{Field: "sender_identity_id", Message: "is required for shared SES adapters"},
+			response.FieldError{Field: "sender_identity_id", Message: "is required for shared adapter sender identities"},
 		)
 	case errors.Is(err, domain.ErrSenderIdentityAccessDenied), errors.Is(err, domain.ErrIdentityNotFound):
 		return response.WriteError(c, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "validation failed",

--- a/internal/service/adapter_access.go
+++ b/internal/service/adapter_access.go
@@ -94,8 +94,8 @@ func (s *AdapterAccessService) GetAdapterAccess(ctx context.Context, workspace *
 		return nil, domain.ErrAdapterAccessDenied
 	}
 
-	switch adapter.AdapterType {
-	case domain.AdapterTypeGmail:
+	switch {
+	case adapter.AdapterType == domain.AdapterTypeGmail:
 		if s.adapterGrants == nil {
 			return nil, domain.ErrAdapterAccessDenied
 		}
@@ -106,7 +106,7 @@ func (s *AdapterAccessService) GetAdapterAccess(ctx context.Context, workspace *
 		if !granted {
 			return nil, domain.ErrAdapterAccessDenied
 		}
-	case domain.AdapterTypeSES:
+	case usesIdentityGrants(adapter.AdapterType):
 		if s.identityGrants == nil {
 			return nil, domain.ErrAdapterAccessDenied
 		}
@@ -124,7 +124,7 @@ func (s *AdapterAccessService) GetAdapterAccess(ctx context.Context, workspace *
 	return &AdapterAccess{Adapter: adapter, Shared: true, Editable: false, OwnerScope: owner}, nil
 }
 
-// ListIdentitiesForWorkspace returns all identities for owned/system scope and only granted emails for shared SES.
+// ListIdentitiesForWorkspace returns all identities for owned/system scope and only granted emails for identity-scoped adapters.
 func (s *AdapterAccessService) ListIdentitiesForWorkspace(ctx context.Context, workspace *domain.Workspace, adapterID uuid.UUID) ([]*domain.AdapterIdentity, error) {
 	if workspace == nil || workspace.IsSystem {
 		return s.identityStore.ListByAdapter(ctx, adapterID)
@@ -162,8 +162,8 @@ func (s *AdapterAccessService) ValidateTemplateTypeSelection(ctx context.Context
 		return domain.ErrAdapterAccessDenied
 	}
 
-	switch adapter.AdapterType {
-	case domain.AdapterTypeGmail:
+	switch {
+	case adapter.AdapterType == domain.AdapterTypeGmail:
 		granted, err := s.adapterGrants.HasAdapterWorkspaceGrant(ctx, adapter.ID, workspace.ID)
 		if err != nil {
 			return err
@@ -172,7 +172,7 @@ func (s *AdapterAccessService) ValidateTemplateTypeSelection(ctx context.Context
 			return domain.ErrAdapterAccessDenied
 		}
 		return s.validateSenderIdentity(ctx, adapter, senderIdentityID, nil)
-	case domain.AdapterTypeSES:
+	case usesIdentityGrants(adapter.AdapterType):
 		if senderIdentityID == nil {
 			return domain.ErrSenderIdentityRequired
 		}
@@ -225,7 +225,7 @@ func (s *AdapterAccessService) ReplaceAdapterWorkspaceAccess(ctx context.Context
 	return s.adapterGrants.ReplaceAdapterWorkspaceGrants(ctx, adapterID, validTargets)
 }
 
-// ReplaceIdentityWorkspaceAccess replaces the workspace grant set for a shared SES email identity.
+// ReplaceIdentityWorkspaceAccess replaces the workspace grant set for a shared email identity.
 func (s *AdapterAccessService) ReplaceIdentityWorkspaceAccess(ctx context.Context, systemWorkspace *domain.Workspace, adapterID, identityID uuid.UUID, workspaceIDs []uuid.UUID) error {
 	if systemWorkspace == nil || !systemWorkspace.IsSystem {
 		return fmt.Errorf("%w: identity grants can only be managed from _system", domain.ErrForbidden)
@@ -234,8 +234,8 @@ func (s *AdapterAccessService) ReplaceIdentityWorkspaceAccess(ctx context.Contex
 	if err != nil {
 		return err
 	}
-	if adapter.WorkspaceID == nil || *adapter.WorkspaceID != systemWorkspace.ID || adapter.AdapterType != domain.AdapterTypeSES {
-		return fmt.Errorf("%w: only system-owned ses adapters can share email identities", domain.ErrValidation)
+	if adapter.WorkspaceID == nil || *adapter.WorkspaceID != systemWorkspace.ID || !usesIdentityGrants(adapter.AdapterType) {
+		return fmt.Errorf("%w: only system-owned identity-scoped adapters can share email identities", domain.ErrValidation)
 	}
 	identity, err := s.identityStore.GetByID(ctx, identityID)
 	if err != nil {
@@ -283,7 +283,7 @@ func (s *AdapterAccessService) ListAdapterWorkspaceAccess(ctx context.Context, s
 	})
 }
 
-// ListIdentityWorkspaceAccess returns tenant workspaces and whether the SES email identity is granted to each one.
+// ListIdentityWorkspaceAccess returns tenant workspaces and whether the email identity is granted to each one.
 func (s *AdapterAccessService) ListIdentityWorkspaceAccess(ctx context.Context, systemWorkspace *domain.Workspace, adapterID, identityID uuid.UUID) ([]WorkspaceAccessGrant, error) {
 	if systemWorkspace == nil || !systemWorkspace.IsSystem {
 		return nil, fmt.Errorf("%w: identity grants can only be managed from _system", domain.ErrForbidden)
@@ -292,8 +292,8 @@ func (s *AdapterAccessService) ListIdentityWorkspaceAccess(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if adapter.WorkspaceID == nil || *adapter.WorkspaceID != systemWorkspace.ID || adapter.AdapterType != domain.AdapterTypeSES {
-		return nil, fmt.Errorf("%w: only system-owned ses adapters can share email identities", domain.ErrValidation)
+	if adapter.WorkspaceID == nil || *adapter.WorkspaceID != systemWorkspace.ID || !usesIdentityGrants(adapter.AdapterType) {
+		return nil, fmt.Errorf("%w: only system-owned identity-scoped adapters can share email identities", domain.ErrValidation)
 	}
 	identity, err := s.identityStore.GetByID(ctx, identityID)
 	if err != nil {
@@ -327,6 +327,10 @@ func (s *AdapterAccessService) validateSenderIdentity(ctx context.Context, adapt
 		}
 	}
 	return nil
+}
+
+func usesIdentityGrants(adapterType domain.AdapterType) bool {
+	return adapterType == domain.AdapterTypeSES || adapterType == domain.AdapterTypeSMTP
 }
 
 func workspaceEnvironment(workspace *domain.Workspace) domain.Environment {

--- a/internal/service/adapter_access_test.go
+++ b/internal/service/adapter_access_test.go
@@ -178,6 +178,83 @@ func TestAdapterAccessService_ValidateSelection_SharedSESRequiresGrantedEmailIde
 	}
 }
 
+func TestAdapterAccessService_ValidateSelection_SharedSMTPRequiresGrantedEmailIdentity(t *testing.T) {
+	systemWorkspaceID := uuid.Must(uuid.NewV7())
+	workspaceID := uuid.Must(uuid.NewV7())
+	adapterID := uuid.Must(uuid.NewV7())
+	identityID := uuid.Must(uuid.NewV7())
+
+	systemWorkspace := &domain.Workspace{ID: systemWorkspaceID, TenantID: uuid.Must(uuid.NewV7()), Code: "_system", IsSystem: true}
+	workspace := &domain.Workspace{ID: workspaceID, TenantID: systemWorkspace.TenantID, Code: "default"}
+
+	adapterStore := &mockAdapterStoreSend{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Adapter{
+				ID:          adapterID,
+				WorkspaceID: &systemWorkspaceID,
+				AdapterType: domain.AdapterTypeSMTP,
+				Name:        "SMTP Shared",
+			}, nil
+		},
+	}
+
+	identityStore := &mockAdapterIdentityStoreSend{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.AdapterIdentity, error) {
+			if id != identityID {
+				return nil, domain.ErrIdentityNotFound
+			}
+			return &domain.AdapterIdentity{
+				ID:           identityID,
+				AdapterID:    adapterID,
+				Identity:     "noreply-senda@tether.education",
+				IdentityType: domain.IdentityTypeEmail,
+				Status:       domain.IdentityStatusVerified,
+			}, nil
+		},
+	}
+
+	wsStore := &mockWorkspaceStoreSend{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Workspace, error) {
+			switch id {
+			case systemWorkspaceID:
+				return systemWorkspace, nil
+			case workspaceID:
+				return workspace, nil
+			default:
+				return nil, domain.ErrNotFound
+			}
+		},
+	}
+
+	identityGrants := &mockIdentityGrantStore{
+		hasIdentityWorkspaceGrantFn: func(_ context.Context, identity uuid.UUID, wsID uuid.UUID) (bool, error) {
+			return identity == identityID && wsID == workspaceID, nil
+		},
+	}
+
+	svc := service.NewAdapterAccessService(
+		adapterStore,
+		identityStore,
+		wsStore,
+		&mockAdapterGrantStore{},
+		identityGrants,
+		&mockTemplateTypeUsageStore{},
+	)
+
+	err := svc.ValidateTemplateTypeSelection(context.Background(), workspace, &adapterID, nil)
+	if !errors.Is(err, domain.ErrSenderIdentityRequired) {
+		t.Fatalf("expected ErrSenderIdentityRequired, got %v", err)
+	}
+
+	err = svc.ValidateTemplateTypeSelection(context.Background(), workspace, &adapterID, &identityID)
+	if err != nil {
+		t.Fatalf("expected shared SMTP selection to pass with granted email identity, got %v", err)
+	}
+}
+
 func TestAdapterAccessService_ValidateSelection_SharedGmailRequiresAdapterGrant(t *testing.T) {
 	systemWorkspaceID := uuid.Must(uuid.NewV7())
 	workspaceID := uuid.Must(uuid.NewV7())
@@ -300,6 +377,73 @@ func TestAdapterAccessService_ListIdentitiesForWorkspace_FiltersSharedSESIdentit
 	}
 }
 
+func TestAdapterAccessService_ListIdentitiesForWorkspace_FiltersSharedSMTPIdentities(t *testing.T) {
+	systemWorkspaceID := uuid.Must(uuid.NewV7())
+	workspaceID := uuid.Must(uuid.NewV7())
+	adapterID := uuid.Must(uuid.NewV7())
+
+	systemWorkspace := &domain.Workspace{ID: systemWorkspaceID, TenantID: uuid.Must(uuid.NewV7()), Code: "_system", IsSystem: true}
+	workspace := &domain.Workspace{ID: workspaceID, TenantID: systemWorkspace.TenantID, Code: "default"}
+
+	adapterStore := &mockAdapterStoreSend{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Adapter{
+				ID:          adapterID,
+				WorkspaceID: &systemWorkspaceID,
+				AdapterType: domain.AdapterTypeSMTP,
+				Name:        "SMTP Shared",
+			}, nil
+		},
+	}
+
+	wsStore := &mockWorkspaceStoreSend{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Workspace, error) {
+			switch id {
+			case systemWorkspaceID:
+				return systemWorkspace, nil
+			case workspaceID:
+				return workspace, nil
+			default:
+				return nil, domain.ErrNotFound
+			}
+		},
+	}
+
+	identityGrants := &mockIdentityGrantStore{
+		listGrantedIdentitiesFn: func(_ context.Context, adapter uuid.UUID, wsID uuid.UUID) ([]*domain.AdapterIdentity, error) {
+			if adapter != adapterID || wsID != workspaceID {
+				return nil, errors.New("unexpected grant lookup")
+			}
+			return []*domain.AdapterIdentity{
+				{ID: uuid.Must(uuid.NewV7()), AdapterID: adapterID, Identity: "noreply-senda@tether.education", IdentityType: domain.IdentityTypeEmail},
+			}, nil
+		},
+	}
+
+	svc := service.NewAdapterAccessService(
+		adapterStore,
+		&mockAdapterIdentityStoreSend{},
+		wsStore,
+		&mockAdapterGrantStore{},
+		identityGrants,
+		&mockTemplateTypeUsageStore{},
+	)
+
+	identities, err := svc.ListIdentitiesForWorkspace(context.Background(), workspace, adapterID)
+	if err != nil {
+		t.Fatalf("unexpected error listing shared SMTP identities: %v", err)
+	}
+	if len(identities) != 1 {
+		t.Fatalf("expected 1 granted identity, got %d", len(identities))
+	}
+	if identities[0].Identity != "noreply-senda@tether.education" {
+		t.Fatalf("expected granted identity noreply-senda@tether.education, got %q", identities[0].Identity)
+	}
+}
+
 func TestAdapterAccessService_ReplaceIdentityWorkspaceAccess_BlocksRevokeWhenInUse(t *testing.T) {
 	systemWorkspaceID := uuid.Must(uuid.NewV7())
 	workspaceID := uuid.Must(uuid.NewV7())
@@ -385,6 +529,62 @@ func TestAdapterAccessService_ReplaceIdentityWorkspaceAccess_BlocksRevokeWhenInU
 	err := svc.ReplaceIdentityWorkspaceAccess(context.Background(), systemWorkspace, adapterID, identityID, nil)
 	if !errors.Is(err, domain.ErrSharedGrantInUse) {
 		t.Fatalf("expected ErrSharedGrantInUse, got %v", err)
+	}
+}
+
+func TestAdapterAccessService_ReplaceIdentityWorkspaceAccess_AllowsSMTPEmailIdentity(t *testing.T) {
+	systemWorkspaceID := uuid.Must(uuid.NewV7())
+	workspaceID := uuid.Must(uuid.NewV7())
+	adapterID := uuid.Must(uuid.NewV7())
+	identityID := uuid.Must(uuid.NewV7())
+
+	systemWorkspace := &domain.Workspace{ID: systemWorkspaceID, TenantID: uuid.Must(uuid.NewV7()), Code: "_system", IsSystem: true}
+	workspace := &domain.Workspace{ID: workspaceID, TenantID: systemWorkspace.TenantID, Code: "default"}
+
+	var replacedTargets []uuid.UUID
+	svc := service.NewAdapterAccessService(
+		&mockAdapterStoreSend{
+			getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+				if id != adapterID {
+					return nil, domain.ErrNotFound
+				}
+				return &domain.Adapter{ID: adapterID, WorkspaceID: &systemWorkspaceID, AdapterType: domain.AdapterTypeSMTP}, nil
+			},
+		},
+		&mockAdapterIdentityStoreSend{
+			getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.AdapterIdentity, error) {
+				if id != identityID {
+					return nil, domain.ErrIdentityNotFound
+				}
+				return &domain.AdapterIdentity{ID: identityID, AdapterID: adapterID, Identity: "noreply-senda@tether.education", IdentityType: domain.IdentityTypeEmail}, nil
+			},
+		},
+		&mockWorkspaceStoreSend{
+			listByTenantFn: func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+				if tenantID != systemWorkspace.TenantID {
+					return nil, "", errors.New("unexpected tenant lookup")
+				}
+				return []*domain.Workspace{systemWorkspace, workspace}, "", nil
+			},
+		},
+		&mockAdapterGrantStore{},
+		&mockIdentityGrantStore{
+			replaceIdentityWorkspaceGrantsFn: func(_ context.Context, id uuid.UUID, workspaceIDs []uuid.UUID) error {
+				if id != identityID {
+					return errors.New("unexpected identity id")
+				}
+				replacedTargets = append([]uuid.UUID(nil), workspaceIDs...)
+				return nil
+			},
+		},
+		&mockTemplateTypeUsageStore{},
+	)
+
+	if err := svc.ReplaceIdentityWorkspaceAccess(context.Background(), systemWorkspace, adapterID, identityID, []uuid.UUID{workspaceID}); err != nil {
+		t.Fatalf("expected SMTP identity grant replacement to pass, got %v", err)
+	}
+	if len(replacedTargets) != 1 || replacedTargets[0] != workspaceID {
+		t.Fatalf("expected replace grants with workspace %s, got %v", workspaceID, replacedTargets)
 	}
 }
 
@@ -602,6 +802,61 @@ func TestAdapterAccessService_ListIdentityWorkspaceAccess_UsesSystemWorkspaceEnv
 	}
 	if listedEnvironment != domain.EnvironmentTest {
 		t.Fatalf("expected grant listing in test environment, got %s", listedEnvironment)
+	}
+	if len(grants) != 1 || grants[0].Workspace.ID != workspaceID || !grants[0].Granted {
+		t.Fatalf("expected granted workspace %s, got %+v", workspaceID, grants)
+	}
+}
+
+func TestAdapterAccessService_ListIdentityWorkspaceAccess_AllowsSMTPEmailIdentity(t *testing.T) {
+	systemWorkspaceID := uuid.Must(uuid.NewV7())
+	workspaceID := uuid.Must(uuid.NewV7())
+	adapterID := uuid.Must(uuid.NewV7())
+	identityID := uuid.Must(uuid.NewV7())
+
+	systemWorkspace := &domain.Workspace{ID: systemWorkspaceID, TenantID: uuid.Must(uuid.NewV7()), Code: "_system", IsSystem: true}
+	workspace := &domain.Workspace{ID: workspaceID, TenantID: systemWorkspace.TenantID, Code: "default", Name: "Default"}
+
+	svc := service.NewAdapterAccessService(
+		&mockAdapterStoreSend{
+			getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+				if id != adapterID {
+					return nil, domain.ErrNotFound
+				}
+				return &domain.Adapter{ID: adapterID, WorkspaceID: &systemWorkspaceID, AdapterType: domain.AdapterTypeSMTP}, nil
+			},
+		},
+		&mockAdapterIdentityStoreSend{
+			getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.AdapterIdentity, error) {
+				if id != identityID {
+					return nil, domain.ErrIdentityNotFound
+				}
+				return &domain.AdapterIdentity{ID: identityID, AdapterID: adapterID, Identity: "noreply-senda@tether.education", IdentityType: domain.IdentityTypeEmail}, nil
+			},
+		},
+		&mockWorkspaceStoreSend{
+			listByTenantFn: func(_ context.Context, tenantID uuid.UUID, _ domain.Environment, _ port.ListOptions) ([]*domain.Workspace, string, error) {
+				if tenantID != systemWorkspace.TenantID {
+					return nil, "", errors.New("unexpected tenant lookup")
+				}
+				return []*domain.Workspace{systemWorkspace, workspace}, "", nil
+			},
+		},
+		&mockAdapterGrantStore{},
+		&mockIdentityGrantStore{
+			listIdentityWorkspaceGrantsFn: func(_ context.Context, id uuid.UUID) ([]uuid.UUID, error) {
+				if id != identityID {
+					return nil, errors.New("unexpected identity id")
+				}
+				return []uuid.UUID{workspaceID}, nil
+			},
+		},
+		&mockTemplateTypeUsageStore{},
+	)
+
+	grants, err := svc.ListIdentityWorkspaceAccess(context.Background(), systemWorkspace, adapterID, identityID)
+	if err != nil {
+		t.Fatalf("expected SMTP identity grant listing to pass, got %v", err)
 	}
 	if len(grants) != 1 || grants[0].Workspace.ID != workspaceID || !grants[0].Granted {
 		t.Fatalf("expected granted workspace %s, got %+v", workspaceID, grants)

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -127,23 +127,30 @@ func (s *IdentityService) CreateManual(ctx context.Context, adapterID uuid.UUID,
 		return nil, fmt.Errorf("%w: invalid email address", domain.ErrValidation)
 	}
 
-	// Check that this email's domain exists as a verified domain identity
-	existing, err := s.identityStore.ListByAdapter(ctx, adapterID)
+	adapter, err := s.adapterStore.GetByID(ctx, adapterID)
 	if err != nil {
 		return nil, err
 	}
 
-	domainVerified := false
-	for _, ident := range existing {
-		if ident.IdentityType == domain.IdentityTypeDomain &&
-			ident.Identity == emailDomain &&
-			ident.Status == domain.IdentityStatusVerified {
-			domainVerified = true
-			break
+	if adapter.AdapterType != domain.AdapterTypeSMTP {
+		// Check that this email's domain exists as a verified domain identity.
+		existing, err := s.identityStore.ListByAdapter(ctx, adapterID)
+		if err != nil {
+			return nil, err
 		}
-	}
-	if !domainVerified {
-		return nil, fmt.Errorf("%w: domain %s is not verified in this adapter", domain.ErrIdentityNotInDomain, emailDomain)
+
+		domainVerified := false
+		for _, ident := range existing {
+			if ident.IdentityType == domain.IdentityTypeDomain &&
+				ident.Identity == emailDomain &&
+				ident.Status == domain.IdentityStatusVerified {
+				domainVerified = true
+				break
+			}
+		}
+		if !domainVerified {
+			return nil, fmt.Errorf("%w: domain %s is not verified in this adapter", domain.ErrIdentityNotInDomain, emailDomain)
+		}
 	}
 
 	now := time.Now().UTC()

--- a/internal/service/identity_factory_test.go
+++ b/internal/service/identity_factory_test.go
@@ -62,3 +62,38 @@ func TestIdentityService_SyncIdentities_UnsupportedAdapter(t *testing.T) {
 		t.Fatalf("expected unsupported-listing error, got %v", err)
 	}
 }
+
+func TestIdentityService_CreateManual_AllowsSMTPEmailWithoutProviderDomain(t *testing.T) {
+	adapterID := uuid.Must(uuid.NewV7())
+	adapterStore := &mockAdapterStoreSend{
+		getByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Adapter, error) {
+			if id != adapterID {
+				return nil, domain.ErrNotFound
+			}
+			return &domain.Adapter{ID: adapterID, AdapterType: domain.AdapterTypeSMTP}, nil
+		},
+	}
+	identityStore := &mockAdapterIdentityStoreSend{
+		createFn: func(_ context.Context, identity *domain.AdapterIdentity) error {
+			if identity.Identity != "noreply-senda@tether.education" {
+				t.Fatalf("identity = %q", identity.Identity)
+			}
+			if identity.IdentityType != domain.IdentityTypeEmail {
+				t.Fatalf("identity type = %q", identity.IdentityType)
+			}
+			if identity.Source != domain.IdentitySourceManual {
+				t.Fatalf("source = %q", identity.Source)
+			}
+			return nil
+		},
+	}
+	svc := service.NewIdentityService(identityStore, adapterStore, nil, nil)
+
+	identity, err := svc.CreateManual(context.Background(), adapterID, "noreply-senda@tether.education", nil)
+	if err != nil {
+		t.Fatalf("CreateManual() error = %v", err)
+	}
+	if identity.Identity != "noreply-senda@tether.education" {
+		t.Fatalf("identity = %q", identity.Identity)
+	}
+}

--- a/internal/service/send_test.go
+++ b/internal/service/send_test.go
@@ -461,12 +461,16 @@ func (m *mockInjectorStoreSend) GetAllValuesByDefinitions(_ context.Context, _ [
 }
 
 type mockAdapterIdentityStoreSend struct {
+	createFn        func(ctx context.Context, identity *domain.AdapterIdentity) error
 	getByIDFn       func(ctx context.Context, id uuid.UUID) (*domain.AdapterIdentity, error)
 	getDefaultFn    func(ctx context.Context, adapterID uuid.UUID) (*domain.AdapterIdentity, error)
 	listByAdapterFn func(ctx context.Context, adapterID uuid.UUID) ([]*domain.AdapterIdentity, error)
 }
 
-func (m *mockAdapterIdentityStoreSend) Create(_ context.Context, _ *domain.AdapterIdentity) error {
+func (m *mockAdapterIdentityStoreSend) Create(ctx context.Context, identity *domain.AdapterIdentity) error {
+	if m.createFn != nil {
+		return m.createFn(ctx, identity)
+	}
 	return nil
 }
 func (m *mockAdapterIdentityStoreSend) GetByID(ctx context.Context, id uuid.UUID) (*domain.AdapterIdentity, error) {

--- a/migrations/000047_add_smtp_adapter_type.down.sql
+++ b/migrations/000047_add_smtp_adapter_type.down.sql
@@ -1,0 +1,2 @@
+-- PostgreSQL cannot remove enum values safely without recreating dependent columns.
+-- Keep this migration irreversible; rolling back code should simply stop creating smtp adapters.

--- a/migrations/000047_add_smtp_adapter_type.up.sql
+++ b/migrations/000047_add_smtp_adapter_type.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE adapter_type ADD VALUE IF NOT EXISTS 'smtp';

--- a/skills/senda/SKILL.md
+++ b/skills/senda/SKILL.md
@@ -81,6 +81,7 @@ For the detailed model, load:
 - **Use `X-Senda-Environment` for external integration requests.**
 - **Runtime reset is test-only.** It is available only on the management environment-scoped test surface.
 - **Test recipient policies are test-only.** Do not assume they exist in prod.
+- **SMTP adapter config is relay-only.** Register full sender email addresses as adapter identities, then select/share those identities like SES email identities.
 
 ## MCP operating playbooks
 
@@ -182,6 +183,22 @@ Load this reference when implementing or reviewing embedder code:
 For detailed flow explanations, load:
 - `references/external-integration-flow.md`
 - `references/resolution-and-inheritance.md`
+
+### SMTP adapter flow
+
+SMTP is a first-class provider adapter, not only a Mailpit/dev fallback.
+
+1. Create an adapter with `adapter_type: "smtp"`.
+2. Configure relay connection fields only: `host`, `port`, `tls_mode`, optional `auth_mode`, optional `username` and `password`.
+3. Use `tls_mode` values `none`, `starttls`, or `implicit_tls`.
+4. Use `auth_mode` values `plain` or `login` when credentials are provided.
+5. Keep `username` and `password` together; one without the other is invalid.
+6. Do not put `from_email` or `from_name` in SMTP config.
+7. Register complete sender emails as manual adapter identities.
+8. Assign a sender identity to the template type or mark an adapter identity as default.
+9. For `_system` SMTP adapters, share at the email-identity level; child workspaces can use only granted SMTP identities.
+
+The frontend defaults SMTP `rate_limit_per_second` to `10`. Operators should adjust it to the real relay policy.
 
 ## Public contracts you must understand
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -333,7 +333,7 @@
     "deleteTemplateTypeAria": "Delete template type {slug}",
     "localTemplateTypesDisabled": "Local template types are disabled by the tenant _system workspace policy.",
     "defaultTemplateTypesReadonly": "Default template types are read-only in workspaces.",
-    "sharedSesRequiresIdentity": "Shared SES adapters require an explicit sender identity",
+    "sharedSesRequiresIdentity": "Shared SES/SMTP adapters require an explicit sender identity",
     "templateTypeCreated": "Template type created",
     "templateTypeCreateFailed": "Failed to create template type",
     "templateTypeDeleted": "Template type deleted",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -333,7 +333,7 @@
     "deleteTemplateTypeAria": "Eliminar template type {slug}",
     "localTemplateTypesDisabled": "Los template types locales están deshabilitados por la política del workspace _system del tenant.",
     "defaultTemplateTypesReadonly": "Los template types default son de solo lectura en workspaces.",
-    "sharedSesRequiresIdentity": "Los adapters SES compartidos requieren una identidad de envío explícita",
+    "sharedSesRequiresIdentity": "Los adapters SES/SMTP compartidos requieren una identidad de envío explícita",
     "templateTypeCreated": "Template type creado",
     "templateTypeCreateFailed": "No se pudo crear el template type",
     "templateTypeDeleted": "Template type eliminado",

--- a/web/src/components/adapters/adapter-capabilities.test.ts
+++ b/web/src/components/adapters/adapter-capabilities.test.ts
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  canTestSendAdapter,
+  getAdapterCapabilities,
+  shouldIncludeTestSendFrom,
+} = await import(new URL("./adapter-capabilities.ts", import.meta.url).href);
+
+test("smtp supports sender identities without provider sync or provisioning", () => {
+  assert.deepEqual(getAdapterCapabilities("smtp"), {
+    supportsIdentitySync: false,
+    supportsProvisioning: false,
+    supportsSenderSharing: true,
+    supportsAdapterSharing: false,
+    usesSenderIdentity: true,
+  });
+});
+
+test("provider adapters keep their existing capability split", () => {
+  assert.equal(getAdapterCapabilities("ses").supportsIdentitySync, true);
+  assert.equal(getAdapterCapabilities("ses").supportsProvisioning, true);
+  assert.equal(getAdapterCapabilities("ses").supportsSenderSharing, true);
+  assert.equal(getAdapterCapabilities("gmail").supportsIdentitySync, true);
+  assert.equal(getAdapterCapabilities("gmail").supportsAdapterSharing, true);
+  assert.equal(getAdapterCapabilities("gmail").supportsSenderSharing, false);
+});
+
+test("smtp and ses test sends require a verified email sender", () => {
+  assert.equal(canTestSendAdapter("smtp", []), false);
+  assert.equal(canTestSendAdapter("ses", []), false);
+  assert.equal(canTestSendAdapter("gmail", []), true);
+  assert.equal(
+    canTestSendAdapter("smtp", [
+      { identity_type: "email", status: "verified" },
+    ]),
+    true,
+  );
+});
+
+test("test send includes from for smtp and ses only", () => {
+  assert.equal(shouldIncludeTestSendFrom("smtp", "sender@example.com"), true);
+  assert.equal(shouldIncludeTestSendFrom("ses", "sender@example.com"), true);
+  assert.equal(shouldIncludeTestSendFrom("gmail", "sender@example.com"), false);
+  assert.equal(shouldIncludeTestSendFrom("smtp", ""), false);
+});

--- a/web/src/components/adapters/adapter-capabilities.ts
+++ b/web/src/components/adapters/adapter-capabilities.ts
@@ -1,0 +1,29 @@
+import type { AdapterIdentity, AdapterType } from "@/types/adapters";
+
+export function getAdapterCapabilities(type: AdapterType) {
+  return {
+    supportsIdentitySync: type === "ses" || type === "gmail",
+    supportsProvisioning: type === "ses",
+    supportsSenderSharing: type === "ses" || type === "smtp",
+    supportsAdapterSharing: type === "gmail",
+    usesSenderIdentity: type === "ses" || type === "smtp",
+  };
+}
+
+export function isVerifiedEmailIdentity(
+  identity: Pick<AdapterIdentity, "identity_type" | "status">,
+) {
+  return identity.identity_type === "email" && identity.status === "verified";
+}
+
+export function canTestSendAdapter(
+  type: AdapterType,
+  identities: Pick<AdapterIdentity, "identity_type" | "status">[],
+) {
+  return !getAdapterCapabilities(type).usesSenderIdentity ||
+    identities.some(isVerifiedEmailIdentity);
+}
+
+export function shouldIncludeTestSendFrom(type: AdapterType, from?: string) {
+  return getAdapterCapabilities(type).usesSenderIdentity && !!from;
+}

--- a/web/src/components/adapters/adapter-form.tsx
+++ b/web/src/components/adapters/adapter-form.tsx
@@ -36,6 +36,8 @@ import type {
   UpdateAdapterRequest,
   SesConfig,
   GmailConfig,
+  SmtpConfig,
+  SmtpTLSMode,
 } from "@/types/adapters";
 
 const SES_REGIONS = [
@@ -73,6 +75,10 @@ const ADAPTER_DEFAULTS: Record<AdapterType, { rateLimit: number; region?: string
     rateLimit: 2,
     description: "Gmail API with Workspace delegation supports ~2 emails/sec per delegated user.",
     docsUrl: "https://developers.google.com/gmail/api/reference/quota",
+  },
+  smtp: {
+    rateLimit: 10,
+    description: "SMTP relay rate limits depend on your provider or internal relay policy.",
   },
 };
 
@@ -124,6 +130,18 @@ export function AdapterForm(props: AdapterFormProps) {
     (isEdit && defaults?.config_meta?.delegate_email) || ""
   );
 
+  // SMTP fields
+  const [smtpHost, setSmtpHost] = useState((isEdit && defaults?.config_meta?.host) || "");
+  const [smtpPort, setSmtpPort] = useState((isEdit && defaults?.config_meta?.port) || "587");
+  const [smtpTLSMode, setSmtpTLSMode] = useState<SmtpTLSMode>(
+    ((isEdit && defaults?.config_meta?.tls_mode) as SmtpTLSMode | undefined) ?? "starttls"
+  );
+  const [smtpAuthMode, setSmtpAuthMode] = useState<"plain" | "login">(
+    ((isEdit && defaults?.config_meta?.auth_mode) as "plain" | "login" | undefined) ?? "plain"
+  );
+  const [smtpUsername, setSmtpUsername] = useState("");
+  const [smtpPassword, setSmtpPassword] = useState("");
+
   function resetForm() {
     if (!isEdit) {
       setName("");
@@ -136,9 +154,15 @@ export function AdapterForm(props: AdapterFormProps) {
     setSesSecretKey("");
     setGmailServiceAccountJSON("");
     setGmailDelegateEmail(isEdit ? defaults?.config_meta?.delegate_email ?? "" : "");
+    setSmtpHost(isEdit ? defaults?.config_meta?.host ?? "" : "");
+    setSmtpPort(isEdit ? defaults?.config_meta?.port ?? "587" : "587");
+    setSmtpTLSMode(((isEdit ? defaults?.config_meta?.tls_mode : undefined) as SmtpTLSMode | undefined) ?? "starttls");
+    setSmtpAuthMode(((isEdit ? defaults?.config_meta?.auth_mode : undefined) as "plain" | "login" | undefined) ?? "plain");
+    setSmtpUsername("");
+    setSmtpPassword("");
   }
 
-  function buildConfig(): (SesConfig | GmailConfig) | undefined {
+  function buildConfig(): (SesConfig | GmailConfig | SmtpConfig) | undefined {
     if (adapterType === "ses") {
       // In edit mode, only send config if user filled something
       if (isEdit && !sesRegion && !sesAccessKey && !sesSecretKey) return undefined;
@@ -147,13 +171,35 @@ export function AdapterForm(props: AdapterFormProps) {
         access_key_id: sesAccessKey,
         secret_access_key: sesSecretKey,
       };
-    } else {
+    }
+
+    if (adapterType === "gmail") {
       if (isEdit && !gmailServiceAccountJSON && !gmailDelegateEmail) return undefined;
       return {
         service_account_json: gmailServiceAccountJSON,
         delegate_email: gmailDelegateEmail,
       };
     }
+
+    const previous = defaults?.config_meta;
+    const smtpChanged =
+      smtpHost !== (previous?.host ?? "") ||
+      smtpPort !== (previous?.port ?? "587") ||
+      smtpTLSMode !== ((previous?.tls_mode as SmtpTLSMode | undefined) ?? "starttls") ||
+      smtpAuthMode !== ((previous?.auth_mode as "plain" | "login" | undefined) ?? "plain") ||
+      !!smtpUsername ||
+      !!smtpPassword;
+
+    if (isEdit && !smtpChanged) return undefined;
+
+    return {
+      host: smtpHost,
+      port: Number(smtpPort),
+      tls_mode: smtpTLSMode,
+      ...(smtpUsername || smtpPassword ? { auth_mode: smtpAuthMode } : {}),
+      ...(smtpUsername ? { username: smtpUsername } : {}),
+      ...(smtpPassword ? { password: smtpPassword } : {}),
+    };
   }
 
   // For SES create: submit button first validates, then creates on second click.
@@ -204,6 +250,9 @@ export function AdapterForm(props: AdapterFormProps) {
     if (!name.trim()) return false;
     if (adapterType === "ses") {
       return sesFieldsReady; // button enables when fields are filled (validate or create)
+    }
+    if (adapterType === "smtp") {
+      return !!(smtpHost.trim() && smtpPort.trim());
     }
     return !!(gmailServiceAccountJSON.trim() && gmailDelegateEmail.trim());
   })();
@@ -272,6 +321,7 @@ export function AdapterForm(props: AdapterFormProps) {
             <SelectContent>
               <SelectItem value="ses">SES (Amazon)</SelectItem>
               <SelectItem value="gmail">Gmail (Google)</SelectItem>
+              <SelectItem value="smtp">SMTP</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -325,10 +375,14 @@ export function AdapterForm(props: AdapterFormProps) {
 
         <div className="border-t pt-4">
           <p className="text-xs font-medium text-muted-foreground mb-3">
-            {adapterType === "ses" ? "AWS SES Configuration" : "Gmail Configuration"}
+            {adapterType === "ses"
+              ? "AWS SES Configuration"
+              : adapterType === "gmail"
+                ? "Gmail Configuration"
+                : "SMTP Configuration"}
           </p>
 
-          {adapterType === "ses" ? (
+          {adapterType === "ses" && (
             <div className="flex flex-col gap-3">
               {!isEdit && (
                 <details className="rounded-md border border-blue-500/30 bg-blue-500/5 text-xs group">
@@ -430,7 +484,9 @@ export function AdapterForm(props: AdapterFormProps) {
                 </div>
               )}
             </div>
-          ) : (
+          )}
+
+          {adapterType === "gmail" && (
             <div className="flex flex-col gap-3">
               <div className="flex flex-col gap-2">
                 <Label htmlFor="gmail-sa-json">Service Account JSON Key</Label>
@@ -460,6 +516,95 @@ export function AdapterForm(props: AdapterFormProps) {
                   className="font-mono"
                   required={!isEdit}
                 />
+              </div>
+            </div>
+          )}
+
+          {adapterType === "smtp" && (
+            <div className="flex flex-col gap-3">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="smtp-host">Host</Label>
+                  <Input
+                    id="smtp-host"
+                    value={smtpHost}
+                    onChange={(e) => setSmtpHost(e.target.value)}
+                    placeholder="smtp.example.com"
+                    className="font-mono"
+                    required={!isEdit}
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="smtp-port">Port</Label>
+                  <Input
+                    id="smtp-port"
+                    type="number"
+                    value={smtpPort}
+                    onChange={(e) => setSmtpPort(e.target.value)}
+                    placeholder="587"
+                    className="font-mono"
+                    required={!isEdit}
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label>Auth Mode</Label>
+                <Select
+                  value={smtpAuthMode}
+                  onValueChange={(v) => setSmtpAuthMode(v as "plain" | "login")}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="plain">PLAIN</SelectItem>
+                    <SelectItem value="login">LOGIN</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label>TLS Mode</Label>
+                <Select
+                  value={smtpTLSMode}
+                  onValueChange={(v) => setSmtpTLSMode(v as SmtpTLSMode)}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="starttls">STARTTLS</SelectItem>
+                    <SelectItem value="implicit_tls">Implicit TLS</SelectItem>
+                    <SelectItem value="none">None</SelectItem>
+                  </SelectContent>
+                </Select>
+                {smtpTLSMode === "none" && (
+                  <p className="text-xs text-amber-400">
+                    Plain SMTP sends without transport encryption. Use only for Mailpit, local testing, or trusted internal relays.
+                  </p>
+                )}
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="smtp-username">Username</Label>
+                  <Input
+                    id="smtp-username"
+                    value={smtpUsername}
+                    onChange={(e) => setSmtpUsername(e.target.value)}
+                    placeholder="user or API key"
+                    className="font-mono"
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="smtp-password">Password</Label>
+                  <Input
+                    id="smtp-password"
+                    type="password"
+                    value={smtpPassword}
+                    onChange={(e) => setSmtpPassword(e.target.value)}
+                    placeholder={isEdit ? "Leave empty to keep current" : "secret"}
+                    className="font-mono"
+                  />
+                </div>
               </div>
             </div>
           )}

--- a/web/src/components/adapters/adapter-form.tsx
+++ b/web/src/components/adapters/adapter-form.tsx
@@ -39,6 +39,11 @@ import type {
   SmtpConfig,
   SmtpTLSMode,
 } from "@/types/adapters";
+import {
+  buildSmtpConfig,
+  hasExistingSmtpAuth,
+  validateSmtpAuthFields,
+} from "./smtp-config-form-model";
 
 const SES_REGIONS = [
   { value: "us-east-1", label: "US East (N. Virginia)" },
@@ -101,6 +106,8 @@ interface AdapterFormEditProps {
 
 type AdapterFormProps = AdapterFormCreateProps | AdapterFormEditProps;
 
+// AdapterForm keeps provider-specific sections colocated with shared form state.
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export function AdapterForm(props: AdapterFormProps) {
   const isEdit = props.mode === "edit";
   const defaults = isEdit ? props.adapter : undefined;
@@ -141,6 +148,7 @@ export function AdapterForm(props: AdapterFormProps) {
   );
   const [smtpUsername, setSmtpUsername] = useState("");
   const [smtpPassword, setSmtpPassword] = useState("");
+  const [smtpClearAuth, setSmtpClearAuth] = useState(false);
 
   function resetForm() {
     if (!isEdit) {
@@ -160,6 +168,7 @@ export function AdapterForm(props: AdapterFormProps) {
     setSmtpAuthMode(((isEdit ? defaults?.config_meta?.auth_mode : undefined) as "plain" | "login" | undefined) ?? "plain");
     setSmtpUsername("");
     setSmtpPassword("");
+    setSmtpClearAuth(false);
   }
 
   function buildConfig(): (SesConfig | GmailConfig | SmtpConfig) | undefined {
@@ -181,33 +190,41 @@ export function AdapterForm(props: AdapterFormProps) {
       };
     }
 
-    const previous = defaults?.config_meta;
-    const smtpChanged =
-      smtpHost !== (previous?.host ?? "") ||
-      smtpPort !== (previous?.port ?? "587") ||
-      smtpTLSMode !== ((previous?.tls_mode as SmtpTLSMode | undefined) ?? "starttls") ||
-      smtpAuthMode !== ((previous?.auth_mode as "plain" | "login" | undefined) ?? "plain") ||
-      !!smtpUsername ||
-      !!smtpPassword;
-
-    if (isEdit && !smtpChanged) return undefined;
-
-    return {
+    return buildSmtpConfig({
       host: smtpHost,
-      port: Number(smtpPort),
-      tls_mode: smtpTLSMode,
-      ...(smtpUsername || smtpPassword ? { auth_mode: smtpAuthMode } : {}),
-      ...(smtpUsername ? { username: smtpUsername } : {}),
-      ...(smtpPassword ? { password: smtpPassword } : {}),
-    };
+      port: smtpPort,
+      tlsMode: smtpTLSMode,
+      authMode: smtpAuthMode,
+      username: smtpUsername,
+      password: smtpPassword,
+      isEdit,
+      clearAuth: smtpClearAuth,
+      previousConfig: defaults?.config_meta,
+    });
   }
 
   // For SES create: submit button first validates, then creates on second click.
   const sesFieldsReady = !!(sesRegion && sesAccessKey && sesSecretKey);
   const sesValidated = sesValidation?.valid === true;
   const needsValidation = !isEdit && adapterType === "ses" && sesFieldsReady && !sesValidated;
+  const smtpHasExistingAuth = isEdit && adapterType === "smtp" && hasExistingSmtpAuth(defaults?.config_meta);
+  const smtpAuthValidation =
+    adapterType === "smtp"
+      ? validateSmtpAuthFields({
+          username: smtpUsername,
+          password: smtpPassword,
+          isEdit,
+          hasExistingAuth: smtpHasExistingAuth,
+          clearAuth: smtpClearAuth,
+        })
+      : { valid: true as const };
+  const smtpAuthError = smtpAuthValidation.valid ? null : smtpAuthValidation.message;
 
   async function handleSubmit(): Promise<boolean | void> {
+    if (adapterType === "smtp" && !smtpAuthValidation.valid) {
+      return true;
+    }
+
     // SES create: first click validates, second click creates
     if (needsValidation) {
       await new Promise<void>((resolve, reject) => {
@@ -252,10 +269,11 @@ export function AdapterForm(props: AdapterFormProps) {
       return sesFieldsReady; // button enables when fields are filled (validate or create)
     }
     if (adapterType === "smtp") {
-      return !!(smtpHost.trim() && smtpPort.trim());
+      return !!(smtpHost.trim() && smtpPort.trim()) && !smtpAuthError;
     }
     return !!(gmailServiceAccountJSON.trim() && gmailDelegateEmail.trim());
   })();
+  const isFormReady = isEdit ? !smtpAuthError : isCreateReady;
 
   // Dynamic submit button label + icon
   const submitLabel = (() => {
@@ -287,7 +305,7 @@ export function AdapterForm(props: AdapterFormProps) {
       onSubmit={handleSubmit}
       open={isEdit ? props.open : undefined}
       onOpenChange={isEdit ? props.onOpenChange : undefined}
-      submitDisabled={!isCreateReady}
+      submitDisabled={!isFormReady}
     >
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
@@ -551,7 +569,10 @@ export function AdapterForm(props: AdapterFormProps) {
                 <Label>Auth Mode</Label>
                 <Select
                   value={smtpAuthMode}
-                  onValueChange={(v) => setSmtpAuthMode(v as "plain" | "login")}
+                  onValueChange={(v) => {
+                    setSmtpAuthMode(v as "plain" | "login");
+                    setSmtpClearAuth(false);
+                  }}
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue />
@@ -583,15 +604,53 @@ export function AdapterForm(props: AdapterFormProps) {
                   </p>
                 )}
               </div>
+              {smtpHasExistingAuth && (
+                <div className="flex items-center justify-between gap-3 rounded-md border border-dashed px-3 py-2 text-xs">
+                  <span className={smtpClearAuth ? "text-destructive" : "text-muted-foreground"}>
+                    {smtpClearAuth
+                      ? "Stored SMTP auth will be removed on update."
+                      : "Stored SMTP auth is configured."}
+                  </span>
+                  {smtpClearAuth ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => setSmtpClearAuth(false)}
+                    >
+                      Keep auth
+                    </Button>
+                  ) : (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => {
+                        setSmtpUsername("");
+                        setSmtpPassword("");
+                        setSmtpClearAuth(true);
+                      }}
+                    >
+                      Clear auth
+                    </Button>
+                  )}
+                </div>
+              )}
               <div className="grid grid-cols-2 gap-3">
                 <div className="flex flex-col gap-2">
                   <Label htmlFor="smtp-username">Username</Label>
                   <Input
                     id="smtp-username"
                     value={smtpUsername}
-                    onChange={(e) => setSmtpUsername(e.target.value)}
+                    onChange={(e) => {
+                      setSmtpUsername(e.target.value);
+                      setSmtpClearAuth(false);
+                    }}
                     placeholder="user or API key"
                     className="font-mono"
+                    aria-invalid={smtpAuthError ? true : undefined}
                   />
                 </div>
                 <div className="flex flex-col gap-2">
@@ -600,12 +659,19 @@ export function AdapterForm(props: AdapterFormProps) {
                     id="smtp-password"
                     type="password"
                     value={smtpPassword}
-                    onChange={(e) => setSmtpPassword(e.target.value)}
+                    onChange={(e) => {
+                      setSmtpPassword(e.target.value);
+                      setSmtpClearAuth(false);
+                    }}
                     placeholder={isEdit ? "Leave empty to keep current" : "secret"}
                     className="font-mono"
+                    aria-invalid={smtpAuthError ? true : undefined}
                   />
                 </div>
               </div>
+              {smtpAuthError && (
+                <p className="text-xs text-destructive">{smtpAuthError}</p>
+              )}
             </div>
           )}
         </div>

--- a/web/src/components/adapters/adapter-type-badge.tsx
+++ b/web/src/components/adapters/adapter-type-badge.tsx
@@ -54,6 +54,15 @@ function GmailIcon({ className }: { className?: string }) {
   );
 }
 
+function SmtpIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
+      <path d="M2 4h10v6H2z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+      <path d="M4 2h6M4 12h6M7 2v2M7 10v2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 const typeConfig: Record<AdapterType, { label: string; textColor: string; bgColor: string; icon: ReactNode }> = {
   ses: {
     label: "SES",
@@ -66,6 +75,12 @@ const typeConfig: Record<AdapterType, { label: string; textColor: string; bgColo
     textColor: "text-adapter-gmail",
     bgColor: "bg-adapter-gmail-bg",
     icon: <GmailIcon className="h-3.5 w-3.5" />,
+  },
+  smtp: {
+    label: "SMTP",
+    textColor: "text-cyan-300",
+    bgColor: "bg-cyan-500/10",
+    icon: <SmtpIcon className="h-3.5 w-3.5" />,
   },
 };
 

--- a/web/src/components/adapters/adapters-content.tsx
+++ b/web/src/components/adapters/adapters-content.tsx
@@ -18,6 +18,12 @@ import { EmptyState } from "@/components/shared/empty-state";
 import { ScopeIndicator } from "@/components/shared/scope-indicator";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
 import { AdapterTypeBadge } from "./adapter-type-badge";
+import {
+  canTestSendAdapter,
+  getAdapterCapabilities,
+  isVerifiedEmailIdentity,
+  shouldIncludeTestSendFrom,
+} from "./adapter-capabilities";
 import { AdapterForm } from "./adapter-form";
 import { ProvisioningStepper } from "./provisioning-stepper";
 import { IdentityPanel } from "./identity-panel";
@@ -42,7 +48,7 @@ import {
   SYSTEM_WORKSPACE_SCOPE_LABEL,
 } from "@/lib/system-workspace-display";
 import type { ColumnDef } from "@tanstack/react-table";
-import type { Adapter, AdapterIdentity, CreateAdapterRequest } from "@/types/adapters";
+import type { Adapter, CreateAdapterRequest } from "@/types/adapters";
 import { useIdentityList } from "@/hooks/use-identities";
 import {
   Select,
@@ -53,9 +59,6 @@ import {
 } from "@/components/ui/select";
 import { TrackingStatus } from "./tracking-status";
 import { DefaultSender } from "./default-sender";
-
-const isVerifiedEmail = (i: AdapterIdentity) =>
-  i.identity_type === "email" && i.status === "verified";
 
 export function AdaptersContent() {
   return <AdaptersTable />;
@@ -227,7 +230,7 @@ function AdaptersTable() {
           <EmptyState
             icon={Plug}
             title="No adapters configured"
-            description="Add an email adapter (SES or Gmail) to start sending emails from this scope."
+            description="Add an email adapter (SES, Gmail, or SMTP) to start sending emails from this scope."
             action={
               <AdapterForm
                 trigger={
@@ -327,14 +330,13 @@ function AdapterActions({
   onIdentities: (a: Adapter) => void;
   onShare: (a: Adapter) => void;
 }) {
+  const capabilities = getAdapterCapabilities(adapter.adapter_type);
   const { data: identities } = useIdentityList(
     scopedPath,
-    adapter.adapter_type === "ses" ? adapter.id : "",
+    capabilities.usesSenderIdentity ? adapter.id : "",
   );
 
-  const hasVerifiedSender =
-    adapter.adapter_type !== "ses" ||
-    (identities ?? []).some(isVerifiedEmail);
+  const hasVerifiedSender = canTestSendAdapter(adapter.adapter_type, identities ?? []);
 
   const readOnlyReason = adapter.is_shared
     ? `Shared from ${SYSTEM_WORKSPACE_SCOPE_LABEL} — read only in this workspace`
@@ -368,9 +370,9 @@ function AdapterActions({
 
   return (
     <div className="flex items-center justify-end gap-1">
-      {adapter.adapter_type === "ses" &&
+      {capabilities.supportsSenderSharing &&
         actionButton({ label: "Senders", icon: <Mail className="h-4 w-4" />, onClick: () => onIdentities(adapter) })}
-      {isSystemWorkspace && adapter.adapter_type === "gmail" &&
+      {isSystemWorkspace && capabilities.supportsAdapterSharing &&
         actionButton({ label: "Workspace access", icon: <Share2 className="h-4 w-4" />, onClick: () => onShare(adapter) })}
       {actionButton({ label: "Edit", icon: <Pencil className="h-4 w-4" />, onClick: () => onEdit(adapter), disabled: !adapter.is_editable })}
       {actionButton({
@@ -530,9 +532,10 @@ function TestSendDialog({
 
   const { data: identities } = useIdentityList(scopedPath, adapter.id);
   const verifiedEmails = useMemo(
-    () => (identities ?? []).filter(isVerifiedEmail),
+    () => (identities ?? []).filter(isVerifiedEmailIdentity),
     [identities],
   );
+  const usesSenderIdentity = getAdapterCapabilities(adapter.adapter_type).usesSenderIdentity;
 
   const defaultFrom =
     verifiedEmails.find((i) => i.is_default)?.identity ??
@@ -547,7 +550,7 @@ function TestSendDialog({
         to,
         subject,
         body,
-        ...(adapter.adapter_type === "ses" && from ? { from } : {}),
+        ...(shouldIncludeTestSendFrom(adapter.adapter_type, from) ? { from } : {}),
       },
       { onSuccess: () => onOpenChange(false) },
     );
@@ -575,7 +578,7 @@ function TestSendDialog({
                 required
               />
             </div>
-            {adapter.adapter_type === "ses" && (
+            {usesSenderIdentity && (
               <div className="flex flex-col gap-2">
                 <Label htmlFor="test-from">Send From</Label>
                 <Select value={from} onValueChange={setSelectedFrom} required>

--- a/web/src/components/adapters/email-address-policy.test.ts
+++ b/web/src/components/adapters/email-address-policy.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { normalizeReasonableEmailAddress } = await import(
+  new URL("./email-address-policy.ts", import.meta.url).href
+);
+
+test("normalizes valid sender email addresses", () => {
+  assert.equal(
+    normalizeReasonableEmailAddress(" sender@example.com "),
+    "sender@example.com",
+  );
+});
+
+test("rejects malformed sender email addresses", () => {
+  assert.equal(normalizeReasonableEmailAddress("sender"), null);
+  assert.equal(normalizeReasonableEmailAddress("sender@example"), null);
+  assert.equal(normalizeReasonableEmailAddress("sender@@example.com"), null);
+  assert.equal(normalizeReasonableEmailAddress("sender example@example.com"), null);
+});

--- a/web/src/components/adapters/email-address-policy.ts
+++ b/web/src/components/adapters/email-address-policy.ts
@@ -1,0 +1,7 @@
+const REASONABLE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function normalizeReasonableEmailAddress(value: string) {
+  const email = value.trim();
+  if (!REASONABLE_EMAIL_PATTERN.test(email)) return null;
+  return email;
+}

--- a/web/src/components/adapters/identity-panel.tsx
+++ b/web/src/components/adapters/identity-panel.tsx
@@ -44,6 +44,7 @@ import { SYSTEM_WORKSPACE_SCOPE_LABEL } from "@/lib/system-workspace-display";
 import type { Adapter, AdapterIdentity } from "@/types/adapters";
 import { useWorkspacesManagement } from "@/hooks/use-workspaces-mgmt";
 import { getAdapterCapabilities } from "./adapter-capabilities";
+import { normalizeReasonableEmailAddress } from "./email-address-policy";
 
 const STATUS_STYLES: Record<string, { className: string; label: string }> = {
   verified: { className: "bg-emerald-500/15 text-emerald-500 border-emerald-500/30", label: "Verified" },
@@ -283,10 +284,12 @@ function ManualEmailAddInput({
   const [email, setEmail] = useState("");
   const [displayName, setDisplayName] = useState("");
   const create = useCreateIdentity(scopedPath, adapterId);
+  const normalizedEmail = normalizeReasonableEmailAddress(email);
+  const emailError = email.trim() && !normalizedEmail ? "Enter a valid email address." : null;
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const identity = email.trim();
+    const identity = normalizeReasonableEmailAddress(email);
     const name = displayName.trim();
     if (!identity) return;
     create.mutate(
@@ -303,11 +306,16 @@ function ManualEmailAddInput({
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-2 rounded-md border border-dashed p-3">
       <input
+        type="email"
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         placeholder="no-reply@example.com"
+        aria-invalid={emailError ? true : undefined}
         className="h-8 rounded-md border bg-transparent px-2 text-xs font-mono"
       />
+      {emailError && (
+        <p className="text-xs text-destructive">{emailError}</p>
+      )}
       <input
         value={displayName}
         onChange={(e) => setDisplayName(e.target.value)}
@@ -317,7 +325,7 @@ function ManualEmailAddInput({
       <Button
         type="submit"
         size="sm"
-        disabled={disabled || !email.trim() || create.isPending}
+        disabled={disabled || !normalizedEmail || create.isPending}
       >
         {create.isPending ? (
           <Loader2 className="h-3 w-3 animate-spin" />

--- a/web/src/components/adapters/identity-panel.tsx
+++ b/web/src/components/adapters/identity-panel.tsx
@@ -43,6 +43,7 @@ import { cn } from "@/lib/utils";
 import { SYSTEM_WORKSPACE_SCOPE_LABEL } from "@/lib/system-workspace-display";
 import type { Adapter, AdapterIdentity } from "@/types/adapters";
 import { useWorkspacesManagement } from "@/hooks/use-workspaces-mgmt";
+import { getAdapterCapabilities } from "./adapter-capabilities";
 
 const STATUS_STYLES: Record<string, { className: string; label: string }> = {
   verified: { className: "bg-emerald-500/15 text-emerald-500 border-emerald-500/30", label: "Verified" },
@@ -270,6 +271,64 @@ function DomainAddInput({
   );
 }
 
+function ManualEmailAddInput({
+  adapterId,
+  scopedPath,
+  disabled,
+}: {
+  adapterId: string;
+  scopedPath: string;
+  disabled?: boolean;
+}) {
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const create = useCreateIdentity(scopedPath, adapterId);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const identity = email.trim();
+    const name = displayName.trim();
+    if (!identity) return;
+    create.mutate(
+      { identity, ...(name ? { display_name: name } : {}) },
+      {
+        onSuccess: () => {
+          setEmail("");
+          setDisplayName("");
+        },
+      },
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 rounded-md border border-dashed p-3">
+      <input
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="no-reply@example.com"
+        className="h-8 rounded-md border bg-transparent px-2 text-xs font-mono"
+      />
+      <input
+        value={displayName}
+        onChange={(e) => setDisplayName(e.target.value)}
+        placeholder="Display name"
+        className="h-8 rounded-md border bg-transparent px-2 text-xs"
+      />
+      <Button
+        type="submit"
+        size="sm"
+        disabled={disabled || !email.trim() || create.isPending}
+      >
+        {create.isPending ? (
+          <Loader2 className="h-3 w-3 animate-spin" />
+        ) : (
+          "Add sender"
+        )}
+      </Button>
+    </form>
+  );
+}
+
 function DomainTree({
   domainIdentity,
   childEmails,
@@ -353,6 +412,7 @@ export function IdentityPanel({
   const scope = useScope();
   const isSystemWorkspace = scope.workspaceCode === SYSTEM_WORKSPACE_CODE;
   const isReadOnly = !adapter.is_editable;
+  const capabilities = getAdapterCapabilities(adapter.adapter_type);
   const [deleteTarget, setDeleteTarget] = useState<AdapterIdentity | null>(null);
   const [shareTarget, setShareTarget] = useState<AdapterIdentity | null>(null);
 
@@ -386,10 +446,12 @@ export function IdentityPanel({
           <DialogHeader className="shrink-0">
             <DialogTitle>Sender Identities — {adapter.name}</DialogTitle>
             <DialogDescription>
-              Verified domains and sender addresses. Add emails under each domain.
+              {adapter.adapter_type === "smtp"
+                ? "Manual SMTP sender email addresses. Add the full sender address before assigning templates or sending tests."
+                : "Verified domains and sender addresses. Add emails under each domain."}
             </DialogDescription>
             <div className="pt-1">
-              {adapter.is_editable ? (
+              {adapter.is_editable && capabilities.supportsIdentitySync ? (
                 <Button
                   variant="outline"
                   size="sm"
@@ -400,27 +462,44 @@ export function IdentityPanel({
                   <RefreshCw className={cn("h-3.5 w-3.5", sync.isPending && "animate-spin")} />
                   Sync from provider
                 </Button>
-              ) : (
+              ) : !adapter.is_editable ? (
                 <div className="inline-flex items-center gap-2 rounded-md bg-scope-system-bg px-2.5 py-1 text-xs text-scope-system">
                   <Lock className="h-3.5 w-3.5" />
                   {`Shared from ${SYSTEM_WORKSPACE_SCOPE_LABEL} — read only`}
                 </div>
-              )}
+              ) : null}
             </div>
           </DialogHeader>
 
           <div className="overflow-y-auto min-h-0 -mx-6 px-6 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-muted-foreground/15 hover:[&::-webkit-scrollbar-thumb]:bg-muted-foreground/30 [&::-webkit-scrollbar-thumb]:rounded-full">
+            {adapter.adapter_type === "smtp" && adapter.is_editable && (
+              <div className="pb-4">
+                <ManualEmailAddInput
+                  adapterId={adapter.id}
+                  scopedPath={scopedPath}
+                  disabled={isBusy}
+                />
+              </div>
+            )}
             {isLoading ? (
               <div className="flex items-center justify-center py-12">
                 <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
               </div>
             ) : domains.length === 0 && orphanEmails.length === 0 ? (
               <div className="flex flex-col items-center gap-3 py-10 text-center">
-                <Globe className="h-8 w-8 text-muted-foreground/30" />
+                {adapter.adapter_type === "smtp" ? (
+                  <Mail className="h-8 w-8 text-muted-foreground/30" />
+                ) : (
+                  <Globe className="h-8 w-8 text-muted-foreground/30" />
+                )}
                 <div>
-                  <p className="text-sm font-medium">No domains found</p>
+                  <p className="text-sm font-medium">
+                    {adapter.adapter_type === "smtp" ? "No sender emails found" : "No domains found"}
+                  </p>
                   <p className="text-xs text-muted-foreground mt-1">
-                    Click &quot;Sync from provider&quot; to import verified domains from SES.
+                    {adapter.adapter_type === "smtp"
+                      ? "Add a full SMTP sender email address manually."
+                      : "Click \"Sync from provider\" to import verified domains from SES."}
                   </p>
                 </div>
               </div>
@@ -463,7 +542,7 @@ export function IdentityPanel({
         open={!!deleteTarget}
         onOpenChange={(open) => !open && setDeleteTarget(null)}
         title="Remove Identity"
-        description={`Remove "${deleteTarget?.identity}" from this adapter? This only removes the local reference — the identity remains in your AWS account.`}
+        description={`Remove "${deleteTarget?.identity}" from this adapter? This only removes the local sender reference.`}
         confirmLabel="Remove"
         onConfirm={() => {
           if (deleteTarget) {
@@ -538,7 +617,7 @@ function IdentityWorkspaceAccessDialog({
         <DialogHeader>
           <DialogTitle>Workspace access — {identity.identity}</DialogTitle>
           <DialogDescription>
-            Choose which workspaces can use this SES sender identity.
+            Choose which workspaces can use this sender identity.
           </DialogDescription>
         </DialogHeader>
         <div className="flex max-h-[50vh] flex-col gap-3 overflow-y-auto py-2">

--- a/web/src/components/adapters/smtp-config-form-model.test.ts
+++ b/web/src/components/adapters/smtp-config-form-model.test.ts
@@ -1,0 +1,147 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  buildSmtpConfig,
+  hasExistingSmtpAuth,
+  validateSmtpAuthFields,
+} = await import(new URL("./smtp-config-form-model.ts", import.meta.url).href);
+
+const SMTP_HOST = "smtp.example.com";
+const SMTP_PORT = "587";
+const SMTP_TLS_MODE = "starttls";
+const SMTP_AUTH_MODE = "plain";
+const EXISTING_AUTH_CONFIG = {
+  host: SMTP_HOST,
+  port: SMTP_PORT,
+  tls_mode: SMTP_TLS_MODE,
+  auth_mode: SMTP_AUTH_MODE,
+};
+
+test("smtp auth validation requires username and password together on create", () => {
+  assert.equal(
+    validateSmtpAuthFields({
+      username: "apikey",
+      password: "",
+      isEdit: false,
+      hasExistingAuth: false,
+      clearAuth: false,
+    }).valid,
+    false,
+  );
+
+  assert.equal(
+    validateSmtpAuthFields({
+      username: "",
+      password: "secret",
+      isEdit: false,
+      hasExistingAuth: false,
+      clearAuth: false,
+    }).valid,
+    false,
+  );
+});
+
+test("smtp auth validation preserves existing password when username is supplied in edit mode", () => {
+  assert.equal(
+    validateSmtpAuthFields({
+      username: "apikey",
+      password: "",
+      isEdit: true,
+      hasExistingAuth: true,
+      clearAuth: false,
+    }).valid,
+    true,
+  );
+});
+
+test("smtp config builder omits auth fields when editing non-auth settings", () => {
+  assert.deepEqual(
+    buildSmtpConfig({
+      host: "smtp-new.example.com",
+      port: "587",
+      tlsMode: "starttls",
+      authMode: "plain",
+      username: "",
+      password: "",
+      isEdit: true,
+      clearAuth: false,
+      previousConfig: {
+        ...EXISTING_AUTH_CONFIG,
+      },
+    }),
+    {
+      host: "smtp-new.example.com",
+      port: Number(SMTP_PORT),
+      tls_mode: SMTP_TLS_MODE,
+    },
+  );
+});
+
+test("smtp config builder sends explicit empty username to clear existing auth", () => {
+  assert.deepEqual(
+    buildSmtpConfig({
+      host: SMTP_HOST,
+      port: SMTP_PORT,
+      tlsMode: SMTP_TLS_MODE,
+      authMode: SMTP_AUTH_MODE,
+      username: "",
+      password: "",
+      isEdit: true,
+      clearAuth: true,
+      previousConfig: EXISTING_AUTH_CONFIG,
+    }),
+    {
+      host: SMTP_HOST,
+      port: Number(SMTP_PORT),
+      tls_mode: SMTP_TLS_MODE,
+      username: "",
+    },
+  );
+});
+
+test("smtp config builder preserves password when edit username is non-empty and password is blank", () => {
+  assert.deepEqual(
+    buildSmtpConfig({
+      host: SMTP_HOST,
+      port: SMTP_PORT,
+      tlsMode: SMTP_TLS_MODE,
+      authMode: "login",
+      username: "apikey",
+      password: "",
+      isEdit: true,
+      clearAuth: false,
+      previousConfig: EXISTING_AUTH_CONFIG,
+    }),
+    {
+      host: SMTP_HOST,
+      port: Number(SMTP_PORT),
+      tls_mode: SMTP_TLS_MODE,
+      auth_mode: "login",
+      username: "apikey",
+    },
+  );
+});
+
+test("smtp config builder returns undefined when edit smtp config is unchanged", () => {
+  assert.equal(
+    buildSmtpConfig({
+      host: SMTP_HOST,
+      port: SMTP_PORT,
+      tlsMode: SMTP_TLS_MODE,
+      authMode: SMTP_AUTH_MODE,
+      username: "",
+      password: "",
+      isEdit: true,
+      clearAuth: false,
+      previousConfig: EXISTING_AUTH_CONFIG,
+    }),
+    undefined,
+  );
+});
+
+test("smtp auth metadata is detected from public config metadata", () => {
+  assert.equal(hasExistingSmtpAuth({ auth_mode: "plain" }), true);
+  assert.equal(hasExistingSmtpAuth({}), false);
+  assert.equal(hasExistingSmtpAuth(undefined), false);
+});

--- a/web/src/components/adapters/smtp-config-form-model.ts
+++ b/web/src/components/adapters/smtp-config-form-model.ts
@@ -1,0 +1,95 @@
+import type { SmtpConfig, SmtpTLSMode } from "@/types/adapters";
+
+type SmtpAuthMode = NonNullable<SmtpConfig["auth_mode"]>;
+type SmtpConfigMeta = Partial<Record<"host" | "port" | "tls_mode" | "auth_mode", string>>;
+
+type SmtpAuthValidationParams = {
+  username: string;
+  password: string;
+  isEdit: boolean;
+  hasExistingAuth: boolean;
+  clearAuth: boolean;
+};
+
+type BuildSmtpConfigParams = {
+  host: string;
+  port: string;
+  tlsMode: SmtpTLSMode;
+  authMode: SmtpAuthMode;
+  username: string;
+  password: string;
+  isEdit: boolean;
+  clearAuth: boolean;
+  previousConfig?: SmtpConfigMeta;
+};
+
+export function hasExistingSmtpAuth(config: SmtpConfigMeta | undefined) {
+  return !!config?.auth_mode;
+}
+
+export function validateSmtpAuthFields({
+  username,
+  password,
+  isEdit,
+  hasExistingAuth,
+  clearAuth,
+}: SmtpAuthValidationParams):
+  | { valid: true }
+  | { valid: false; message: string } {
+  if (clearAuth) return { valid: true };
+
+  const cleanedUsername = username.trim();
+  const cleanedPassword = password.trim();
+
+  if (!cleanedUsername && !cleanedPassword) return { valid: true };
+  if (cleanedUsername && cleanedPassword) return { valid: true };
+  if (isEdit && hasExistingAuth && cleanedUsername && !cleanedPassword) {
+    return { valid: true };
+  }
+
+  return {
+    valid: false,
+    message: "SMTP username and password must be provided together.",
+  };
+}
+
+export function buildSmtpConfig({
+  host,
+  port,
+  tlsMode,
+  authMode,
+  username,
+  password,
+  isEdit,
+  clearAuth,
+  previousConfig,
+}: BuildSmtpConfigParams): SmtpConfig | undefined {
+  const cleanedHost = host.trim();
+  const cleanedPort = port.trim();
+  const cleanedUsername = username.trim();
+  const cleanedPassword = password.trim();
+  const previousHost = previousConfig?.host ?? "";
+  const previousPort = previousConfig?.port ?? "587";
+  const previousTLSMode = (previousConfig?.tls_mode as SmtpTLSMode | undefined) ?? "starttls";
+  const previousAuthMode = (previousConfig?.auth_mode as SmtpAuthMode | undefined) ?? "plain";
+  const smtpChanged =
+    cleanedHost !== previousHost ||
+    cleanedPort !== previousPort ||
+    tlsMode !== previousTLSMode ||
+    authMode !== previousAuthMode ||
+    !!cleanedUsername ||
+    !!cleanedPassword ||
+    clearAuth;
+
+  if (isEdit && !smtpChanged) return undefined;
+
+  return {
+    host: cleanedHost,
+    port: Number(cleanedPort),
+    tls_mode: tlsMode,
+    ...(clearAuth ? { username: "" } : {}),
+    ...(!clearAuth && (cleanedUsername || cleanedPassword) ? { auth_mode: authMode } : {}),
+    ...(!clearAuth && cleanedUsername ? { username: cleanedUsername } : {}),
+    ...(!clearAuth && cleanedPassword ? { password: cleanedPassword } : {}),
+  };
+}

--- a/web/src/components/layout/header.tsx
+++ b/web/src/components/layout/header.tsx
@@ -74,17 +74,7 @@ export function AppHeader({
       </div>
       <div className="flex items-center gap-2">
         {scope.level === "workspace" ? (
-          <div className="flex items-center gap-2 rounded-full border bg-background px-1 py-1">
-            <span
-              className={cn(
-                "rounded-full px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.08em]",
-                environment === "prod"
-                  ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-200"
-                  : "bg-amber-100 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200",
-              )}
-            >
-              {environment}
-            </span>
+          <div className="flex items-center gap-1 rounded-full border bg-background px-1 py-1">
             <div className="flex items-center gap-1">
               {(["prod", "test"] as const).map((option) => (
                 <button

--- a/web/src/components/templates/empty-media-placeholder.test.ts
+++ b/web/src/components/templates/empty-media-placeholder.test.ts
@@ -76,6 +76,20 @@ test("resolveSrcForMjml valid URL is returned directly", () => {
   assert.equal(resolveSrcForMjml(url, "image"), url);
 });
 
+test("resolveSrcForMjml ignores percentage width for placeholders", () => {
+  const result = resolveSrcForMjml("", "video", "100%");
+  const decoded = decodePlaceholder(result);
+  assert.ok(decoded.includes('width="600"'), `Missing default width 600`);
+  assert.ok(decoded.includes('height="340"'), `Missing default height 340`);
+});
+
+test("resolveSrcForMjml respects fixed pixel width for placeholders", () => {
+  const result = resolveSrcForMjml("", "video", "320px");
+  const decoded = decodePlaceholder(result);
+  assert.ok(decoded.includes('width="320"'), `Missing width 320`);
+  assert.ok(decoded.includes('height="340"'), `Missing height 340`);
+});
+
 test("resolveSrcForMjml never calls placeholder when token present", () => {
   const token = "{{ injector.user.avatar }}";
   const result = resolveSrcForMjml(token, "image");

--- a/web/src/components/templates/empty-media-placeholder.ts
+++ b/web/src/components/templates/empty-media-placeholder.ts
@@ -8,6 +8,13 @@ const TOKEN_PATTERN = /\{\{[^}]+\}\}/;
 const DEFAULT_IMAGE_PLACEHOLDER = buildPlaceholderUri("No image", DEFAULT_IMAGE_WIDTH, DEFAULT_IMAGE_HEIGHT);
 const DEFAULT_VIDEO_PLACEHOLDER = buildPlaceholderUri("No video", DEFAULT_VIDEO_WIDTH, DEFAULT_VIDEO_HEIGHT);
 
+function parseFixedPixelWidth(widthStr?: string): number | undefined {
+  if (!widthStr) return undefined;
+  const trimmed = widthStr.trim();
+  if (!/^\d+(?:px)?$/i.test(trimmed)) return undefined;
+  return Number.parseInt(trimmed, 10) || undefined;
+}
+
 function buildPlaceholderUri(label: string, width: number, height: number): string {
   const svg =
     `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
@@ -47,7 +54,7 @@ export function resolveSrcForMjml(
     return raw;
   }
   if (!raw.trim()) {
-    const width = widthStr ? Number.parseInt(widthStr, 10) || undefined : undefined;
+    const width = parseFixedPixelWidth(widthStr);
     return emptyMediaPlaceholder(kind, width ? { width } : undefined);
   }
   return raw;

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -3757,10 +3757,10 @@ export function MjmlEditor({
             </div>
           </div>
           <div className="flex items-center gap-2.5">
-            <div className="flex items-center gap-1 rounded-md border bg-background h-8 px-1">
+            <div className="flex h-9 items-center rounded-md border bg-background">
               <button
                 type="button"
-                className={`px-2 h-6 rounded-sm font-mono text-[11px] font-medium transition-colors ${
+                className={`h-full px-2.5 font-mono text-[11px] font-medium transition-colors ${
                   activeLocale === "default"
                     ? LOCALE_ACTIVE_CLASS
                     : LOCALE_INACTIVE_CLASS
@@ -3774,7 +3774,7 @@ export function MjmlEditor({
                 <div key={loc.locale} className="relative group flex items-center">
                   <button
                     type="button"
-                    className={`px-2 h-6 rounded-sm font-mono text-[11px] font-medium transition-colors ${
+                    className={`h-full px-2.5 font-mono text-[11px] font-medium transition-colors ${
                       activeLocale === loc.locale
                         ? LOCALE_ACTIVE_CLASS
                         : LOCALE_INACTIVE_CLASS
@@ -3804,7 +3804,7 @@ export function MjmlEditor({
                   <PopoverTrigger asChild>
                     <button
                       type="button"
-                      className={`h-6 w-6 flex items-center justify-center rounded-sm ${LOCALE_INACTIVE_CLASS} transition-colors`}
+                      className={`flex h-full w-8 items-center justify-center rounded-none ${LOCALE_INACTIVE_CLASS} transition-colors`}
                     >
                       <Plus className="h-3.5 w-3.5" />
                     </button>
@@ -3820,9 +3820,9 @@ export function MjmlEditor({
               )}
             </div>
 
-            <div className="flex items-center gap-1 rounded-md border bg-background">
+            <div className="flex h-9 items-center overflow-hidden rounded-md border bg-background">
               <button
-                className={`h-8 px-2.5 text-xs ${
+                className={`h-full px-2.5 text-xs ${
                   editorMode === "visual"
                     ? LOCALE_ACTIVE_CLASS
                     : "text-muted-foreground hover:text-foreground"
@@ -3833,7 +3833,7 @@ export function MjmlEditor({
                 <Paintbrush className="h-3.5 w-3.5" />
               </button>
               <button
-                className={`h-8 px-2.5 text-xs ${
+                className={`h-full px-2.5 text-xs ${
                   editorMode === "code"
                     ? LOCALE_ACTIVE_CLASS
                     : "text-muted-foreground hover:text-foreground"

--- a/web/src/components/templates/sender-identity-policy.test.ts
+++ b/web/src/components/templates/sender-identity-policy.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  adapterUsesSenderIdentity,
+  requiresExplicitSenderIdentity,
+} = await import(new URL("./sender-identity-policy.ts", import.meta.url).href);
+
+test("ses and smtp adapters use sender identities", () => {
+  assert.equal(adapterUsesSenderIdentity({ adapter_type: "ses" }), true);
+  assert.equal(adapterUsesSenderIdentity({ adapter_type: "smtp" }), true);
+  assert.equal(adapterUsesSenderIdentity({ adapter_type: "gmail" }), false);
+  assert.equal(adapterUsesSenderIdentity(undefined), false);
+});
+
+test("shared ses and smtp adapters require explicit sender identity", () => {
+  assert.equal(
+    requiresExplicitSenderIdentity({ adapter_type: "ses", is_shared: true }),
+    true,
+  );
+  assert.equal(
+    requiresExplicitSenderIdentity({ adapter_type: "smtp", is_shared: true }),
+    true,
+  );
+  assert.equal(
+    requiresExplicitSenderIdentity({ adapter_type: "smtp", is_shared: false }),
+    false,
+  );
+  assert.equal(
+    requiresExplicitSenderIdentity({ adapter_type: "gmail", is_shared: true }),
+    false,
+  );
+});

--- a/web/src/components/templates/sender-identity-policy.test.ts
+++ b/web/src/components/templates/sender-identity-policy.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 const {
   adapterUsesSenderIdentity,
   requiresExplicitSenderIdentity,
+  resolveTemplateTypeSenderIdentityId,
 } = await import(new URL("./sender-identity-policy.ts", import.meta.url).href);
 
 test("ses and smtp adapters use sender identities", () => {
@@ -30,4 +31,21 @@ test("shared ses and smtp adapters require explicit sender identity", () => {
     requiresExplicitSenderIdentity({ adapter_type: "gmail", is_shared: true }),
     false,
   );
+});
+
+test("template type update serializes cleared sender identity as an explicit empty string", () => {
+  assert.equal(
+    resolveTemplateTypeSenderIdentityId("", { clearWithEmptyString: true }),
+    "",
+  );
+  assert.equal(
+    resolveTemplateTypeSenderIdentityId("__default__", { clearWithEmptyString: true }),
+    "",
+  );
+});
+
+test("template type create omits blank/default sender identity", () => {
+  assert.equal(resolveTemplateTypeSenderIdentityId(""), undefined);
+  assert.equal(resolveTemplateTypeSenderIdentityId("__default__"), undefined);
+  assert.equal(resolveTemplateTypeSenderIdentityId(" sender-id "), "sender-id");
 });

--- a/web/src/components/templates/sender-identity-policy.ts
+++ b/web/src/components/templates/sender-identity-policy.ts
@@ -1,5 +1,7 @@
 import type { AdapterType } from "@/types/adapters";
 
+export const SENDER_DEFAULT_VALUE = "__default__";
+
 type SenderIdentityAdapter = {
   adapter_type: AdapterType;
   is_shared?: boolean;
@@ -11,4 +13,15 @@ export function adapterUsesSenderIdentity(adapter: SenderIdentityAdapter | undef
 
 export function requiresExplicitSenderIdentity(adapter: SenderIdentityAdapter | undefined) {
   return adapterUsesSenderIdentity(adapter) && adapter?.is_shared === true;
+}
+
+export function resolveTemplateTypeSenderIdentityId(
+  value: string | undefined,
+  options: { clearWithEmptyString?: boolean } = {},
+) {
+  const normalized = value?.trim() ?? "";
+  if (!normalized || normalized === SENDER_DEFAULT_VALUE) {
+    return options.clearWithEmptyString ? "" : undefined;
+  }
+  return normalized;
 }

--- a/web/src/components/templates/sender-identity-policy.ts
+++ b/web/src/components/templates/sender-identity-policy.ts
@@ -1,0 +1,14 @@
+import type { AdapterType } from "@/types/adapters";
+
+type SenderIdentityAdapter = {
+  adapter_type: AdapterType;
+  is_shared?: boolean;
+};
+
+export function adapterUsesSenderIdentity(adapter: SenderIdentityAdapter | undefined) {
+  return adapter?.adapter_type === "ses" || adapter?.adapter_type === "smtp";
+}
+
+export function requiresExplicitSenderIdentity(adapter: SenderIdentityAdapter | undefined) {
+  return adapterUsesSenderIdentity(adapter) && adapter?.is_shared === true;
+}

--- a/web/src/components/templates/template-types-content.tsx
+++ b/web/src/components/templates/template-types-content.tsx
@@ -53,6 +53,10 @@ import {
 import type { TemplateType } from "@/types/templates";
 import type { Adapter } from "@/types/adapters";
 import { toast } from "sonner";
+import {
+  adapterUsesSenderIdentity,
+  requiresExplicitSenderIdentity,
+} from "./sender-identity-policy";
 
 const SENDER_DEFAULT = "__default__";
 const SENDER_NONE = "__none__";
@@ -279,7 +283,7 @@ function TemplateTypesTable() {
     if (!newSlug.trim() || !newName.trim()) return;
     try {
       const selectedAdapter = adapters.find((adapter) => adapter.id === newAdapterId);
-      if (selectedAdapter?.adapter_type === "ses" && selectedAdapter.is_shared && !newSenderIdentityId) {
+      if (requiresExplicitSenderIdentity(selectedAdapter) && !newSenderIdentityId) {
         toast.error(t("sharedSesRequiresIdentity"));
         return;
       }
@@ -562,8 +566,8 @@ function EditTemplateTypeDialog({
 
     try {
       const selectedAdapter = adapters.find((adapter) => adapter.id === adapterId);
-      if (selectedAdapter?.adapter_type === "ses" && selectedAdapter.is_shared && !senderIdentityId) {
-        toast.error("Shared SES adapters require an explicit sender identity");
+      if (requiresExplicitSenderIdentity(selectedAdapter) && !senderIdentityId) {
+        toast.error("Shared SES/SMTP adapters require an explicit sender identity");
         return true;
       }
       const senderIdValue = senderIdentityId && senderIdentityId !== SENDER_DEFAULT ? senderIdentityId : "";
@@ -773,8 +777,8 @@ function AdapterSelect({
 }) {
   const scopedPath = useScopedPath();
   const selectedAdapter = adapters.find((a) => a.id === value);
-  const showIdentitySelect = !!selectedAdapter && selectedAdapter.adapter_type === "ses";
-  const requireExplicitSender = !!selectedAdapter && selectedAdapter.adapter_type === "ses" && selectedAdapter.is_shared;
+  const showIdentitySelect = adapterUsesSenderIdentity(selectedAdapter);
+  const requireExplicitSender = requiresExplicitSenderIdentity(selectedAdapter);
 
   return (
     <div className="flex flex-col gap-3">
@@ -859,7 +863,7 @@ function SenderIdentitySelect({
       </Select>
       <p className="text-xs text-muted-foreground">
         {requireExplicitSender
-          ? "Shared SES adapters require an explicit granted sender identity."
+          ? "Shared SES/SMTP adapters require an explicit granted sender identity."
           : "Choose which email address to send from. Add senders in the adapter&apos;s identity panel."}
       </p>
     </div>

--- a/web/src/components/templates/template-types-content.tsx
+++ b/web/src/components/templates/template-types-content.tsx
@@ -56,9 +56,11 @@ import { toast } from "sonner";
 import {
   adapterUsesSenderIdentity,
   requiresExplicitSenderIdentity,
+  resolveTemplateTypeSenderIdentityId,
+  SENDER_DEFAULT_VALUE,
 } from "./sender-identity-policy";
 
-const SENDER_DEFAULT = "__default__";
+const SENDER_DEFAULT = SENDER_DEFAULT_VALUE;
 const SENDER_NONE = "__none__";
 const TEST_RECIPIENT_INHERIT = "__inherit__";
 const SLUG_WARNING_LINES = [
@@ -287,7 +289,7 @@ function TemplateTypesTable() {
         toast.error(t("sharedSesRequiresIdentity"));
         return;
       }
-      const senderIdValue = newSenderIdentityId && newSenderIdentityId !== SENDER_DEFAULT ? newSenderIdentityId : undefined;
+      const senderIdValue = resolveTemplateTypeSenderIdentityId(newSenderIdentityId);
       const payload: Parameters<typeof createMutation.mutateAsync>[0] = {
         slug: newSlug.trim(),
         name: newName.trim(),
@@ -570,12 +572,14 @@ function EditTemplateTypeDialog({
         toast.error("Shared SES/SMTP adapters require an explicit sender identity");
         return true;
       }
-      const senderIdValue = senderIdentityId && senderIdentityId !== SENDER_DEFAULT ? senderIdentityId : "";
+      const senderIdValue = resolveTemplateTypeSenderIdentityId(senderIdentityId, {
+        clearWithEmptyString: true,
+      });
       const payload: Parameters<typeof updateMutation.mutateAsync>[0] = {
         name: name.trim(),
         slug: slug.trim(),
         adapter_id: adapterId || undefined,
-        sender_identity_id: senderIdValue || undefined,
+        sender_identity_id: senderIdValue,
       };
       if (isTestEnvironment) {
         if (testRecipientMode === TEST_RECIPIENT_INHERIT) {

--- a/web/src/hooks/use-environment-mode.ts
+++ b/web/src/hooks/use-environment-mode.ts
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { applyEnvironmentSearchParam, normalizeEnvironment } from "@/lib/environment-mode";
+import { normalizeEnvironment, resolveEnvironmentSwitchPath } from "@/lib/environment-mode";
 import type { Environment } from "@/types/api";
 
 export function useEnvironmentMode() {
@@ -14,7 +14,7 @@ export function useEnvironmentMode() {
   const setEnvironment = useCallback(
     (nextEnvironment: Environment) => {
       const currentPath = `${pathname}${searchParams.toString() ? `?${searchParams.toString()}` : ""}`;
-      router.replace(applyEnvironmentSearchParam(currentPath, nextEnvironment));
+      router.replace(resolveEnvironmentSwitchPath(currentPath, nextEnvironment));
     },
     [pathname, router, searchParams],
   );

--- a/web/src/lib/environment-mode.test.ts
+++ b/web/src/lib/environment-mode.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   applyEnvironmentSearchParam,
   normalizeEnvironment,
+  resolveEnvironmentSwitchPath,
 } from "./environment-mode.ts";
 
 test("normalizeEnvironment defaults invalid values to prod", () => {
@@ -24,6 +25,16 @@ test("applyEnvironmentSearchParam preserves query params and hash", () => {
 test("applyEnvironmentSearchParam overwrites the previous environment value", () => {
   assert.equal(
     applyEnvironmentSearchParam("/t/acme/w/marketing?environment=prod", "test"),
+    "/t/acme/w/marketing?environment=test",
+  );
+});
+
+test("resolveEnvironmentSwitchPath returns workspace dashboard on environment change", () => {
+  assert.equal(
+    resolveEnvironmentSwitchPath(
+      "/t/acme/w/marketing/templates/welcome/edit?templateId=123&versionId=456&environment=prod#preview",
+      "test",
+    ),
     "/t/acme/w/marketing?environment=test",
   );
 });

--- a/web/src/lib/environment-mode.ts
+++ b/web/src/lib/environment-mode.ts
@@ -17,3 +17,18 @@ export function applyEnvironmentSearchParam(
   url.searchParams.set("environment", normalized);
   return `${url.pathname}${url.search}${url.hash}`;
 }
+
+export function resolveEnvironmentSwitchPath(
+  path: string,
+  environment?: string | null,
+): string {
+  const normalized = normalizeEnvironment(environment);
+  const url = new URL(path, "https://local");
+  const match = url.pathname.match(/^\/t\/([^/]+)\/w\/([^/]+)/);
+
+  if (!match) {
+    return applyEnvironmentSearchParam(path, normalized);
+  }
+
+  return applyEnvironmentSearchParam(`/t/${match[1]}/w/${match[2]}`, normalized);
+}

--- a/web/src/types/adapters.ts
+++ b/web/src/types/adapters.ts
@@ -1,5 +1,6 @@
 /** Adapter types */
-export type AdapterType = "ses" | "gmail";
+export type AdapterType = "ses" | "gmail" | "smtp";
+export type SmtpTLSMode = "none" | "starttls" | "implicit_tls";
 
 /** Adapter record */
 export interface Adapter {
@@ -31,11 +32,21 @@ export interface GmailConfig {
   delegate_email: string;
 }
 
+/** SMTP adapter config (relay-only; sender identities are separate records) */
+export interface SmtpConfig {
+  host: string;
+  port: number;
+  tls_mode: SmtpTLSMode;
+  auth_mode?: "plain" | "login";
+  username?: string;
+  password?: string;
+}
+
 /** Create adapter request */
 export interface CreateAdapterRequest {
   name: string;
   adapter_type: AdapterType;
-  config: SesConfig | GmailConfig;
+  config: SesConfig | GmailConfig | SmtpConfig;
   is_default?: boolean;
   rate_limit_per_second?: number;
 }
@@ -43,7 +54,7 @@ export interface CreateAdapterRequest {
 /** Update adapter request */
 export interface UpdateAdapterRequest {
   name?: string;
-  config?: SesConfig | GmailConfig;
+  config?: SesConfig | GmailConfig | SmtpConfig;
   is_default?: boolean;
   rate_limit_per_second?: number;
 }


### PR DESCRIPTION
## Summary
- Add SMTP as a first-class adapter with plain/authenticated relay config, TLS modes, and encrypted credential handling.
- Expose SMTP in the adapters UI, including validation, sender identities, test sends, and template-type sender selection.
- Fix environment switching so prod/test changes return to the workspace dashboard, and ensure template test-send uses the assigned adapter config.
- Document SMTP operations in the Senda skill and project docs.

## Validation
- make lint
- make vet
- make test
- corepack pnpm --dir web typecheck
- corepack pnpm --dir web lint
- corepack pnpm --dir web test
- make ci-taxonomy-check
- UI E2E: created SMTP adapter, added sender identity, sent adapter test email, assigned adapter/sender to a template type, created draft, and sent template test email from the editor.