### PR TITLE
fix(template-editor): preserve body_mjml when visual builder cannot represent it

### DIFF
--- a/docs/superpowers/specs/2026-04-29-mjml-pre-submit-validator-design.md
+++ b/docs/superpowers/specs/2026-04-29-mjml-pre-submit-validator-design.md
@@ -1,0 +1,138 @@
+# MJML Pre-Submit Validator — Design
+
+**Date:** 2026-04-29
+**Status:** Approved (brainstorming) — pending implementation plan
+**Owner:** rendis
+
+## Problem
+
+An agent operating Senda via Claude Code authored a template body that wrapped MJML inside an HTML document scaffold (`<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`) placed inside `<mj-raw>`. The save succeeded, but the runtime browser/MJML-XML parser failed:
+
+> XML Parsing Error: not well-formed
+> Line Number 3, Column 3
+
+Root cause: the agent did not internalize that MJML *compiles into* HTML, so wrapping MJML in HTML is double-wrapping. The skill (`skills/senda/references/building-a-template.md`) lists `mj-raw` as a supported tag without an explicit anti-pattern, and the agent inferred (incorrectly) that `mj-raw` accepts a full HTML document.
+
+There is no enforcement gate between "agent composes MJML" and "agent submits via API". Senda's `POST .../preview-mjml` would have caught the problem, but the skill treats it as recommended, not mandatory.
+
+## Goal
+
+Make the reported class of error impossible to commit by adding (a) a deterministic pre-submit check the agent must run, and (b) explicit anti-pattern documentation. Solution targets Claude Code agents with bash; other runtimes (MCP-only) can mirror the rules from the same source.
+
+Non-goals: redesigning the MJML authoring flow, replacing `preview-mjml`, validating Senda variable syntax, building a YAML/JSON DSL.
+
+## Approach
+
+**B + D from brainstorming**: a static validator script + skill doc updates. Static-only — no HTTP, no auth, no env vars. Complements (does not replace) `preview-mjml`.
+
+## Components
+
+### 1. `skills/senda/scripts/mjml-check.sh`
+
+- Pure bash, executable (`chmod +x`), no external deps beyond POSIX shell utilities (`grep`, `sed`, `awk`) available on macOS + Linux.
+- CLI: `mjml-check.sh <path>` or `mjml-check.sh -` (stdin).
+- Exit 0 if all rules pass; exit 1 if any rule fails. All violations reported in one run (no first-fail).
+- All output to stderr. No stdout output on success.
+
+**Rules (all hard-fail):**
+
+| # | Rule | Message stem |
+|---|---|---|
+| 1 | No `<!DOCTYPE` (case-insensitive, anywhere) | `forbidden HTML document tag <!DOCTYPE` |
+| 2 | No `<html`, `</html>` (case-insensitive) | `forbidden HTML root tag <html>` |
+| 3 | No `<head>`, `</head>` (case-insensitive) | `forbidden HTML <head> tag (use <mj-head>)` |
+| 4 | No `<body>`, `</body>` (case-insensitive — must distinguish from `<mj-body>`) | `forbidden HTML <body> tag (use <mj-body>)` |
+| 5 | No `<meta`, `<title`, `<link`, `<base` (case-insensitive) | `forbidden HTML head tag <X>` |
+| 6 | Document root is `<mjml>...</mjml>` (whitespace/comments allowed before) | `document must start with <mjml> and end with </mjml>` |
+| 7 | If a violation of rules 1–5 is found inside an `<mj-raw>...</mj-raw>` block, append a clarifying hint pointing at the documented anti-pattern | `<mj-raw> is for small HTML snippets, not full documents` |
+
+**Output format (stderr):**
+```
+mjml-check: FAIL line 3: forbidden HTML document tag <!DOCTYPE
+  MJML compiles INTO HTML. Wrapping MJML in HTML is double-wrapping.
+  See skills/senda/references/building-a-template.md "Anti-pattern: HTML wrappers".
+mjml-check: FAIL line 4: forbidden HTML root tag <html>
+  ...
+mjml-check: 2 violation(s)
+```
+
+On success: silent, exit 0.
+
+**Implementation notes:**
+- Use `grep -niE` for line numbers and case-insensitive matching.
+- Distinguish `<body>` from `<mj-body>` with a negative-lookbehind-equivalent regex (e.g., `(^|[^-])<body[> ]`).
+- For the `<mj-raw>` clarifier, do a second pass: find `<mj-raw>...</mj-raw>` ranges (line-based; multi-line OK with `awk` or `sed -n`) and check if any rule-1–5 hit lands inside one.
+
+### 2. `skills/senda/scripts/mjml-check.test.sh`
+
+- Bash test runner. Executable.
+- Embeds fixtures as heredocs (no separate fixture files — keeps the skill self-contained).
+- Runs `mjml-check.sh` against each fixture and asserts expected exit code.
+
+**Cases:**
+
+| ID | Type | Fixture | Expected |
+|---|---|---|---|
+| ok-1 | PASS | minimal `<mjml><mj-body><mj-section><mj-column><mj-text>hi</mj-text>...` | exit 0 |
+| ok-2 | PASS | hero + section + button | exit 0 |
+| ok-3 | PASS | `<mj-raw><div class="x">snippet</div></mj-raw>` (legitimate small HTML) | exit 0 |
+| fail-1 | FAIL | `<!DOCTYPE html>` at top | exit 1, stderr mentions DOCTYPE |
+| fail-2 | FAIL | `<html><head>...</head><body>...</body></html>` outside any `<mjml>` | exit 1, multiple violations |
+| fail-3 | FAIL | `<mj-raw><!DOCTYPE html><html>...</html></mj-raw>` (the reported case) | exit 1, mentions `<mj-raw>` clarifier |
+| fail-4 | FAIL | `<head><meta charset="utf-8"></head>` inside body | exit 1 |
+| fail-5 | FAIL | document does not start with `<mjml>` | exit 1, rule 6 |
+
+Runner output: `OK <case>` / `FAIL <case>: <reason>`, exit 1 if any case fails.
+
+### 3. Skill doc updates
+
+**`skills/senda/references/building-a-template.md`:**
+- Insert new section "Anti-pattern: HTML wrappers" immediately after "Document skeleton". Show wrong example (the reported one) and right example. Two paragraphs.
+- Update "Composer's checklist" — replace the current step about `preview-mjml` with two ordered steps: (1) `bash skills/senda/scripts/mjml-check.sh <file>` (mandatory, blocks submit), (2) `POST .../preview-mjml` (mandatory before publish).
+- Update the "Engine and version" note about `mj-raw` to add: *"`<mj-raw>` accepts small HTML snippets, never full documents — see Anti-pattern below."*
+
+**`skills/senda/references/versions-locales-and-builder.md`:**
+- Add a Gotcha bullet: *"Pre-submit gate: run `skills/senda/scripts/mjml-check.sh` on `body_mjml` before any version POST/PUT — blocks the HTML-wrapper class of error that `preview-mjml` would otherwise catch only on send."*
+
+**`skills/senda/SKILL.md`:**
+- Add one row to the decision table: *"If you change MJML composition rules → update `skills/senda/scripts/mjml-check.sh` (rules + tests)."*
+
+## Data flow
+
+```
+agent → composes MJML → mjml-check.sh (static) → preview-mjml (compile) → POST/PUT version/locale
+                                ↓ exit 1
+                        agent fixes, retries
+```
+
+The validator never calls Senda. `preview-mjml` is a separate, downstream step the skill documents.
+
+## Error handling
+
+- Script: exits 1 on any rule violation. All violations printed before exit (no first-fail). On script bugs (unexpected grep failure, IO error), exit 2 with `mjml-check: internal error: <msg>` to distinguish from rule failures.
+- Tests: run all cases; report each; exit 1 if any case fails. No partial-credit.
+
+## Testing
+
+- Test script lives next to the validator (`mjml-check.test.sh`).
+- Run manually during development.
+- Not wired into `make` targets — YAGNI; can be added later if the script gains complexity.
+- The skill update in `SKILL.md` makes maintenance of the test fixtures part of the maintenance contract.
+
+## Out of scope
+
+- HTTP / `preview-mjml` integration in the script. Kept separate so the script has zero deps and zero auth surface.
+- Variable-syntax validation (`{{ event.x }}` / `{{ injector.x.y }}`). Skill already documents these are silent — adding validation here duplicates without value.
+- A CLI to *generate* MJML (rejected during brainstorming as a YAML→MJML translation that adds an extra format without removing the underlying error class).
+- MCP-only runtime support. The script is bash; MCP-only clients without shell access don't benefit. If that becomes a real need later, the rules can be ported to a server-side endpoint or an MCP tool — but the static rules in the script are the canonical source of truth either way.
+
+## Maintenance contract
+
+When the visual builder or `gomjml` upgrades change which top-level tags are legal MJML, update `mjml-check.sh` in the same PR. The `SKILL.md` decision-table entry enforces this as a review checklist.
+
+## Acceptance criteria
+
+1. The reported case (`<mj-raw><!DOCTYPE html><html>...</html></mj-raw>`) piped into `bash skills/senda/scripts/mjml-check.sh -` exits 1 and the stderr output includes the `<mj-raw>` clarifier message.
+2. `bash skills/senda/scripts/mjml-check.test.sh` exits 0 with all 8 cases (3 PASS, 5 FAIL) passing — fixtures are embedded as heredocs in the test runner, no separate fixture files.
+3. `skills/senda/references/building-a-template.md` contains the new "Anti-pattern: HTML wrappers" section and the updated checklist references the script.
+4. A fresh agent reading the skill end-to-end after the change cannot infer that `<mj-raw>` accepts a full HTML document.

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -183,7 +183,9 @@
     "blockNoProperties": "No properties",
     "blockListType": "List type",
     "variableHintEvent": "Event variable",
