### PR TITLE
fix(template-types): apply description and variable_schema on PUT

### DIFF
--- a/internal/adapter/postgres/template_repo.go
+++ b/internal/adapter/postgres/template_repo.go
@@ -64,7 +64,9 @@ func (r *TemplateRepo) CreateType(ctx context.Context, tt *domain.TemplateType) 
 func (r *TemplateRepo) UpdateType(ctx context.Context, tt *domain.TemplateType) error {
 	row := r.pool.QueryRow(ctx,
 		`UPDATE template_types
-		 SET slug = @slug, name = @name, adapter_id = @adapter_id, sender_identity_id = @sender_identity_id,
+		 SET slug = @slug, name = @name, description = @description,
+		     adapter_id = @adapter_id, sender_identity_id = @sender_identity_id,
+		     variable_schema = @variable_schema,
 		     test_recipient_mode = @test_recipient_mode, test_recipient_addresses = @test_recipient_addresses,
 		     updated_at = now()
 		 WHERE id = @id AND deleted_at IS NULL
@@ -73,8 +75,10 @@ func (r *TemplateRepo) UpdateType(ctx context.Context, tt *domain.TemplateType) 
 			"id":                       tt.ID,
 			"slug":                     tt.Slug,
 			"name":                     tt.Name,
+			"description":              tt.Description,
 			"adapter_id":               tt.AdapterID,
 			"sender_identity_id":       tt.SenderIdentityID,
+			"variable_schema":          coalesceJSON(tt.VariableSchema),
 			"test_recipient_mode":      tt.TestRecipientMode,
 			"test_recipient_addresses": domain.NormalizeRecipientAddresses(tt.TestRecipientAddresses),
 		},

--- a/internal/adapter/postgres/template_repo_test.go
+++ b/internal/adapter/postgres/template_repo_test.go
@@ -358,6 +358,63 @@ func TestTemplateRepo_UpdateType_UpdatesSlugAndName(t *testing.T) {
 	}
 }
 
+func TestTemplateRepo_UpdateType_PersistsDescriptionAndVariableSchema(t *testing.T) {
+	ctx := context.Background()
+	pool := setupTestDB(ctx, t)
+	repo := pgadapter.NewTemplateRepo(pool)
+
+	originalDesc := "original"
+	tt := &domain.TemplateType{
+		ID:             uuid.New(),
+		Slug:           "vs-update-" + uuid.New().String()[:8],
+		Name:           "VS Update",
+		Description:    &originalDesc,
+		VariableSchema: map[string]any{"type": "object"},
+	}
+	if err := repo.CreateType(ctx, tt); err != nil {
+		t.Fatalf("CreateType() error: %v", err)
+	}
+
+	newDesc := "rewritten"
+	tt.Description = &newDesc
+	tt.VariableSchema = map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"unsubscribe_url": map[string]any{"type": "string"},
+		},
+	}
+	if err := repo.UpdateType(ctx, tt); err != nil {
+		t.Fatalf("UpdateType() error: %v", err)
+	}
+
+	got, err := repo.FindTypeBySlugInScope(ctx, tt.Slug, nil)
+	if err != nil {
+		t.Fatalf("FindTypeBySlugInScope() error: %v", err)
+	}
+	if got.Description == nil || *got.Description != "rewritten" {
+		t.Fatalf("expected updated description %q, got %v", "rewritten", got.Description)
+	}
+	props, ok := got.VariableSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected variable_schema.properties to be a map, got %T", got.VariableSchema["properties"])
+	}
+	if _, hasUnsubscribe := props["unsubscribe_url"]; !hasUnsubscribe {
+		t.Fatalf("expected variable_schema to include unsubscribe_url, got %v", props)
+	}
+
+	tt.Description = nil
+	if err := repo.UpdateType(ctx, tt); err != nil {
+		t.Fatalf("UpdateType() error clearing description: %v", err)
+	}
+	got, err = repo.FindTypeBySlugInScope(ctx, tt.Slug, nil)
+	if err != nil {
+		t.Fatalf("FindTypeBySlugInScope() error: %v", err)
+	}
+	if got.Description != nil {
+		t.Fatalf("expected description cleared, got %q", *got.Description)
+	}
+}
+
 // --- Template tests ---
 
 func TestTemplateRepo_CreateTemplate(t *testing.T) {

--- a/internal/http/handler/template_type.go
+++ b/internal/http/handler/template_type.go
@@ -309,6 +309,21 @@ func applyTemplateTypeUpdateRequest(tt *domain.TemplateType, req request.UpdateT
 	if req.Name != nil {
 		tt.Name = *req.Name
 	}
+	if req.Description != nil {
+		if *req.Description == "" {
+			tt.Description = nil
+		} else {
+			desc := *req.Description
+			tt.Description = &desc
+		}
+	}
+	if req.VariableSchema != nil {
+		var schema map[string]any
+		if err := json.Unmarshal(*req.VariableSchema, &schema); err != nil {
+			return "variable_schema", err
+		}
+		tt.VariableSchema = schema
+	}
 	if req.AdapterID != nil {
 		if *req.AdapterID == "" {
 			tt.AdapterID = nil

--- a/internal/http/handler/template_type_test.go
+++ b/internal/http/handler/template_type_test.go
@@ -740,6 +740,137 @@ func TestTemplateTypeHandler_Update_Success(t *testing.T) {
 	}
 }
 
+func TestTemplateTypeHandler_Update_AppliesDescriptionAndVariableSchema(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+	ttID := uuid.Must(uuid.NewV7())
+	originalDesc := "old description"
+	original := &domain.TemplateType{
+		ID:          ttID,
+		WorkspaceID: &ws.ID,
+		Slug:        "welcome-email",
+		Name:        "Welcome Email",
+		Description: &originalDesc,
+		VariableSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"name": map[string]any{"type": "string"}},
+		},
+	}
+
+	var updated *domain.TemplateType
+	store := &mockTemplateStore{
+		getTypeBySlugFn: func(_ context.Context, _ string, _ []uuid.NullUUID) (*domain.TemplateType, error) {
+			return original, nil
+		},
+		updateTypeFn: func(_ context.Context, tt *domain.TemplateType) error {
+			updated = tt
+			return nil
+		},
+	}
+	e, _ := setupTemplateTypeTest(store, ts, wsStore)
+
+	body := `{
+		"description": "new description",
+		"variable_schema": {
+			"type": "object",
+			"properties": {
+				"name": {"type": "string"},
+				"unsubscribe_url": {"type": "string", "format": "uri"}
+			},
+			"required": ["name"]
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/default/template-types/welcome-email", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if updated == nil {
+		t.Fatal("expected updated template type")
+	}
+	if updated.Description == nil || *updated.Description != "new description" {
+		t.Fatalf("expected updated description %q, got %v", "new description", updated.Description)
+	}
+	props, ok := updated.VariableSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected variable_schema.properties to be a map, got %T", updated.VariableSchema["properties"])
+	}
+	if _, hasUnsubscribe := props["unsubscribe_url"]; !hasUnsubscribe {
+		t.Fatalf("expected variable_schema to include unsubscribe_url, got %v", props)
+	}
+}
+
+func TestTemplateTypeHandler_Update_ClearsDescriptionWhenEmptyString(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+	ttID := uuid.Must(uuid.NewV7())
+	originalDesc := "old description"
+	original := &domain.TemplateType{
+		ID:          ttID,
+		WorkspaceID: &ws.ID,
+		Slug:        "welcome-email",
+		Name:        "Welcome Email",
+		Description: &originalDesc,
+	}
+
+	var updated *domain.TemplateType
+	store := &mockTemplateStore{
+		getTypeBySlugFn: func(_ context.Context, _ string, _ []uuid.NullUUID) (*domain.TemplateType, error) {
+			return original, nil
+		},
+		updateTypeFn: func(_ context.Context, tt *domain.TemplateType) error {
+			updated = tt
+			return nil
+		},
+	}
+	e, _ := setupTemplateTypeTest(store, ts, wsStore)
+
+	body := `{"description": ""}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/default/template-types/welcome-email", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if updated == nil {
+		t.Fatal("expected updated template type")
+	}
+	if updated.Description != nil {
+		t.Fatalf("expected description to be cleared, got %q", *updated.Description)
+	}
+}
+
+func TestTemplateTypeHandler_Update_RejectsInvalidVariableSchemaJSON(t *testing.T) {
+	_, ws, ts, wsStore := testTenantAndWorkspace()
+	ttID := uuid.Must(uuid.NewV7())
+	original := &domain.TemplateType{
+		ID:          ttID,
+		WorkspaceID: &ws.ID,
+		Slug:        "welcome-email",
+		Name:        "Welcome Email",
+	}
+
+	store := &mockTemplateStore{
+		getTypeBySlugFn: func(_ context.Context, _ string, _ []uuid.NullUUID) (*domain.TemplateType, error) {
+			return original, nil
+		},
+	}
+	e, _ := setupTemplateTypeTest(store, ts, wsStore)
+
+	body := `{"variable_schema": "not-an-object"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/manage/tenants/acme/workspaces/default/template-types/welcome-email", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestTemplateTypeHandler_Update_InvalidSlug(t *testing.T) {
 	_, ws, ts, wsStore := testTenantAndWorkspace()
 	ttID := uuid.Must(uuid.NewV7())


### PR DESCRIPTION
## Summary

- Handler now applies `description` and `variable_schema` from `UpdateTemplateTypeRequest` (`internal/http/handler/template_type.go`).
- `UpdateType` SQL in the postgres adapter writes both columns (`internal/adapter/postgres/template_repo.go`).

Without both fixes the PR would be a no-op end to end: the handler change alone wouldn't reach the DB, and the SQL change alone wouldn't be triggered by any caller.

Closes #105

## Test plan

- [x] Unit: 3 new handler tests (`internal/http/handler/template_type_test.go`)
  - `TestTemplateTypeHandler_Update_AppliesDescriptionAndVariableSchema` — round-trip both fields through the HTTP handler
  - `TestTemplateTypeHandler_Update_ClearsDescriptionWhenEmptyString` — `""` clears nullable description
  - `TestTemplateTypeHandler_Update_RejectsInvalidVariableSchemaJSON` — 422 on malformed JSON
- [x] Integration: 1 new repo test (`internal/adapter/postgres/template_repo_test.go`, build tag `integration`)
  - `TestTemplateRepo_UpdateType_PersistsDescriptionAndVariableSchema` — verifies both fields persist after `UpdateType` and that nil description clears the column
- [x] `go test ./internal/http/handler/ ./internal/service/ -count=1` → 513 passed
- [x] `go build -tags=integration ./internal/adapter/postgres/` clean
- [x] `go vet -tags=integration ./internal/adapter/postgres/` clean
- [ ] `make test-integration` (TestContainers required, run pre-merge)

## Notes

- The handler block deliberately has no null-clear path for `variable_schema`: Echo's JSON binder maps `"variable_schema": null` to a nil `*json.RawMessage`, indistinguishable from field absent. Adding sentinel handling would require a custom request type and is out of scope. Description clears via the existing convention (empty string), consistent with sibling fields in the same function.
- No cache-invalidation change needed: `invalidateResolvedTemplates` is already called unconditionally after every successful update (`template_type.go:252`).
- Reviewed by Codex (independent pass).