-    "variableHintInjector": "Injector variable"
+    "variableHintInjector": "Injector variable",
+    "visualUnavailableForRawMjml": "Visual editor unavailable: this template uses MJML constructs not supported by the block builder.",
+    "rawMjmlNotice": "This template uses MJML the visual editor cannot represent. Editing is available in code mode only."
   },
   "scopeSwitcher": {
     "globalScope": "Global",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -183,7 +183,9 @@
     "blockNoProperties": "Sin propiedades",
     "blockListType": "Tipo de lista",
     "variableHintEvent": "Variable de evento",
-    "variableHintInjector": "Variable de injector"
+    "variableHintInjector": "Variable de injector",
+    "visualUnavailableForRawMjml": "Editor visual no disponible: este template usa elementos MJML que el constructor de bloques no soporta.",
+    "rawMjmlNotice": "Este template usa MJML que el editor visual no puede representar. Solo se puede editar en modo código."
   },
   "scopeSwitcher": {
     "globalScope": "Global",

--- a/web/src/components/templates/mjml-editor.tsx
+++ b/web/src/components/templates/mjml-editor.tsx
@@ -1569,12 +1569,29 @@ function parseBuilderDocumentFromMjml(rawMjml: string): BuilderDocument | null {
 
       if (topTag === "mj-section") {
         const column = topChild.getElementsByTagName("mj-column")[0];
-        if (!column) continue;
+        if (!column) {
+          // mj-section without mj-column is not representable in the visual builder.
+          return null;
+        }
         for (const child of Array.from(column.children)) {
           const parsed = parseColumnChildToBlock(child);
-          if (parsed) blocks.push(parsed);
+          if (!parsed) {
+            // Unsupported tag inside a column (e.g. mj-raw, mj-table). Bailing
+            // out here is intentional: silently dropping it would let the
+            // visual builder recompile and overwrite body_mjml on save,
+            // discarding the original content.
+            return null;
+          }
+          blocks.push(parsed);
         }
+        continue;
       }
+
+      // Any other direct child of mj-body (mj-raw, mj-style, mj-include,
+      // mj-attributes, mj-class, mj-table, mj-social, mj-navbar, ...) cannot
+      // be represented as a builder block. Returning null forces the editor
+      // into code mode so the original body_mjml is preserved verbatim.
+      return null;
     }
 
     if (!blocks.length) {
@@ -1588,6 +1605,51 @@ function parseBuilderDocumentFromMjml(rawMjml: string): BuilderDocument | null {
   } catch {
     return null;
   }
+}
+
+type HydratedBuilderState = {
+  /** Block tree to load into the visual builder, or null when only the code editor can render the body. */
+  document: BuilderDocument | null;
+  /**
+   * True when body_mjml has content the visual builder cannot represent
+   * (e.g. mj-raw, mj-style, mj-table, multiple columns per section). The
+   * caller MUST force editorMode to "code" so the visual builder does not
+   * recompile a fallback document and overwrite the saved body.
+   */
+  forceCodeMode: boolean;
+};
+
+function hydrateBuilderState(source: {
+  editor_data?: unknown;
+  body_mjml?: string | null;
+}): HydratedBuilderState {
+  const hasPersistedEditorData = Boolean(
+    source.editor_data &&
+      typeof source.editor_data === "object" &&
+      Object.keys(source.editor_data as Record<string, unknown>).length > 0
+  );
+  if (hasPersistedEditorData) {
+    return {
+      document: normalizeBuilderDocument(source.editor_data),
+      forceCodeMode: false,
+    };
+  }
+  const fromMjml = parseBuilderDocumentFromMjml(source.body_mjml ?? "");
+  if (fromMjml) {
+    return { document: fromMjml, forceCodeMode: false };
+  }
+  if ((source.body_mjml ?? "").trim().length > 0) {
+    // The saved body uses MJML constructs the visual builder cannot
+    // round-trip. Keep the body verbatim and tell the caller to render the
+    // code editor instead.
+    return { document: null, forceCodeMode: true };
+  }
+  // Empty body and no editor data — fall back to the default skeleton so the
+  // user sees an editable starting point.
+  return {
+    document: normalizeBuilderDocument(source.editor_data),
+    forceCodeMode: false,
+  };
 }
 
 function renderColumnBlockToMjml(block: BuilderBlock): string {
@@ -1942,15 +2004,9 @@ export function MjmlEditor({
 
     if (activeLocale === "default") {
       // Restore default version content
-      const hasEditorData = Boolean(
-        version.editor_data && Object.keys(version.editor_data).length > 0
-      );
-      const parsed =
-        (hasEditorData
-          ? normalizeBuilderDocument(version.editor_data)
-          : parseBuilderDocumentFromMjml(version.body_mjml ?? "")) ??
-        normalizeBuilderDocument(version.editor_data);
-      if (parsed) setBuilderDocument(parsed);
+      const { document: parsed, forceCodeMode } = hydrateBuilderState(version);
+      setBuilderDocument(parsed);
+      if (forceCodeMode) setEditorMode("code");
       const code = version.body_mjml ?? "";
       setCodeOverride(code);
       if (code) triggerPreview(code);
@@ -1967,13 +2023,12 @@ export function MjmlEditor({
     // Non-default locale
     const localeData = localeContentQuery.data;
     if (localeData) {
-      const hasEditorData = Boolean(
-        localeData.editor_data && Object.keys(localeData.editor_data as object).length > 0
-      );
-      const parsed = hasEditorData
-        ? normalizeBuilderDocument(localeData.editor_data)
-        : parseBuilderDocumentFromMjml(localeData.body_mjml ?? version.body_mjml ?? "");
-      if (parsed) setBuilderDocument(parsed);
+      const { document: parsed, forceCodeMode } = hydrateBuilderState({
+        editor_data: localeData.editor_data,
+        body_mjml: localeData.body_mjml ?? version.body_mjml,
+      });
+      setBuilderDocument(parsed);
+      if (forceCodeMode) setEditorMode("code");
       const code = localeData.body_mjml ?? version.body_mjml ?? "";
       setCodeOverride(code);
       if (code) triggerPreview(code);
@@ -1985,15 +2040,9 @@ export function MjmlEditor({
       });
     } else if (!localeContentQuery.isLoading) {
       // 404 or first load - use default content as starting point
-      const hasEditorData = Boolean(
-        version.editor_data && Object.keys(version.editor_data).length > 0
-      );
-      const parsed =
-        (hasEditorData
-          ? normalizeBuilderDocument(version.editor_data)
-          : parseBuilderDocumentFromMjml(version.body_mjml ?? "")) ??
-        normalizeBuilderDocument(version.editor_data);
-      if (parsed) setBuilderDocument(parsed);
+      const { document: parsed, forceCodeMode } = hydrateBuilderState(version);
+      setBuilderDocument(parsed);
+      if (forceCodeMode) setEditorMode("code");
       const code = version.body_mjml ?? "";
       setCodeOverride(code);
       if (code) triggerPreview(code);
@@ -2145,24 +2194,18 @@ export function MjmlEditor({
       return;
     }
 
-    const hasPersistedEditorData = Boolean(
-      version.editor_data && Object.keys(version.editor_data).length > 0
-    );
-    const parsed =
-      (hasPersistedEditorData
-        ? normalizeBuilderDocument(version.editor_data)
-        : parseBuilderDocumentFromMjml(version.body_mjml ?? "")) ??
-      normalizeBuilderDocument(version.editor_data);
+    const { document: parsed, forceCodeMode } = hydrateBuilderState(version);
     setBuilderDocument(parsed);
+    if (forceCodeMode) setEditorMode("code");
 
     const initialCode = version.body_mjml ?? "";
-    const visualCode = buildTemplateMjml(parsed);
+    const visualCode = parsed ? buildTemplateMjml(parsed) : "";
     const nextCode =
       typeof initialCode === "string" && initialCode.trim().length > 0
         ? initialCode
         : visualCode;
     setCodeOverride(nextCode);
-    setSelectedBlockId(parsed.blocks[0]?.id ?? null);
+    setSelectedBlockId(parsed?.blocks[0]?.id ?? null);
 
     if (nextCode) {
       triggerPreview(nextCode);
@@ -2558,6 +2601,11 @@ export function MjmlEditor({
   }
 
   const codeMjml = version ? codeOverride : "";
+  // Body uses MJML constructs the visual builder cannot represent
+  // (e.g. mj-raw, mj-style, mj-table). The visual mode toggle is disabled
+  // because switching to it would render an empty fallback that auto-saves
+  // and overwrites the saved body. The user can still edit via the code panel.
+  const isCodeOnlyMjml = builderDocument === null && codeMjml.trim().length > 0;
   const watchedSubject = watch("subject");
   const watchedPreviewText = watch("preview_text");
   const watchedFromName = watch("from_name");
@@ -3826,9 +3874,15 @@ export function MjmlEditor({
                   editorMode === "visual"
                     ? LOCALE_ACTIVE_CLASS
                     : "text-muted-foreground hover:text-foreground"
-                }`}
+                } disabled:cursor-not-allowed disabled:opacity-50`}
                 onClick={() => setEditorMode("visual")}
                 type="button"
+                disabled={isCodeOnlyMjml}
+                title={
+                  isCodeOnlyMjml
+                    ? t("visualUnavailableForRawMjml")
+                    : undefined
+                }
               >
                 <Paintbrush className="h-3.5 w-3.5" />
               </button>
@@ -4967,7 +5021,14 @@ export function MjmlEditor({
               </div>
             ) : (
               <div className="relative flex-1 min-w-0">
-                <div className="absolute inset-0">
+                {isCodeOnlyMjml && (
+                  <div className="absolute inset-x-0 top-0 z-10 border-b bg-amber-50 px-3 py-1.5 text-[11px] text-amber-900 dark:bg-amber-950 dark:text-amber-200">
+                    {t("rawMjmlNotice")}
+                  </div>
+                )}
+                <div
+                  className={`absolute inset-0 ${isCodeOnlyMjml ? "pt-[28px]" : ""}`}
+                >
                   <MonacoEditorWrapper
                     value={codeMjml}
                     onChange={handleCodeChange}


### PR DESCRIPTION
Closes #107

## Summary

- Stop the visual editor from silently overwriting `body_mjml` when the saved body uses MJML the block builder cannot represent (`mj-raw`, `mj-style`, `mj-table`, multiple columns per section, etc.).
- Force `editorMode = "code"` and disable the visual toggle in that scenario, so the user can still edit and the saved body is preserved verbatim.

## Context

- Related issue: #107
- Risk / tradeoffs: `parseBuilderDocumentFromMjml` is now stricter — it bails to `null` on any unsupported direct child of `mj-body` or any unparsed child inside an `mj-column`. Previously it silently dropped them. Templates whose `body_mjml` exclusively uses the validated builder tags continue to round-trip identically; templates that mixed builder blocks with `mj-raw` would have been corrupted on save anyway, so the new behavior is strictly safer.

## What changed

1. `parseBuilderDocumentFromMjml` is strict: returns `null` whenever the body contains a construct outside the visual builder's supported subset, instead of silently dropping it. (`mj-raw`, `mj-style`, `mj-table`, `mj-include`, `mj-attributes`, `mj-class`, `mj-social`, `mj-navbar`, multi-column sections, sections without an `mj-column`, etc.)
2. New `hydrateBuilderState({ editor_data, body_mjml })` helper centralizes the `editor_data → body_mjml → default` fallback chain and reports `forceCodeMode = true` when the body can't be represented. It is the single source of truth for the three hydration paths.
3. The three hydration `useEffect`s (default locale, locale switch, version reload by id/body) now use the helper. When `forceCodeMode` is set they call `setBuilderDocument(null)` and `setEditorMode("code")` instead of installing a destructive empty fallback. This breaks the chain that previously caused TipTap's `onCreate` font-family chain in `text-block-editor.tsx` to schedule an auto-save with the empty fallback.
4. The visual mode toggle is `disabled` (with `title` tooltip) and a small inline amber notice is rendered above the Monaco editor when `builderDocument === null && codeMjml.trim().length > 0` (`isCodeOnlyMjml`). New i18n keys `editor.visualUnavailableForRawMjml` and `editor.rawMjmlNotice` in `en.json` / `es.json`.

## Validation

- [x] `pnpm --prefix web typecheck`
- [x] `pnpm --prefix web test` (227/227)
- [x] `make ci-frontend` (exit 0)

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test-only
- [ ] Security-sensitive

## Contributor checklist

- [x] I kept the change focused and reviewable.
- [ ] I added or updated tests where behavior changed. *(Note: `parseBuilderDocumentFromMjml` and the new `hydrateBuilderState` helper rely on `DOMParser`, which is not available in the `node --test` environment; existing tests in `templates/` only cover pure helpers. Manual reproduction documented in #107.)*
- [x] I updated docs when behavior, setup, API, or workflows changed. *(N/A — internal frontend behavior; no docs reference the previous fallback.)*
- [x] I did not add build-only validation as a substitute for the required local gates.
- [x] I did not add AI attribution or `Co-Authored-By` trailers.

## Compatibility / ops impact

- [x] No migration
- [x] No config changes
- [x] No security impact